### PR TITLE
Add infra adapters for AWS EC2, Hetzner, DigitalOcean, and GCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,9 @@ open-forge/
         ├── SKILL.md                       ← end-user-Claude entrypoint
         ├── references/
         │   ├── projects/<name>.md         ← software layer
-        │   ├── runtimes/<name>.md         ← runtime layer (planned — see refactor below)
-        │   ├── infra/<name>.md            ← infra layer
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, backups, monitoring)
+        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, native.md)
+        │   ├── infra/<name>.md            ← infra layer (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
+        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
         └── scripts/                       ← reused operational scripts; empty by default
 ```
 
@@ -151,19 +151,19 @@ Publish flow:
 
 Commits authored as `Qi Zhang <zhangqi444@gmail.com>` — set inline via env vars (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`), **don't write to git config**.
 
-## Refactor in progress (started 2026-04-24)
+## Refactor (started 2026-04-24, completed 2026-04-26)
 
-Current state collapses three axes into linear "Path A/B/C" inside `openclaw.md`, which hides valid combos and biases preflight toward AWS even for non-AWS deployments. Migrating to the 3-layer file layout above. Order:
+Initial state collapsed three axes into linear "Path A/B/C" inside `openclaw.md`, which hid valid combos and biased preflight toward AWS even for non-AWS deployments. Migrated to the 3-layer file layout above. Order:
 
 1. ✅ CLAUDE.md model locked in (this section).
-2. Preflight refactor — branch on infra choice; only require AWS CLI when infra ∈ AWS.
-3. Skeleton infra adapters: `infra/aws/lightsail-blueprint.md`, `infra/aws/lightsail-ubuntu.md`, `infra/byo-vps.md`, `infra/localhost.md`.
-4. Runtime modules: `runtimes/docker.md`, `runtimes/native.md`. Extracted from openclaw.md Paths B and C.
-5. Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else.
-6. Add `modules/tunnels.md` for localhost public-reach (Cloudflare Tunnel / Tailscale / ngrok).
-7. Update SKILL.md, README.md support tables and prompts. Bump plugin version.
+2. ✅ Preflight refactor — branch on infra choice; only require AWS CLI when infra ∈ AWS.
+3. ✅ Skeleton infra adapters: `infra/aws/lightsail.md` (Bitnami + OpenClaw blueprints share this; the blueprint-vs-Ubuntu split is a project-recipe concern, not a separate adapter), `infra/aws/ec2.md`, `infra/hetzner/cloud-cx.md`, `infra/digitalocean/droplet.md`, `infra/gcp/compute-engine.md`, `infra/byo-vps.md`, `infra/localhost.md`.
+4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/native.md`. Extracted from openclaw.md Paths B and C.
+5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else.
+6. ✅ Add `modules/tunnels.md` for localhost public-reach (Cloudflare Tunnel / Tailscale / ngrok).
+7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.6.0).
 
-Each step commits independently. Path A/B/C terminology retired in step 5.
+Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here.
 
 ## Behavioral guidelines (echoes of bota CLAUDE.md, kept here for autonomy)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Self-host open-source apps on your own cloud, guided by Claude Code.
 
 Given a project and a cloud provider, open-forge walks you through provisioning, DNS, TLS, outbound email (SMTP), and inbound email. It captures the non-obvious gotchas that usually cost hours the first time: proxy misconfigurations, non-interactive certbot flags, mail config quirks, DNS propagation, etc.
 
-## Supported today (v0.1)
+## Supported today
 
 Supported software:
 
@@ -17,8 +17,12 @@ Supported **where**:
 
 | Where | How |
 |---|---|
-| AWS Lightsail | OpenClaw blueprint (Bedrock pre-wired) · Ubuntu + Docker · Ubuntu + native · Ghost Bitnami blueprint |
-| Any Linux VM you already have (Hetzner / DO / GCP / EC2 / bare metal) | Docker · native |
+| **AWS Lightsail** | OpenClaw blueprint (Bedrock pre-wired) · Ubuntu + Docker · Ubuntu + native · Ghost Bitnami blueprint |
+| **AWS EC2** | Ubuntu / Amazon Linux + Docker · + native |
+| **Hetzner Cloud** | CX-line VM + Docker · + native |
+| **DigitalOcean** | Droplet + Docker · + native |
+| **GCP Compute Engine** | VM + Docker · + native |
+| Any Linux VM you already have (other providers, bare metal) | Docker · native |
 | **Your own machine** (macOS / Linux / Windows) | Docker Desktop · native |
 
 Three-question flow: what to host, where to host, how to host. Claude asks only what's genuinely ambiguous — if your prompt already names a clear cloud, the first question is skipped.
@@ -58,9 +62,10 @@ open-forge/
         └── skills/open-forge/
             ├── SKILL.md
             ├── references/
-            │   ├── projects/           # per-project recipes (ghost.md, ...)
-            │   ├── infra/              # per-infra adapters (lightsail.md, ...)
-            │   └── modules/            # cross-cutting (dns, tls, smtp, inbound)
+            │   ├── projects/           # per-project recipes (ghost.md, openclaw.md, ...)
+            │   ├── infra/              # per-infra adapters (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
+            │   ├── runtimes/           # docker.md, native.md
+            │   └── modules/            # cross-cutting (preflight, dns, tls, smtp, inbound, tunnels)
             └── scripts/
 ```
 

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-forge",
-  "version": "0.5.0",
-  "description": "Self-host open-source apps on your own cloud, your own VPS, or your own laptop. Chat-friendly interface to existing tools (aws, docker, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw. Supported where: AWS Lightsail, any Linux VPS (BYO), and localhost.",
+  "version": "0.6.0",
+  "description": "Self-host open-source apps on your own cloud, your own VPS, or your own laptop. Chat-friendly interface to existing tools (aws, hcloud, doctl, gcloud, docker, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw. Supported where: AWS (Lightsail + EC2), Hetzner Cloud, DigitalOcean, GCP Compute Engine, any Linux VPS (BYO), and localhost.",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",
   "license": "MIT"

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-forge
-description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS/Lightsail/Hetzner/DigitalOcean", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint), OpenClaw on AWS Lightsail (openclaw_ls_1_0 blueprint). More projects and infras added under `references/projects/` and `references/infra/`.
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Hetzner / DigitalOcean / GCP", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw on AWS Lightsail (openclaw_ls_1_0 blueprint), AWS EC2, Hetzner Cloud, DigitalOcean, GCP Compute Engine, BYO VPS, and localhost. More projects and infras added under `references/projects/` and `references/infra/`.
 ---
 
 # open-forge
@@ -36,7 +36,10 @@ Supported **infras** (under `references/infra/`):
 
 | Cloud | Services |
 |---|---|
-| AWS | `aws/lightsail.md` (generic Lightsail provisioning; Ghost Bitnami blueprint + OpenClaw blueprint both use it) |
+| AWS | `aws/lightsail.md` (Ghost Bitnami blueprint + OpenClaw blueprint), `aws/ec2.md` (general-purpose VM with security group + EIP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` — CX-line VPS via `hcloud` CLI |
+| DigitalOcean | `digitalocean/droplet.md` — Droplet via `doctl` CLI |
+| GCP | `gcp/compute-engine.md` — Compute Engine VM via `gcloud` CLI |
 | Any Linux VM you already have | `byo-vps.md` — SSH in, no cloud APIs |
 | Your own machine | `localhost.md` — Claude runs commands directly, no SSH |
 
@@ -45,10 +48,8 @@ Supported **runtimes** (under `references/runtimes/`):
 | Runtime | Notes |
 |---|---|
 | Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd lifecycle, reverse-proxy guidance. Reusable across every infra. |
 | Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
-| Native installer | Project-specific (e.g. OpenClaw's `curl \| bash`); documented in each project recipe |
-
-Hetzner / DigitalOcean / GCP / EC2 dedicated adapters land as needed — until then, any Linux VM on them works through `byo-vps.md`.
 
 ## Selection — ask three questions
 

--- a/plugins/open-forge/skills/open-forge/references/infra/aws/ec2.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/aws/ec2.md
@@ -1,0 +1,214 @@
+---
+name: ec2-infra
+description: AWS EC2 infra adapter — how to provision an EC2 instance with security group, key pair, Elastic IP, and SSH-in for open-forge deployments. Pair with `runtimes/docker.md` or `runtimes/native.md` for the application install. Picked when the user wants more control than Lightsail offers (custom AMI, VPC, instance types beyond Lightsail's 5 sizes).
+---
+
+# AWS EC2 adapter
+
+EC2 is AWS's general-purpose compute. Use it instead of Lightsail when you need: a non-Bitnami AMI, custom networking (VPC, subnets, peering), instance types Lightsail doesn't expose (GPU, ARM Graviton, large memory), or you already have an organization VPC the deployment must live in.
+
+## Prerequisites
+
+Check during preflight; stop and install/configure if missing:
+
+- `aws` CLI v2 (`aws --version`)
+- A configured AWS profile with EC2 + IAM permissions (`aws configure list-profiles`)
+- A default VPC in the chosen region (most accounts have one; required for the simple flow below)
+
+## Inputs to collect
+
+Cross-cutting preflight collects `aws_profile`, `aws_region`, deployment name. The EC2 adapter additionally needs:
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Instance type?" | `AskUserQuestion`, options from the table below | Project-recipe-suggested |
+| End of preflight | "AMI?" | `AskUserQuestion`: `Ubuntu 24.04 LTS (canonical owner)` / `Amazon Linux 2023` / `Other (specify ID)` | `Ubuntu 24.04 LTS` |
+| End of preflight | "Root volume size (GB)?" | `AskUserQuestion`: `20` / `30` / `50` / `Other` | `30` |
+
+Derived (no prompt):
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.instance_name` | Deployment name |
+| `outputs.security_group_name` | `<deployment-name>-sg` |
+| `outputs.key_pair_name` | `<deployment-name>-key` |
+| `outputs.eip_allocation_id` | `aws ec2 allocate-address` output |
+| `outputs.public_ip` | `aws ec2 describe-addresses` |
+| `outputs.ssh_key_path` | `~/.ssh/<deployment-name>-ec2.pem` |
+
+### Common instance-type options
+
+| Type | vCPU | RAM | Approx $/mo (us-east-1, on-demand) | When |
+|---|---|---|---|---|
+| `t3.micro` | 2 | 1 GB | $7.6 | Toy / static. Free tier eligible for first 12 mo. |
+| `t3.small` | 2 | 2 GB | $15 | Light Ghost-style blog |
+| `t3.medium` | 2 | 4 GB | $30 | OpenClaw, Nextcloud, anything Node/JVM |
+| `t4g.medium` | 2 | 4 GB | $24 | Same as t3.medium but ARM (Graviton) — cheaper if upstream ships ARM |
+| `t3.large` | 2 | 8 GB | $60 | Heavier workloads |
+| `c7g.large` | 2 | 4 GB | $58 | Compute-heavy ARM |
+
+Project recipes will suggest a default. Pick the smallest that meets the project's RAM minimum.
+
+## Provisioning
+
+### 1. Resolve the AMI ID for the chosen region
+
+Always resolve dynamically — AMI IDs are region-scoped and rotate frequently.
+
+```bash
+# Ubuntu 24.04 LTS (Canonical's AWS account 099720109477)
+AMI_ID=$(aws ec2 describe-images \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --owners 099720109477 \
+  --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*" \
+            "Name=state,Values=available" \
+  --query 'sort_by(Images, &CreationDate)[-1].ImageId' --output text)
+echo "$AMI_ID"
+
+# For ARM (Graviton) — replace amd64 with arm64
+# For Amazon Linux 2023 — owner 137112412989, name 'al2023-ami-2023.*-x86_64'
+```
+
+### 2. Create a key pair (or reuse one)
+
+EC2 key pairs are region-scoped. Save the private key the first time it's created.
+
+```bash
+KEY_NAME="${INSTANCE_NAME}-key"
+KEY_PATH="$HOME/.ssh/${INSTANCE_NAME}-ec2.pem"
+
+if ! aws ec2 describe-key-pairs \
+       --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+       --key-names "$KEY_NAME" >/dev/null 2>&1; then
+  aws ec2 create-key-pair \
+    --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+    --key-name "$KEY_NAME" --key-type ed25519 \
+    --query 'KeyMaterial' --output text > "$KEY_PATH"
+  chmod 600 "$KEY_PATH"
+fi
+```
+
+### 3. Create the security group + open initial ports
+
+Default-VPC flow (simplest). For non-default VPCs, add `--vpc-id <vpc-id>` and use `aws ec2 authorize-security-group-ingress` with explicit `--group-id`.
+
+```bash
+SG_NAME="${INSTANCE_NAME}-sg"
+SG_ID=$(aws ec2 create-security-group \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --group-name "$SG_NAME" \
+  --description "open-forge: $INSTANCE_NAME" \
+  --query 'GroupId' --output text)
+
+aws ec2 authorize-security-group-ingress \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --group-id "$SG_ID" \
+  --ip-permissions \
+    'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=0.0.0.0/0}]' \
+    'IpProtocol=tcp,FromPort=80,ToPort=80,IpRanges=[{CidrIp=0.0.0.0/0}]' \
+    'IpProtocol=tcp,FromPort=443,ToPort=443,IpRanges=[{CidrIp=0.0.0.0/0}]'
+```
+
+If the project recipe needs additional ports (custom WebSocket, SMTP submission), open them the same way at the relevant phase.
+
+### 4. Launch the instance
+
+```bash
+INSTANCE_ID=$(aws ec2 run-instances \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --image-id "$AMI_ID" \
+  --instance-type "$INSTANCE_TYPE" \
+  --key-name "$KEY_NAME" \
+  --security-group-ids "$SG_ID" \
+  --block-device-mappings "DeviceName=/dev/sda1,Ebs={VolumeSize=$ROOT_VOLUME_GB,VolumeType=gp3,DeleteOnTermination=true,Encrypted=true}" \
+  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$INSTANCE_NAME},{Key=open-forge,Value=true}]" \
+  --metadata-options "HttpTokens=required,HttpEndpoint=enabled" \
+  --query 'Instances[0].InstanceId' --output text)
+
+aws ec2 wait instance-running \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --instance-ids "$INSTANCE_ID"
+```
+
+`HttpTokens=required` enforces IMDSv2 — protects metadata service from SSRF. Leave it on unless the project recipe explicitly says it's incompatible (rare).
+
+### 5. Allocate and associate an Elastic IP
+
+EIPs persist across stop/start; the auto-assigned public IP doesn't. Always attach an EIP before DNS.
+
+```bash
+EIP_OUT=$(aws ec2 allocate-address \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --domain vpc \
+  --tag-specifications "ResourceType=elastic-ip,Tags=[{Key=Name,Value=$INSTANCE_NAME-ip},{Key=open-forge,Value=true}]")
+
+EIP_ALLOC=$(echo "$EIP_OUT" | jq -r '.AllocationId')
+PUBLIC_IP=$(echo "$EIP_OUT"  | jq -r '.PublicIp')
+
+aws ec2 associate-address \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --instance-id "$INSTANCE_ID" \
+  --allocation-id "$EIP_ALLOC"
+```
+
+Save `outputs.eip_allocation_id`, `outputs.public_ip`.
+
+## SSH convention
+
+- User: **`ubuntu`** for Ubuntu AMIs, **`ec2-user`** for Amazon Linux / RHEL, **`admin`** for Debian.
+- First SSH: `-o StrictHostKeyChecking=accept-new`. Don't blow away `known_hosts` entries when a new EIP is associated.
+
+```bash
+ssh -i "$KEY_PATH" -o StrictHostKeyChecking=accept-new "ubuntu@$PUBLIC_IP"
+```
+
+## Firewall changes after provision
+
+Add ports later via `authorize-security-group-ingress`; remove via `revoke-security-group-ingress`. Open only what the project actually needs — default deny is your friend on EC2.
+
+```bash
+aws ec2 authorize-security-group-ingress \
+  --profile "$AWS_PROFILE" --region "$AWS_REGION" \
+  --group-id "$SG_ID" \
+  --ip-permissions "IpProtocol=tcp,FromPort=<N>,ToPort=<N>,IpRanges=[{CidrIp=0.0.0.0/0}]"
+```
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `aws ec2 describe-instances --instance-ids "$INSTANCE_ID" --query 'Reservations[0].Instances[0].State.Name'` returns `running`
+- `aws ec2 describe-addresses --allocation-ids "$EIP_ALLOC" --query 'Addresses[0].InstanceId'` returns the instance ID (associated)
+- `ssh -i $KEY_PATH ubuntu@$PUBLIC_IP 'echo ok'` prints `ok`
+
+## Teardown
+
+For cleanup later (do **not** auto-run; confirm with the user):
+
+```bash
+aws ec2 terminate-instances --instance-ids "$INSTANCE_ID"
+aws ec2 wait instance-terminated --instance-ids "$INSTANCE_ID"
+aws ec2 release-address --allocation-id "$EIP_ALLOC"
+aws ec2 delete-security-group --group-id "$SG_ID"
+aws ec2 delete-key-pair --key-name "$KEY_NAME"
+rm -f "$KEY_PATH"
+```
+
+EBS root volume is deleted on terminate (`DeleteOnTermination=true` set above). Snapshot it first if the user wants the data.
+
+## Gotchas
+
+- **EIP charged when not associated.** AWS bills idle EIPs (~$0.005/hr). Release on teardown, or leave attached even when the instance is stopped.
+- **Default VPC may be missing.** Some org accounts have no default VPC. Detect with `aws ec2 describe-vpcs --filters Name=is-default,Values=true`. If empty, fall back to asking the user for an existing VPC + subnet ID, or stop and explain.
+- **Spot vs on-demand.** open-forge defaults to on-demand for predictable single-node deploys. Spot can interrupt with 2-minute notice — wrong for stateful self-hosting.
+- **Security group "default-vpc-default-sg" trap.** New instances launched without `--security-group-ids` join the VPC's default SG, which often allows all-internal but no external. Always pass our explicit SG.
+- **IMDSv2 token requirement.** Old SDKs / instance-metadata callers that still use IMDSv1 will fail with `401 Unauthorized` against the metadata endpoint. Project recipes that hit `http://169.254.169.254/` need to support v2 (Bedrock SDK, recent AWS CLI — yes; very old curl-based scripts — no).
+- **AMI rotation.** Don't hardcode AMI IDs in state files. Resolve fresh each time, or store the AMI ID alongside the deployment so rebuilds reuse the exact image.
+- **Region-scoped key pair.** A new region means a new key. Don't try to import the same key everywhere — let each deployment create its own.
+- **`stop-instances` keeps EBS billed.** Stopped instances pay $0 compute but full EBS storage. Long-pause deployments should be terminated with a snapshot if cost matters.
+
+## Reference
+
+- EC2 user guide: <https://docs.aws.amazon.com/ec2/latest/userguide/>
+- Default-VPC flow: <https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html>
+- Ubuntu AMI catalog: <https://cloud-images.ubuntu.com/locator/ec2/>

--- a/plugins/open-forge/skills/open-forge/references/infra/digitalocean/droplet.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/digitalocean/droplet.md
@@ -1,0 +1,197 @@
+---
+name: digitalocean-droplet-infra
+description: DigitalOcean Droplet infra adapter — how to provision a Droplet with SSH key upload, Cloud Firewall, and Reserved IP via the `doctl` CLI. Pair with `runtimes/docker.md` or `runtimes/native.md` for the application install. Picked when the user wants polished UX, integrated managed services (Spaces, Postgres) potentially layered on later, or a US-headquartered alternative to Hetzner.
+---
+
+# DigitalOcean Droplet adapter
+
+DigitalOcean ships clean APIs, regional coverage in 14+ datacenters, and an integrated ecosystem (managed Postgres, Spaces object storage, Load Balancers) that you can layer on later from the same console. Pricing sits between Hetzner (cheaper) and AWS (more expensive).
+
+## Prerequisites
+
+Check during preflight; stop and install/configure if missing:
+
+- `doctl` CLI (`doctl version`)
+- A DigitalOcean API token with read+write scope
+- The user has a DigitalOcean account
+
+### Install + auth
+
+```bash
+# macOS
+brew install doctl
+
+# Linux — download the latest binary
+curl -fsSL -o /tmp/doctl.tgz \
+  "https://github.com/digitalocean/doctl/releases/latest/download/doctl-$(curl -fsSL https://api.github.com/repos/digitalocean/doctl/releases/latest | jq -r .tag_name | sed 's/^v//')-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+tar -xzf /tmp/doctl.tgz -C /tmp doctl
+sudo install -m 0755 /tmp/doctl /usr/local/bin/doctl
+doctl version
+
+# One-time auth — paste the API token (generated at https://cloud.digitalocean.com/account/api/tokens)
+doctl auth init                          # interactive
+doctl auth list                          # confirm; the active context is highlighted
+doctl account get                        # sanity check
+```
+
+`doctl` stores tokens in `~/.config/doctl/config.yaml`. Multiple accounts: `doctl auth init --context <name>` then `doctl auth switch --context <name>`.
+
+## Inputs to collect
+
+Cross-cutting preflight collects deployment name. The DO adapter additionally needs:
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Droplet size?" | `AskUserQuestion`, options from the table below | Project-recipe-suggested |
+| End of preflight | "Region?" | `AskUserQuestion`: `New York 3 (nyc3)` / `San Francisco 3 (sfo3)` / `Toronto 1 (tor1)` / `London 1 (lon1)` / `Frankfurt 1 (fra1)` / `Amsterdam 3 (ams3)` / `Singapore 1 (sgp1)` / `Bangalore 1 (blr1)` / `Sydney 1 (syd1)` | Geographic-closest to user |
+| End of preflight | "Image?" | `AskUserQuestion`: `Ubuntu 24.04 LTS` / `Debian 12` / `Other (specify slug)` | `ubuntu-24-04-x64` |
+| End of preflight | "SSH key — upload an existing one?" | `AskUserQuestion`: `Yes (default ~/.ssh/id_ed25519.pub)` / `Generate a new one` / `Use a key already on this DO account` | Existing default |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.droplet_name` | Deployment name |
+| `outputs.firewall_name` | `<deployment-name>-fw` |
+| `outputs.ssh_key_name` | `<deployment-name>-key` |
+| `outputs.reserved_ip` | `doctl compute reserved-ip create` output |
+| `outputs.public_ip` | Same as reserved IP once associated |
+| `outputs.ssh_key_path` | Local path to the private key |
+
+### Common droplet-size options
+
+| Slug | vCPU | RAM | Disk | Approx $/mo | When |
+|---|---|---|---|---|---|
+| `s-1vcpu-1gb` | 1 | 1 GB | 25 GB | $6 | Toy / static |
+| `s-1vcpu-2gb` | 1 | 2 GB | 50 GB | $12 | Light Ghost |
+| `s-2vcpu-2gb` | 2 | 2 GB | 60 GB | $18 | Real Ghost / WordPress |
+| `s-2vcpu-4gb` | 2 | 4 GB | 80 GB | $24 | OpenClaw, Nextcloud — **recommended default** |
+| `s-2vcpu-8gb-amd` | 2 | 8 GB | 160 GB | $63 | Premium AMD; heavier workloads |
+
+`s-` is "Basic"; `c-` and `g-` are CPU- and general-purpose performance tiers.
+
+## Provisioning
+
+### 1. Upload (or reuse) the SSH key
+
+```bash
+KEY_NAME="${DROPLET_NAME}-key"
+
+if [ ! -f "$SSH_PUBKEY_PATH" ]; then
+  ssh-keygen -t ed25519 -f "${SSH_PUBKEY_PATH%.pub}" -N "" -C "open-forge $DROPLET_NAME"
+fi
+
+if ! doctl compute ssh-key list --format Name --no-header | grep -qx "$KEY_NAME"; then
+  doctl compute ssh-key import "$KEY_NAME" --public-key-file "$SSH_PUBKEY_PATH"
+fi
+
+KEY_ID=$(doctl compute ssh-key list --format ID,Name --no-header | awk -v n="$KEY_NAME" '$2==n{print $1}')
+```
+
+### 2. Create the droplet
+
+DO doesn't have a "create firewall first then attach" requirement — droplets get created with all-open inbound until a firewall covers them. Sequence matters: create droplet, then immediately apply firewall before continuing to app install.
+
+```bash
+DROPLET_OUT=$(doctl compute droplet create "$DROPLET_NAME" \
+  --image "$IMAGE_SLUG" \
+  --size "$DROPLET_SIZE" \
+  --region "$REGION" \
+  --ssh-keys "$KEY_ID" \
+  --enable-monitoring \
+  --tag-names "open-forge,deployment-$DROPLET_NAME" \
+  --wait \
+  --format ID,PublicIPv4 --no-header)
+
+DROPLET_ID=$(echo "$DROPLET_OUT" | awk '{print $1}')
+DROPLET_IP=$(echo "$DROPLET_OUT" | awk '{print $2}')
+```
+
+`--wait` blocks until the droplet is `active`.
+
+### 3. Apply a Cloud Firewall (default-deny inbound, allow web + SSH)
+
+```bash
+FW_NAME="${DROPLET_NAME}-fw"
+
+doctl compute firewall create \
+  --name "$FW_NAME" \
+  --droplet-ids "$DROPLET_ID" \
+  --inbound-rules \
+    "protocol:tcp,ports:22,address:0.0.0.0/0,address:::/0 \
+     protocol:tcp,ports:80,address:0.0.0.0/0,address:::/0 \
+     protocol:tcp,ports:443,address:0.0.0.0/0,address:::/0" \
+  --outbound-rules \
+    "protocol:tcp,ports:all,address:0.0.0.0/0,address:::/0 \
+     protocol:udp,ports:all,address:0.0.0.0/0,address:::/0 \
+     protocol:icmp,address:0.0.0.0/0,address:::/0"
+
+FW_ID=$(doctl compute firewall list --format ID,Name --no-header | awk -v n="$FW_NAME" '$2==n{print $1}')
+```
+
+### 4. (Optional) Reserve a Floating / Reserved IP
+
+DO Reserved IPs (formerly Floating IPs) survive droplet rebuild. For deployments where DNS must keep working across recreates, allocate one and assign:
+
+```bash
+RESERVED_IP=$(doctl compute reserved-ip create --region "$REGION" --format IP --no-header)
+doctl compute reserved-ip-action assign "$RESERVED_IP" "$DROPLET_ID"
+PUBLIC_IP="$RESERVED_IP"
+```
+
+For typical hobby deploys, the droplet's default IPv4 (`$DROPLET_IP` above) is fine — skip unless rebuild-stable DNS matters.
+
+## SSH convention
+
+- User: **`root`** by default on DO marketplace and base OS images. DO pushes your uploaded SSH keys into `/root/.ssh/authorized_keys`.
+- First SSH: `-o StrictHostKeyChecking=accept-new`.
+
+```bash
+ssh -i "${SSH_PUBKEY_PATH%.pub}" -o StrictHostKeyChecking=accept-new "root@$PUBLIC_IP"
+```
+
+Project recipes that prefer a non-root user own the `adduser` + `sshd_config` hardening.
+
+## Firewall changes after provision
+
+```bash
+doctl compute firewall add-rules "$FW_ID" \
+  --inbound-rules "protocol:tcp,ports:<N>,address:0.0.0.0/0,address:::/0"
+
+doctl compute firewall remove-rules "$FW_ID" \
+  --inbound-rules "protocol:tcp,ports:<N>,address:0.0.0.0/0,address:::/0"
+```
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `doctl compute droplet get "$DROPLET_ID" --format Status --no-header` returns `active`
+- `doctl compute firewall get "$FW_ID" --format DropletIDs --no-header` includes `$DROPLET_ID`
+- `ssh -i <key> root@$PUBLIC_IP 'echo ok'` prints `ok`
+
+## Teardown
+
+Don't auto-run; confirm with the user.
+
+```bash
+doctl compute reserved-ip delete "$RESERVED_IP"     # only if you reserved one
+doctl compute firewall delete "$FW_ID"
+doctl compute droplet delete "$DROPLET_ID"
+doctl compute ssh-key delete "$KEY_ID"              # only if no other droplet uses it
+```
+
+## Gotchas
+
+- **Window between droplet create and firewall apply.** A droplet without a firewall has all inbound open. Keep the gap small — firewall step right after `--wait` returns.
+- **`s-` vs `c-` vs `g-` slugs.** `s-` (Basic) shares CPU; `c-` (CPU-Optimized) and `g-` (General Purpose) are dedicated. For most self-hosts, Basic is plenty; only upgrade if you see CPU steal.
+- **Reserved IP outage after detach.** Detaching a Reserved IP (e.g. to migrate to a new droplet) takes ~30s for DNS-cached clients to reconnect. Plan for it during maintenance windows.
+- **Image slug rotation.** `ubuntu-24-04-x64` is stable; older images do get retired. Resolve with `doctl compute image list-distribution --public --format Slug,Distribution,Name` if the user supplies a custom slug.
+- **No automated backups by default.** DO offers backups at +20% of droplet cost; snapshots are pay-per-GB. Single-node hobby deploys often skip both — be explicit with the user.
+- **Tag naming for cleanup.** Tag everything with `open-forge` (and a deployment-specific tag) so a future cleanup script can find it. `doctl ... --tag-names` is supported on droplet, firewall, and reserved-ip create.
+
+## Reference
+
+- DigitalOcean docs: <https://docs.digitalocean.com/>
+- `doctl` reference: <https://docs.digitalocean.com/reference/doctl/>
+- Droplet pricing: <https://www.digitalocean.com/pricing/droplets>

--- a/plugins/open-forge/skills/open-forge/references/infra/gcp/compute-engine.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/gcp/compute-engine.md
@@ -1,0 +1,217 @@
+---
+name: gcp-compute-engine-infra
+description: Google Cloud Compute Engine infra adapter — how to provision a VM with VPC firewall rule, SSH key in instance metadata, and reserved external IP via the `gcloud` CLI. Pair with `runtimes/docker.md` or `runtimes/native.md` for the application install. Picked when the user already has a GCP org / billing account, or wants e2-small free-tier-eligible VMs.
+---
+
+# GCP Compute Engine adapter
+
+Compute Engine is GCP's general-purpose VM service. Worth picking when: the user already has a GCP project + billing set up, they want the e2-micro free-tier (specific regions only), or they need GCP-native networking with other GCP services.
+
+## Prerequisites
+
+Check during preflight; stop and install/configure if missing:
+
+- `gcloud` CLI (`gcloud version`)
+- A configured GCP project with billing enabled and Compute Engine API enabled
+- The user is authenticated (`gcloud auth list` shows an active account)
+
+### Install + auth
+
+```bash
+# macOS
+brew install --cask google-cloud-sdk
+
+# Linux — Google's apt repo
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+  | sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
+sudo apt-get update && sudo apt-get install -y google-cloud-cli
+gcloud version
+
+# One-time auth (opens browser)
+gcloud auth login
+gcloud config set project <project-id>
+gcloud config set compute/region <region>          # optional — sets default
+gcloud config set compute/zone   <region>-a        # optional — sets default
+gcloud services enable compute.googleapis.com      # idempotent; needed once per project
+```
+
+`gcloud auth list` should show the active account marked with `*`. `gcloud config get-value project` should print the project ID.
+
+## Inputs to collect
+
+Cross-cutting preflight collects deployment name. The GCP adapter additionally needs:
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "GCP project ID?" | `AskUserQuestion`: list from `gcloud projects list` | Active default |
+| End of preflight | "Region / zone?" | `AskUserQuestion`: `us-central1-a` / `us-east1-b` / `us-west1-a` / `europe-west1-b` / `asia-northeast1-a` / `Other` | Geographic-closest |
+| End of preflight | "Machine type?" | `AskUserQuestion`, options from the table below | Project-recipe-suggested |
+| End of preflight | "Image family?" | `AskUserQuestion`: `ubuntu-2404-lts-amd64` / `debian-12` / `Other (specify)` | `ubuntu-2404-lts-amd64` |
+| End of preflight | "Boot disk size (GB)?" | `AskUserQuestion`: `20` / `30` / `50` / `Other` | `30` |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.instance_name` | Deployment name |
+| `outputs.firewall_rule_name` | `<deployment-name>-allow-web` |
+| `outputs.address_name` | `<deployment-name>-ip` |
+| `outputs.public_ip` | `gcloud compute addresses describe` output |
+| `outputs.ssh_key_path` | `~/.ssh/google_compute_engine` (gcloud-managed default) |
+
+### Common machine-type options
+
+| Type | vCPU | RAM | Approx $/mo (us-central1, sustained) | When |
+|---|---|---|---|---|
+| `e2-micro` | 2 (shared) | 1 GB | $7 (free-tier eligible in select regions) | Toy / static |
+| `e2-small` | 2 (shared) | 2 GB | $13 | Light Ghost |
+| `e2-medium` | 2 (shared) | 4 GB | $25 | OpenClaw, Nextcloud — **recommended default** |
+| `e2-standard-2` | 2 (dedicated) | 8 GB | $49 | Heavier workloads |
+| `t2a-standard-1` | 1 (Ampere ARM) | 4 GB | $24 | ARM workloads |
+
+Free tier (`e2-micro`) is restricted to one VM per month in `us-west1`, `us-central1`, or `us-east1`. Outside those regions the small bill applies.
+
+## Provisioning
+
+### 1. Create a firewall rule (default-deny → allow specific ports)
+
+GCP's "default" VPC ships with a `default-allow-ssh` rule already; we add an explicit web rule. Tag-targeted rules attach to instances by tag rather than by name, which is more robust.
+
+```bash
+RULE_NAME="${INSTANCE_NAME}-allow-web"
+NETWORK_TAG="open-forge-${INSTANCE_NAME}"
+
+gcloud compute firewall-rules create "$RULE_NAME" \
+  --project "$GCP_PROJECT" \
+  --network default \
+  --direction INGRESS \
+  --action ALLOW \
+  --rules tcp:80,tcp:443 \
+  --source-ranges 0.0.0.0/0 \
+  --target-tags "$NETWORK_TAG"
+```
+
+SSH (`tcp:22`) is already allowed by `default-allow-ssh` on the `default` network for any instance. If the user customized their VPC and `default-allow-ssh` is gone, add `tcp:22` here too.
+
+### 2. Reserve a static external IP
+
+```bash
+ADDRESS_NAME="${INSTANCE_NAME}-ip"
+
+gcloud compute addresses create "$ADDRESS_NAME" \
+  --project "$GCP_PROJECT" \
+  --region "$GCP_REGION"
+
+PUBLIC_IP=$(gcloud compute addresses describe "$ADDRESS_NAME" \
+  --project "$GCP_PROJECT" --region "$GCP_REGION" \
+  --format='value(address)')
+```
+
+### 3. Create the VM
+
+```bash
+gcloud compute instances create "$INSTANCE_NAME" \
+  --project "$GCP_PROJECT" \
+  --zone "$GCP_ZONE" \
+  --machine-type "$MACHINE_TYPE" \
+  --image-family "$IMAGE_FAMILY" \
+  --image-project ubuntu-os-cloud \
+  --boot-disk-size "${BOOT_DISK_GB}GB" \
+  --boot-disk-type pd-balanced \
+  --tags "$NETWORK_TAG" \
+  --address "$PUBLIC_IP" \
+  --shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring \
+  --labels "open-forge=true,deployment=$INSTANCE_NAME"
+```
+
+`--image-project ubuntu-os-cloud` is correct for Canonical-published Ubuntu images; Debian uses `debian-cloud`. The `--address $PUBLIC_IP` flag attaches the reserved IP at launch (avoids the "ephemeral first, swap later" dance).
+
+Wait for the boot to settle:
+
+```bash
+gcloud compute instances describe "$INSTANCE_NAME" \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE" \
+  --format='value(status)'
+# Expect: RUNNING
+```
+
+### 4. Push your SSH key (the gcloud way)
+
+`gcloud compute ssh` lazily generates `~/.ssh/google_compute_engine` and pushes the public key into the instance's metadata on first use. To do it explicitly:
+
+```bash
+gcloud compute ssh "$INSTANCE_NAME" \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE" \
+  --command 'echo ok'
+```
+
+This is the easiest path. For tools (Ansible, plain `ssh`) that don't go through `gcloud`, add the key to project- or instance-level metadata:
+
+```bash
+gcloud compute instances add-metadata "$INSTANCE_NAME" \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE" \
+  --metadata "ssh-keys=<linux-user>:$(cat ~/.ssh/id_ed25519.pub)"
+```
+
+## SSH convention
+
+Two paths:
+
+```bash
+# Through gcloud (handles key + IAP fallback)
+gcloud compute ssh "$INSTANCE_NAME" --project "$GCP_PROJECT" --zone "$GCP_ZONE"
+
+# Plain ssh (after key is in metadata; user is your local username on Ubuntu images by default)
+ssh -i ~/.ssh/google_compute_engine -o StrictHostKeyChecking=accept-new "$USER@$PUBLIC_IP"
+```
+
+The default Linux username on Ubuntu/Debian images is **whatever local username gcloud detects** (often the segment of your Google email before `@`). Plain `ssh` needs `-l <user>` or `<user>@host` matching what gcloud created.
+
+## Firewall changes after provision
+
+```bash
+gcloud compute firewall-rules update "$RULE_NAME" \
+  --project "$GCP_PROJECT" \
+  --rules tcp:22,tcp:80,tcp:443,tcp:<N>,tcp:<M>
+```
+
+(GCP firewall rules' `--rules` is replace-not-append. Pass the full final list each time.)
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `gcloud compute instances describe ... --format='value(status)'` returns `RUNNING`
+- `gcloud compute addresses describe ... --format='value(status)'` returns `IN_USE`
+- `gcloud compute ssh "$INSTANCE_NAME" --command 'echo ok'` prints `ok`
+
+## Teardown
+
+Don't auto-run; confirm with the user.
+
+```bash
+gcloud compute instances delete "$INSTANCE_NAME" \
+  --project "$GCP_PROJECT" --zone "$GCP_ZONE" --quiet
+gcloud compute addresses delete "$ADDRESS_NAME" \
+  --project "$GCP_PROJECT" --region "$GCP_REGION" --quiet
+gcloud compute firewall-rules delete "$RULE_NAME" \
+  --project "$GCP_PROJECT" --quiet
+```
+
+## Gotchas
+
+- **Compute Engine API not enabled.** A fresh GCP project doesn't enable Compute Engine by default. `gcloud services enable compute.googleapis.com` once per project. Symptom on `gcloud compute instances create`: `Compute Engine API has not been used in project <id> before or it is disabled.`
+- **Billing not linked.** Free-tier projects without a billing account block instance creation. Surface this clearly — only the user can attach billing in the GCP Console.
+- **Address must match zone's region.** Reserved IPs are regional. The instance must be in a zone within that region. Mixing `--region us-central1` IP with `--zone us-east1-a` instance fails.
+- **Default `default-allow-ssh` may be missing.** Some org policies remove default firewall rules. If `default-allow-ssh` doesn't exist, our `--rules` must include `tcp:22`.
+- **`gcloud auth login` vs `gcloud auth application-default login`.** The first authenticates the CLI itself (used by `gcloud compute …` commands). The second sets up Application Default Credentials for SDKs (boto-style libraries on the VM). Don't conflate; for our use, only the first is needed.
+- **Sustained-use vs committed-use discounts** apply automatically the longer the VM runs, but the headline price you see on the Pricing page is *list*. Cheaper than what AWS shows by default.
+- **Static IP outside the free tier costs $$ when not attached** (~$0.005/hr). Release on teardown unless you want to retain the IP for a future deploy.
+- **OS Login vs metadata-keys.** Org-policy may force OS Login (centralized IAM-based SSH). When that's on, adding metadata keys silently does nothing — `gcloud compute ssh` is the only path. Detect with `gcloud compute project-info describe --format='value(commonInstanceMetadata.items.enable-oslogin)'`.
+
+## Reference
+
+- Compute Engine docs: <https://cloud.google.com/compute/docs>
+- `gcloud compute` reference: <https://cloud.google.com/sdk/gcloud/reference/compute>
+- Free tier eligibility: <https://cloud.google.com/free/docs/free-cloud-features#compute>

--- a/plugins/open-forge/skills/open-forge/references/infra/hetzner/cloud-cx.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/hetzner/cloud-cx.md
@@ -1,0 +1,187 @@
+---
+name: hetzner-cloud-cx-infra
+description: Hetzner Cloud (CX-line VPS) infra adapter — how to provision a CX server with SSH key upload, firewall, and primary IP via the `hcloud` CLI. Pair with `runtimes/docker.md` or `runtimes/native.md` for the application install. Picked when the user wants the cheapest serious-VPS option (€4–€7/mo), EU-jurisdiction hosting, or both.
+---
+
+# Hetzner Cloud — CX-line adapter
+
+Hetzner Cloud is a German-headquartered VPS provider with the cheapest "real" tier in the market (CX22 ≈ €4.5/mo for 4 GB RAM). Good default for hobby self-hosts where every dollar matters and EU-jurisdiction is a feature, not a constraint.
+
+## Prerequisites
+
+Check during preflight; stop and install/configure if missing:
+
+- `hcloud` CLI (`hcloud version`)
+- A Hetzner Cloud API token with read+write scope, set in an `hcloud` context
+- The user has a Hetzner Cloud account and has created at least one project in the Hetzner Console
+
+### Install + auth
+
+```bash
+# macOS
+brew install hcloud
+
+# Linux — download the latest binary
+curl -fsSL -o /tmp/hcloud.tgz \
+  "https://github.com/hetznercloud/cli/releases/latest/download/hcloud-linux-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz"
+tar -xzf /tmp/hcloud.tgz -C /tmp hcloud
+sudo install -m 0755 /tmp/hcloud /usr/local/bin/hcloud
+hcloud version
+
+# One-time: create a context tied to a project token
+# (User generates the token in https://console.hetzner.cloud → project → Security → API Tokens)
+hcloud context create open-forge        # interactive — paste the token
+hcloud context use open-forge
+hcloud server-type list                 # sanity check — should print the catalog
+```
+
+Tokens are project-scoped; one per Hetzner project. open-forge does not store tokens — `hcloud` keeps them in `~/.config/hcloud/cli.toml` with `chmod 600`.
+
+## Inputs to collect
+
+Cross-cutting preflight collects deployment name. The Hetzner adapter additionally needs:
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Server type?" | `AskUserQuestion`, options from the table below | Project-recipe-suggested |
+| End of preflight | "Location?" | `AskUserQuestion`: `Falkenstein, DE (fsn1)` / `Nuremberg, DE (nbg1)` / `Helsinki, FI (hel1)` / `Ashburn, US (ash)` / `Hillsboro, US (hil)` / `Singapore (sin)` | Geographic-closest to user |
+| End of preflight | "Image?" | `AskUserQuestion`: `Ubuntu 24.04` / `Debian 12` / `Other (specify)` | `Ubuntu 24.04` |
+| End of preflight | "SSH key — upload an existing one?" | `AskUserQuestion`: `Yes (default ~/.ssh/id_ed25519.pub)` / `Generate a new one for this deployment` / `Use a key already in this Hetzner project` | Existing default |
+
+Derived (no prompt):
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.server_name` | Deployment name |
+| `outputs.firewall_name` | `<deployment-name>-fw` |
+| `outputs.ssh_key_name` | `<deployment-name>-key` (or pre-existing name if reusing) |
+| `outputs.public_ip` | `hcloud server describe` output |
+| `outputs.ssh_key_path` | The local path the user supplied / generated key |
+
+### Common server-type options (Intel x86)
+
+| Type | vCPU | RAM | Disk | Approx €/mo | When |
+|---|---|---|---|---|---|
+| `cx22` | 2 (shared) | 4 GB | 40 GB | €4.5 | OpenClaw, Ghost, anything Node — recommended default |
+| `cx32` | 4 (shared) | 8 GB | 80 GB | €7.5 | Heavier Node/Java workloads |
+| `cx42` | 8 (shared) | 16 GB | 160 GB | €15 | Real production |
+| `cpx11` | 2 (dedicated AMD) | 2 GB | 40 GB | €5 | When CPU steal matters more than RAM |
+
+ARM (Ampere) lines (`cax11` etc.) are also offered — pick if upstream ships ARM.
+
+## Provisioning
+
+### 1. Upload (or reuse) the SSH key
+
+```bash
+KEY_NAME="${SERVER_NAME}-key"
+
+if [ ! -f "$SSH_PUBKEY_PATH" ]; then
+  ssh-keygen -t ed25519 -f "${SSH_PUBKEY_PATH%.pub}" -N "" -C "open-forge $SERVER_NAME"
+fi
+
+if ! hcloud ssh-key describe "$KEY_NAME" >/dev/null 2>&1; then
+  hcloud ssh-key create --name "$KEY_NAME" --public-key-from-file "$SSH_PUBKEY_PATH"
+fi
+```
+
+### 2. Create a firewall (default-deny, then allow)
+
+Hetzner's stateful firewall lives outside the VM (no host iptables needed for ingress).
+
+```bash
+FW_NAME="${SERVER_NAME}-fw"
+
+hcloud firewall create --name "$FW_NAME"
+
+hcloud firewall add-rule "$FW_NAME" --direction in --protocol tcp --port 22  --source-ips 0.0.0.0/0 --source-ips ::/0 --description SSH
+hcloud firewall add-rule "$FW_NAME" --direction in --protocol tcp --port 80  --source-ips 0.0.0.0/0 --source-ips ::/0 --description HTTP
+hcloud firewall add-rule "$FW_NAME" --direction in --protocol tcp --port 443 --source-ips 0.0.0.0/0 --source-ips ::/0 --description HTTPS
+```
+
+If the project recipe needs additional ports, add them the same way at the relevant phase.
+
+### 3. Create the server
+
+```bash
+hcloud server create \
+  --name "$SERVER_NAME" \
+  --type "$SERVER_TYPE" \
+  --image "$IMAGE" \
+  --location "$LOCATION" \
+  --ssh-key "$KEY_NAME" \
+  --firewall "$FW_NAME" \
+  --label "open-forge=true" \
+  --label "deployment=$SERVER_NAME"
+```
+
+`hcloud server create` blocks until the server is `running`. The output contains the IPv4 + IPv6.
+
+```bash
+PUBLIC_IP=$(hcloud server ip "$SERVER_NAME")
+```
+
+### 4. (Optional) Reserve a Primary IP for portability
+
+Hetzner servers come with a primary IPv4 + IPv6 by default. They survive reboots but **not** delete-and-recreate. For deployments where the same DNS A record must keep working across rebuilds, allocate a separate Primary IP and assign it:
+
+```bash
+hcloud primary-ip create \
+  --type ipv4 --datacenter "${LOCATION}-dc1" \
+  --name "${SERVER_NAME}-ip" \
+  --assignee-type server --assignee-id "$(hcloud server describe "$SERVER_NAME" -o json | jq -r .id)"
+```
+
+For most hobby deploys this is overkill — the server's default IP is fine. Skip unless the user explicitly wants rebuild-stable DNS.
+
+## SSH convention
+
+- User: **`root`** by default on Hetzner Ubuntu/Debian images. Hetzner provisioning seeds your SSH key into `/root/.ssh/authorized_keys` directly; there is no `ubuntu` user pre-created.
+- First SSH: `-o StrictHostKeyChecking=accept-new`.
+
+```bash
+ssh -i "${SSH_PUBKEY_PATH%.pub}" -o StrictHostKeyChecking=accept-new "root@$PUBLIC_IP"
+```
+
+For a non-root daily user, follow the project recipe — most recipes do `adduser <name>`, copy `authorized_keys`, then disable root login in `/etc/ssh/sshd_config`. `runtimes/native.md` and `runtimes/docker.md` assume the user already has shell access.
+
+## Firewall changes after provision
+
+```bash
+hcloud firewall add-rule "$FW_NAME" --direction in --protocol tcp --port <N> --source-ips 0.0.0.0/0 --source-ips ::/0 --description '<purpose>'
+hcloud firewall delete-rule "$FW_NAME" --direction in --protocol tcp --port <N> --source-ips 0.0.0.0/0 --source-ips ::/0
+```
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `hcloud server describe "$SERVER_NAME" -o json | jq -r .status` returns `running`
+- `ssh -i <key> root@$PUBLIC_IP 'echo ok'` prints `ok`
+
+## Teardown
+
+Don't auto-run; confirm with the user.
+
+```bash
+hcloud server delete "$SERVER_NAME"
+hcloud firewall delete "$FW_NAME"
+hcloud ssh-key delete "$KEY_NAME"          # only if no other server uses it
+hcloud primary-ip delete "${SERVER_NAME}-ip"   # only if you allocated one
+```
+
+## Gotchas
+
+- **Default user is `root`.** Different from AWS / GCP defaults (`ubuntu`, `ec2-user`). Don't try `ubuntu@<ip>` — it doesn't exist.
+- **Server delete also frees the default Primary IP.** If you reserved one separately (step 4 above), keep that — it's not auto-deleted.
+- **Firewall must be attached at create time** (or via `hcloud firewall apply-to-resource` after) — a server without a firewall has all inbound open at the cloud level. The `--firewall` flag on `server create` is the simplest path.
+- **Bandwidth metering.** Hetzner's per-server traffic allowance (20 TB/mo on most plans) is generous; over-allowance is billed at €1/TB. Not a concern for typical self-host workloads.
+- **Snapshot vs backup.** Snapshots are manual (€0.0119/GB/mo); automated backups are 20% of server price. Hobby deploys often skip both — explain the trade to the user before ticking either on.
+- **`hcloud context` is per-project.** Multiple Hetzner projects in one account each have their own API token and need their own context. Switch with `hcloud context use <name>`.
+- **No private networking by default.** All traffic between Hetzner servers goes over the public internet unless you create a Hetzner Cloud Network and attach servers. Single-node self-hosts don't need this.
+
+## Reference
+
+- Hetzner Cloud docs: <https://docs.hetzner.com/cloud/>
+- `hcloud` CLI: <https://github.com/hetznercloud/cli>
+- Server-type catalog: <https://www.hetzner.com/cloud/>

--- a/plugins/open-forge/skills/open-forge/references/modules/preflight.md
+++ b/plugins/open-forge/skills/open-forge/references/modules/preflight.md
@@ -31,7 +31,7 @@ Use `AskUserQuestion`:
 > - Bring-your-own VPS (any Linux VM you already have)
 > - **localhost** (your own machine)
 
-Loads the matching infra adapter — `references/infra/<cloud>/` or `references/infra/{byo-vps,localhost}.md`. For clouds that don't yet have a dedicated adapter, fall through to `byo-vps.md` (user provides an already-provisioned VM).
+Loads the matching infra adapter — `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`. Today AWS (Lightsail + EC2), Hetzner Cloud, DigitalOcean, and GCP Compute Engine each have a dedicated adapter; anything else (other providers, on-prem, etc.) goes through `byo-vps.md`.
 
 ### 1c. How? (service + runtime)
 
@@ -61,10 +61,10 @@ Infra-conditional:
 
 | If infra ∈ | Also required |
 |---|---|
-| AWS | `aws` (v2) CLI |
-| Hetzner (when adapter lands) | `hcloud` CLI |
-| DigitalOcean (when adapter lands) | `doctl` CLI |
-| GCP (when adapter lands) | `gcloud` CLI |
+| AWS (Lightsail or EC2) | `aws` (v2) CLI |
+| Hetzner | `hcloud` CLI |
+| DigitalOcean | `doctl` CLI |
+| GCP | `gcloud` CLI |
 | BYO VPS | `ssh` (usually preinstalled) |
 | localhost | none — Claude runs local Bash |
 
@@ -119,6 +119,9 @@ Announce in one sentence, then run. Verify after (`<tool> --version`).
 | `jq` | `brew install jq` | `sudo apt-get install -y jq` | `sudo dnf install -y jq` | `sudo pacman -S --noconfirm jq` | <https://jqlang.org/download/> |
 | `curl` | preinstalled | `sudo apt-get install -y curl` | `sudo dnf install -y curl` | `sudo pacman -S curl` | preinstalled on macOS |
 | `aws` v2 | `brew install awscli` | official installer (below) | `sudo dnf install -y awscli` | `sudo pacman -S aws-cli-v2` | <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html> |
+| `hcloud` | `brew install hcloud` | binary release (see `infra/hetzner/cloud-cx.md`) | binary release | binary release | <https://github.com/hetznercloud/cli/releases> |
+| `doctl` | `brew install doctl` | binary release (see `infra/digitalocean/droplet.md`) | binary release | binary release | <https://docs.digitalocean.com/reference/doctl/how-to/install/> |
+| `gcloud` | `brew install --cask google-cloud-sdk` | Google's apt repo (see `infra/gcp/compute-engine.md`) | Google's dnf repo | AUR `google-cloud-sdk` | <https://cloud.google.com/sdk/docs/install> |
 
 `aws` note: `apt-get install awscli` installs v1 on older Ubuntu/Debian. Prefer the official v2 installer:
 
@@ -156,9 +159,49 @@ aws sts get-caller-identity --profile "$AWS_PROFILE"
 
 Show the user *which account* is selected — single most common preflight mistake is using the wrong AWS account. If it errors ("could not be found" / "expired"), help re-auth (`aws sso login --profile <name>` for SSO setups) before continuing.
 
-### Hetzner / DigitalOcean / GCP
+### Hetzner
 
-When those adapters land, each has its own credential flow (`hcloud config`, `doctl auth init`, `gcloud auth login`). Follow their standard onboarding — don't reinvent.
+```bash
+hcloud context list
+hcloud context active
+```
+
+- **No context**: ask the user to generate a project API token (Hetzner Console → project → Security → API Tokens), then run `hcloud context create <name>` interactively to paste it. Never see the token.
+- **One context**: confirm.
+- **Multiple contexts**: `AskUserQuestion` to pick, then `hcloud context use <name>`.
+
+Sanity-check: `hcloud server-type list | head -5`. Surface the active project name so the user can spot a wrong-project mistake.
+
+See `references/infra/hetzner/cloud-cx.md` for full adapter details.
+
+### DigitalOcean
+
+```bash
+doctl auth list
+```
+
+- **No context**: run `doctl auth init` interactively (user pastes the token, generated at <https://cloud.digitalocean.com/account/api/tokens>).
+- **One context**: confirm.
+- **Multiple contexts**: `AskUserQuestion`, then `doctl auth switch --context <name>`.
+
+Sanity-check: `doctl account get` — show the user the active account email.
+
+See `references/infra/digitalocean/droplet.md` for full adapter details.
+
+### GCP
+
+```bash
+gcloud auth list
+gcloud config get-value project
+```
+
+- **No active account**: `gcloud auth login` (opens browser).
+- **No project set**: `gcloud projects list`, then `AskUserQuestion` to pick, then `gcloud config set project <id>`.
+- **API not enabled**: `gcloud services enable compute.googleapis.com` (idempotent, runs once per project).
+
+Sanity-check: `gcloud compute regions list --limit 1` (will fail clearly if billing or API isn't set up).
+
+See `references/infra/gcp/compute-engine.md` for full adapter details.
 
 ### BYO VPS
 

--- a/plugins/open-forge/skills/open-forge/references/projects/openclaw.md
+++ b/plugins/open-forge/skills/open-forge/references/projects/openclaw.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-project
-description: OpenClaw recipe for open-forge — a self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game). Covers install on AWS Lightsail (vendor blueprint or Ubuntu VM), any Linux VPS (Hetzner / DigitalOcean / bring-your-own), and localhost. Supports any model provider (Anthropic / OpenAI / Google / Bedrock / local). Pairs with references/runtimes/docker.md, references/infra/*.md, and references/modules/tunnels.md as needed.
+description: OpenClaw recipe for open-forge — a self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game). Covers install on AWS Lightsail (vendor blueprint or Ubuntu VM), AWS EC2, Hetzner Cloud, DigitalOcean, GCP Compute Engine, any Linux VPS (bring-your-own), and localhost. Supports any model provider (Anthropic / OpenAI / Google / Bedrock / local). Pairs with references/runtimes/{docker,native}.md, references/infra/*.md, and references/modules/tunnels.md as needed.
 ---
 
 # OpenClaw
@@ -9,20 +9,27 @@ Self-hosted personal AI agent with web browsing, file access, shell execution, a
 
 ## Compatible combos
 
-| Where (infra) | How (service × runtime) | Notes |
-|---|---|---|
-| **AWS Lightsail** | **OpenClaw blueprint** | Fastest on AWS; Bedrock pre-wired via cross-account role. Requires a one-time IAM setup script. |
-| AWS Lightsail | Ubuntu VM + Docker | Use this if you don't want the vendor blueprint's Bedrock lock-in |
-| AWS Lightsail | Ubuntu VM + native installer | Same as above, no container |
-| AWS EC2 | any + Docker or native | More control; pair with `references/runtimes/docker.md` |
-| Hetzner / DigitalOcean / GCP / BYO VPS | VM + Docker or native | Use `references/infra/byo-vps.md` |
-| **localhost** | Docker Desktop / native | Upstream's default path (openclaw.ai's installer is designed for local). Public reach via `references/modules/tunnels.md`. |
+| Where (infra) | How (service × runtime) | Adapter / runtime | Notes |
+|---|---|---|---|
+| **AWS Lightsail** | **OpenClaw blueprint** | `infra/aws/lightsail.md` (vendor-bundled runtime) | Fastest on AWS; Bedrock pre-wired via cross-account role. Requires a one-time IAM setup script. |
+| AWS Lightsail | Ubuntu VM + Docker | `infra/aws/lightsail.md` + `runtimes/docker.md` | Use this if you don't want the vendor blueprint's Bedrock lock-in |
+| AWS Lightsail | Ubuntu VM + native installer | `infra/aws/lightsail.md` + `runtimes/native.md` | Same as above, no container |
+| AWS EC2 | Docker | `infra/aws/ec2.md` + `runtimes/docker.md` | More control than Lightsail; security groups and AMI choice |
+| AWS EC2 | native | `infra/aws/ec2.md` + `runtimes/native.md` | Same as above, no container |
+| Hetzner Cloud | Docker | `infra/hetzner/cloud-cx.md` + `runtimes/docker.md` | Cheapest VPS option; EU-regulated |
+| Hetzner Cloud | native | `infra/hetzner/cloud-cx.md` + `runtimes/native.md` | |
+| DigitalOcean | Docker | `infra/digitalocean/droplet.md` + `runtimes/docker.md` | Single-click droplets; integrated firewall |
+| DigitalOcean | native | `infra/digitalocean/droplet.md` + `runtimes/native.md` | |
+| GCP | Docker | `infra/gcp/compute-engine.md` + `runtimes/docker.md` | Compute Engine VM; needs `gcloud` configured |
+| GCP | native | `infra/gcp/compute-engine.md` + `runtimes/native.md` | |
+| BYO VPS (any other provider, on-prem) | Docker or native | `infra/byo-vps.md` + `runtimes/{docker,native}.md` | Catch-all when no dedicated adapter exists |
+| **localhost** | Docker Desktop / native | `infra/localhost.md` + `runtimes/{docker,native}.md` | Upstream's default path (openclaw.ai's installer is designed for local). Public reach via `references/modules/tunnels.md`. |
 
 The dynamic **how** question's options come from this table filtered by the user's **where** answer. On AWS the blueprint is the recommended default; on localhost the native installer is (simpler than Docker Desktop for most users).
 
 ## Inputs to collect
 
-After cross-cutting preflight (AWS profile/region only when infra ∈ AWS; nothing for localhost; SSH details for byo-vps):
+After cross-cutting preflight (cloud creds only when infra ∈ AWS/Hetzner/DO/GCP; nothing for localhost; SSH details for byo-vps):
 
 | Phase | Prompt | Tool | Notes |
 |---|---|---|---|
@@ -348,41 +355,45 @@ docker compose run --rm openclaw-cli devices approve --latest \
 
 ---
 
-## Native installer (any Linux host without Docker)
+## Native installer (any Linux/macOS host without Docker)
 
-When the user picks **any Linux host → native installer** or **localhost → native**.
+When the user picks **any Linux/macOS host → native installer** or **localhost → native**. Pair with [`references/runtimes/native.md`](../runtimes/native.md) for the host-level prereqs (build tools, systemd/launchd lifecycle, reverse proxy guidance).
 
 ### Install
 
 ```bash
-# Prereqs on fresh Ubuntu/Debian
-sudo apt-get update && sudo apt-get install -y curl build-essential
+# Linux: native.md installs build-essential / curl / ca-certificates first.
+# macOS: native.md installs Xcode CLI tools first.
 
-# Official installer
+# Official installer (same on Linux + macOS)
 curl -fsSL https://openclaw.ai/install.sh | bash
 exec $SHELL -l
 openclaw --version
-openclaw onboard --install-daemon    # interactive: pick provider, paste API key
+openclaw onboard --install-daemon    # interactive — pause autonomous mode; user picks provider, pastes API key
 openclaw gateway status
 ```
 
-For macOS localhost: `brew install node@22` first (if no Node), then the same installer. On Linux distros other than Debian/Ubuntu, adjust the build-tools package names.
+The installer drops a systemd user unit on Linux and a launchd plist on macOS. Lifecycle commands (`status` / `restart` / `journalctl`) are in `runtimes/native.md`.
 
 ### Access
 
-Gateway binds to `127.0.0.1:18789`. For remote hosts, SSH tunnel is the default:
+Gateway binds to `127.0.0.1:18789`. Two paths to reach it:
 
 ```bash
+# Remote host — SSH tunnel
 ssh -L 18789:127.0.0.1:18789 <user>@<host>
 # then open: http://localhost:18789/#token=<TOKEN>
+
+# Localhost — open directly
+# http://localhost:18789/#token=<TOKEN>
 ```
 
-For localhost, open the URL directly.
+For public reach on a remote host, see `runtimes/native.md` § *Reverse proxy* (Caddy is recommended for new installs; if you're on a Bitnami/Lightsail-blueprint host, Apache is already wired).
 
-### Native-specific gotchas
+### Native-specific gotchas (OpenClaw-only)
 
-- **Node version mismatch after reboot.** The installer pins a specific Node. If the user has nvm or a system Node, verify `openclaw gateway status` after reboot, not just right after install.
-- **Public exposure needs a reverse proxy you set up yourself** (Caddy, nginx, Apache). No vendor-managed proxy like the Lightsail blueprint ships.
+- **Node version mismatch after reboot.** The installer pins a specific Node. If the user has nvm or a system Node, verify `openclaw gateway status` after a deliberate reboot, not just right after install. (See `runtimes/native.md` § *PATH not refreshed* and *Node / Python version pinning* for general handling.)
+- **`openclaw onboard` and `openclaw configure` are interactive** — pause autonomous mode. The native installer never has a non-interactive flow today.
 
 ---
 
@@ -404,7 +415,7 @@ Universal:
 - **`openclaw onboard` / `openclaw configure` are interactive.** Don't try to automate — pause open-forge's autonomous mode.
 - **Model costs compound.** Long agent runs can burn tokens fast. Set spend limits at the provider dashboard before first real use.
 
-AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — see *Docker-specific gotchas*. Native — see *Native-specific gotchas*.
+AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — see *Docker-specific gotchas* + `runtimes/docker.md` § *Common gotchas*. Native — see *Native-specific gotchas* + `runtimes/native.md` § *Common gotchas*.
 
 ---
 

--- a/plugins/open-forge/skills/open-forge/references/runtimes/native.md
+++ b/plugins/open-forge/skills/open-forge/references/runtimes/native.md
@@ -1,0 +1,195 @@
+---
+name: native-runtime
+description: Cross-cutting runtime module for native (non-containerized) deployments. Loaded whenever the user picks the native installer / curl-pipe-bash / package-manager path on any infra (Lightsail Ubuntu, EC2, Hetzner, DO, GCP, BYO VPS, localhost). Owns OS prereqs, daemon lifecycle, reverse-proxy guidance, and common gotchas. Project recipes own their own installer command, config paths, and app-specific service unit.
+---
+
+# Native runtime
+
+Reusable across every Linux/macOS host where the project ships a native installer (no container). The project recipe specifies *what* to run (installer URL, config paths, the service unit's exact `ExecStart`); this module specifies *how* — install OS prereqs, manage the daemon's lifecycle, set up a reverse proxy, troubleshoot common native-install issues.
+
+## When this module is loaded
+
+User answered the **how** question with anything native:
+
+- "Lightsail Ubuntu + native installer", "EC2 + native", "Hetzner CX + native"
+- "BYO VPS + native"
+- "localhost + native" (macOS / Linux home directory install)
+
+Skipped when the runtime is bundled by the infra (e.g. Lightsail vendor blueprint) or when the user picked Docker.
+
+## Host requirements
+
+- **Linux**: kernel ≥ 4.x, systemd (for daemon supervision), `curl`, `bash`. ARM and x86_64 both supported by most upstream installers; verify with the project's matrix.
+- **macOS** (only valid for `infra/localhost.md`): Homebrew preinstalled by the user; `launchd` is built-in for autostart.
+- **Windows** (only valid for `infra/localhost.md`): native installs are project-by-project; many projects only ship Linux/macOS native and recommend WSL or Docker on Windows.
+- **Disk**: ≥ 5 GB free for most native installs (much smaller than Docker-based — no image cache).
+- **RAM**: project-dependent. Native runs lighter than Docker because no container overhead.
+
+## Install OS prereqs
+
+The installer scripts most projects ship (`curl … | bash`) assume `curl`, `tar`, and a C/C++ toolchain are present. Install once before running the project installer:
+
+### Debian / Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install -y curl ca-certificates build-essential
+```
+
+### RHEL / Fedora / Amazon Linux
+
+```bash
+sudo dnf install -y curl ca-certificates @development-tools
+# or older: sudo yum groupinstall -y 'Development Tools'
+```
+
+### Alpine
+
+```bash
+sudo apk add --no-cache curl ca-certificates build-base
+```
+
+### macOS
+
+```bash
+xcode-select --install        # one-time; installs Apple's CLI tools (clang, make, …)
+# Homebrew should already be installed; if not: https://brew.sh
+```
+
+Project recipes will list any **additional** prereqs (e.g. `nodejs`, `python3`, `imagemagick`). Install those with the matching package manager — never fall back to `pip`/`npm` global installs without the user's approval.
+
+## Run the project installer
+
+Project recipes own the exact command. Generic patterns:
+
+```bash
+# curl | bash (most common)
+curl -fsSL https://<project>.example/install.sh | bash
+
+# package manager
+sudo apt-get install -y <project>          # Debian/Ubuntu
+brew install <project>                     # macOS
+
+# binary release
+curl -fsSL -o /tmp/<project> https://github.com/<org>/<project>/releases/latest/download/<project>-linux-x86_64
+sudo install -m 0755 /tmp/<project> /usr/local/bin/<project>
+```
+
+Always announce in one sentence before piping a remote script to a shell. Some users want to inspect first — offer `curl -fsSL <url> -o /tmp/install.sh && less /tmp/install.sh` as an alternative.
+
+## Daemon lifecycle
+
+Most projects ship a service unit. Three flavors:
+
+### systemd (Linux)
+
+System-wide unit (root-owned, starts at boot regardless of user login):
+
+```bash
+sudo systemctl status <project>
+sudo systemctl start <project>
+sudo systemctl stop <project>
+sudo systemctl restart <project>
+sudo systemctl enable <project>      # autostart on boot
+sudo journalctl -u <project> -f      # live logs
+```
+
+User unit (runs as the logged-in user; needs `loginctl enable-linger` for no-login persistence):
+
+```bash
+systemctl --user status <project>
+systemctl --user restart <project>
+journalctl --user -u <project> -f
+
+# One-time, so the user unit survives no-login sessions:
+sudo loginctl enable-linger "$USER"
+```
+
+User units are common when the project's data lives under `$HOME` and root isn't needed. The Lightsail OpenClaw blueprint uses this pattern.
+
+### launchd (macOS)
+
+```bash
+launchctl load -w ~/Library/LaunchAgents/<project>.plist     # enable + start
+launchctl unload ~/Library/LaunchAgents/<project>.plist      # stop + disable
+launchctl list | grep <project>                              # status
+```
+
+Logs go to wherever the plist's `StandardOutPath` / `StandardErrorPath` point — usually `~/Library/Logs/<project>.log`.
+
+### Foreground (no daemon)
+
+Some installers don't ship a unit. Run the binary in a `tmux` / `screen` session as a stopgap, then offer to write a unit file. Don't leave the user with "open a terminal and remember to keep it running" as the long-term answer.
+
+## Reverse proxy (when public-facing)
+
+Native installs typically bind to `127.0.0.1:<port>`. For public reach you need a reverse proxy that terminates TLS and forwards to the local port. Choices:
+
+| Proxy | Why pick it |
+|---|---|
+| **Caddy** | Easiest TLS — automatic Let's Encrypt with no config. Single binary. Recommended default. |
+| **nginx** | Ubiquitous, well-documented, more knobs. Requires `certbot` for TLS. |
+| **Apache** | Default on some vendor blueprints (Lightsail OpenClaw, Bitnami). Already in place — don't rip out. |
+
+Generic Caddy setup (Linux):
+
+```bash
+sudo apt-get install -y caddy   # Debian/Ubuntu via Caddy's apt repo; see https://caddyserver.com/docs/install
+sudo tee /etc/caddy/Caddyfile <<EOF
+<domain> {
+  reverse_proxy 127.0.0.1:<port>
+}
+EOF
+sudo systemctl reload caddy
+```
+
+Caddy fetches the cert on first request to `<domain>`. Make sure the DNS A record points at the host first.
+
+For nginx + certbot, see `references/modules/tls-letsencrypt.md`. For Apache (Bitnami / Lightsail OpenClaw), the blueprint's vhost is already wired — use `certbot --apache` to swap the snakeoil cert for a real one.
+
+## Upgrades
+
+Project-specific. Generic patterns:
+
+```bash
+# curl | bash installers — re-running picks up the latest version
+curl -fsSL https://<project>.example/install.sh | bash
+
+# package manager
+sudo apt-get update && sudo apt-get install -y --only-upgrade <project>
+brew upgrade <project>
+
+# binary release — replace the binary, then restart the service
+sudo install -m 0755 /tmp/<project>-new /usr/local/bin/<project>
+sudo systemctl restart <project>
+```
+
+Always restart the service after a binary swap. Persistent state under `$HOME` / `/var/lib/<project>` / `/etc/<project>` survives upgrades.
+
+## Firewall
+
+Native services typically listen on `127.0.0.1:<port>` and need a reverse proxy on `:80` / `:443`. Open those at the *infra* layer (Lightsail firewall, Hetzner Cloud Firewall, `ufw`, etc.). Don't open the project's app port (`18789`, `2368`, …) directly to the internet — bypassing the proxy bypasses TLS.
+
+For host-level firewall on a BYO VPS without provider firewall:
+
+```bash
+sudo ufw allow OpenSSH
+sudo ufw allow 'Nginx Full'      # opens 80 + 443
+sudo ufw enable
+```
+
+## Common gotchas
+
+- **PATH not refreshed after install.** Many installers drop a binary in `~/.local/bin` or `/usr/local/bin` and rely on shell rc to pick it up. After install, run `exec $SHELL -l` (or open a new shell) before invoking the binary. Symptom: `command not found` immediately after a successful install.
+- **Node / Python version pinning.** Installers that bundle a runtime (Node 22, Python 3.11) often pin a specific version. If the user has `nvm` / `pyenv` / a system Node, the wrong one can shadow the bundled one after `exec $SHELL -l`. Verify with `which <runtime> && <runtime> --version` and `<project> --version`. Mitigations: project-specific shims, asdf, or `update-alternatives`.
+- **systemd user unit dies on reboot without linger.** `systemctl --user enable <project>` alone doesn't survive logout. Pair with `sudo loginctl enable-linger "$USER"` once.
+- **`sudo` doesn't inherit user DBUS.** Symptoms like `Failed to connect to bus: No medium found` when running `sudo systemctl --user …` or any command that talks to the user's DBUS — run as the unprivileged user instead, or `sudo -i -u <user>` to get a full login env.
+- **Reboot loses the running daemon, not the data.** Config and state under `$HOME` / `/var/lib/<project>` survive. The service comes back only if `enable`d (and lingered, for user units). Verify after a deliberate reboot, not just right after install.
+- **No automatic TLS** — unlike vendor blueprints (Lightsail) or tunnels (Cloudflare/Tailscale), bare native installs don't ship with a cert. Pair with `references/modules/tls-letsencrypt.md` (or Caddy, which automates it).
+- **Permissions on `/usr/local/bin`** — on some macOS installs, `/usr/local/bin` isn't writable without `sudo`. Homebrew handles this; manual `install -m 0755` may need `sudo`.
+
+## Reference
+
+- systemd service docs: <https://www.freedesktop.org/software/systemd/man/systemd.service.html>
+- launchd docs (macOS): <https://www.launchd.info/>
+- Caddy: <https://caddyserver.com/docs/>


### PR DESCRIPTION
## Summary

This PR adds comprehensive infrastructure provisioning adapters for four major cloud providers, enabling open-forge to guide users through VM provisioning on AWS EC2, Hetzner Cloud, DigitalOcean, and Google Cloud Platform. It also introduces a cross-cutting `native` runtime module for non-containerized deployments.

## Key Changes

- **AWS EC2 adapter** (`infra/aws/ec2.md`): Provisions EC2 instances with security groups, key pairs, Elastic IPs, and SSH access. Supports dynamic AMI resolution, custom instance types, and IMDSv2 enforcement.

- **Hetzner Cloud adapter** (`infra/hetzner/cloud-cx.md`): Provisions CX-line servers with SSH key management, stateful firewall rules, and optional Primary IP reservation. Targets cost-conscious self-hosters in EU jurisdiction.

- **DigitalOcean adapter** (`infra/digitalocean/droplet.md`): Provisions Droplets with Cloud Firewall, SSH key upload, and optional Reserved IP. Includes integrated ecosystem guidance (Spaces, Postgres, Load Balancers).

- **GCP Compute Engine adapter** (`infra/gcp/compute-engine.md`): Provisions VMs with VPC firewall rules, SSH key metadata injection, and reserved external IPs. Covers free-tier eligibility and Shielded VM security features.

- **Native runtime module** (`runtimes/native.md`): Cross-cutting module for non-containerized deployments across all infra providers. Covers OS prereqs, daemon lifecycle (systemd/launchd), reverse proxy setup (Caddy/nginx), and common gotchas.

- **Updated preflight module** (`modules/preflight.md`): Reflects new adapters in infra selection and CLI tool requirements table.

- **Updated project recipes**: OpenClaw and other projects now reference the new adapters in their compatibility matrices.

- **Documentation updates**: README and CLAUDE.md updated to reflect expanded provider support.

## Notable Implementation Details

- All adapters follow a consistent pattern: preflight checks → input collection → provisioning steps → SSH convention → verification → teardown.
- Each adapter includes region/location selection, machine type/size options with pricing guidance, and image selection (Ubuntu/Debian defaults).
- Firewall/security group rules are explicitly managed (default-deny + allow specific ports) across all providers.
- SSH key handling varies by provider (gcloud-managed for GCP, explicit key pairs for AWS/Hetzner/DO) but converges on standard SSH conventions.
- Native runtime decouples from infra layer, enabling reuse across Lightsail, EC2, Hetzner, DO, GCP, BYO VPS, and localhost.
- All adapters include gotchas sections documenting provider-specific pitfalls (billing, API enablement, firewall timing, etc.).

https://claude.ai/code/session_01F85DthcYEpVsj9dWaN6iXF