### PR TITLE
v0.6 → v0.8: cover every official OpenClaw deployment method (docs.openclaw.ai/install/*)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,8 @@ open-forge/
         ├── SKILL.md                       ← end-user-Claude entrypoint
         ├── references/
         │   ├── projects/<name>.md         ← software layer
-        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, native.md, kubernetes.md)
-        │   ├── infra/<name>.md            ← infra layer (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
+        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
+        │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
         │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
         └── scripts/                       ← reused operational scripts; empty by default
 ```
@@ -157,13 +157,13 @@ Initial state collapsed three axes into linear "Path A/B/C" inside `openclaw.md`
 
 1. ✅ CLAUDE.md model locked in (this section).
 2. ✅ Preflight refactor — branch on infra choice; only require AWS CLI when infra ∈ AWS.
-3. ✅ Skeleton infra adapters: `infra/aws/lightsail.md` (Bitnami + OpenClaw blueprints share this; the blueprint-vs-Ubuntu split is a project-recipe concern, not a separate adapter), `infra/aws/ec2.md`, `infra/hetzner/cloud-cx.md`, `infra/digitalocean/droplet.md`, `infra/gcp/compute-engine.md`, `infra/byo-vps.md`, `infra/localhost.md`.
-4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/native.md`, `runtimes/kubernetes.md`. Docker + native extracted from openclaw.md Paths B and C; kubernetes added when openclaw upstream's official Helm chart was wired in (v0.7.0).
-5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else. Adds a Kubernetes section (v0.7.0) citing the upstream chart at `charts.openclaw.ai`.
+3. ✅ Skeleton infra adapters: `infra/aws/lightsail.md` (Bitnami + OpenClaw blueprints share this; the blueprint-vs-Ubuntu split is a project-recipe concern, not a separate adapter), `infra/aws/ec2.md`, `infra/azure/vm.md`, `infra/hetzner/cloud-cx.md`, `infra/digitalocean/droplet.md`, `infra/gcp/compute-engine.md`, `infra/oracle/free-tier-arm.md`, `infra/hostinger.md`, `infra/raspberry-pi.md`, `infra/macos-vm.md`, `infra/byo-vps.md`, `infra/localhost.md`, plus a PaaS family under `infra/paas/`: `fly.md`, `render.md`, `railway.md`, `northflank.md`, `exe-dev.md`.
+4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/podman.md`, `runtimes/native.md`, `runtimes/kubernetes.md`. Docker + native extracted from openclaw.md Paths B and C; kubernetes added when openclaw upstream's Kustomize-based path was wired in; podman added in v0.8.0.
+5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else. v0.8.0: corrected the Kubernetes section to be Kustomize-first (matches upstream `scripts/k8s/deploy.sh`); added Podman, ClawDock, Ansible, Nix, and Bun (experimental) sections; combo table now enumerates every upstream-blessed install method documented under `docs.openclaw.ai/install/*`.
 6. ✅ Add `modules/tunnels.md` for localhost public-reach (Cloudflare Tunnel / Tailscale / ngrok).
-7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.7.0).
+7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.8.0).
 
-Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here. Cluster-provisioning adapters (EKS / GKE / AKS / DOKS) are intentionally not in scope — open-forge orchestrates an existing cluster; users own cluster create/delete in their cloud's k8s UI.
+Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here. Cluster-provisioning adapters (EKS / GKE / AKS / DOKS) are intentionally not in scope — open-forge orchestrates an existing cluster; users own cluster create/delete in their cloud's k8s UI. Cloud-VM adapters and PaaS adapters added in v0.8.0 are documented from upstream docs only — none has been exercised end-to-end yet; first-run discipline (CLAUDE.md § *First-run discipline*) applies as those deployments happen.
 
 ## Behavioral guidelines (echoes of bota CLAUDE.md, kept here for autonomy)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ open-forge/
         ├── SKILL.md                       ← end-user-Claude entrypoint
         ├── references/
         │   ├── projects/<name>.md         ← software layer
-        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, native.md)
+        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
         │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
         └── scripts/                       ← reused operational scripts; empty by default
@@ -158,12 +158,12 @@ Initial state collapsed three axes into linear "Path A/B/C" inside `openclaw.md`
 1. ✅ CLAUDE.md model locked in (this section).
 2. ✅ Preflight refactor — branch on infra choice; only require AWS CLI when infra ∈ AWS.
 3. ✅ Skeleton infra adapters: `infra/aws/lightsail.md` (Bitnami + OpenClaw blueprints share this; the blueprint-vs-Ubuntu split is a project-recipe concern, not a separate adapter), `infra/aws/ec2.md`, `infra/hetzner/cloud-cx.md`, `infra/digitalocean/droplet.md`, `infra/gcp/compute-engine.md`, `infra/byo-vps.md`, `infra/localhost.md`.
-4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/native.md`. Extracted from openclaw.md Paths B and C.
-5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else.
+4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/native.md`, `runtimes/kubernetes.md`. Docker + native extracted from openclaw.md Paths B and C; kubernetes added when openclaw upstream's official Helm chart was wired in (v0.7.0).
+5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else. Adds a Kubernetes section (v0.7.0) citing the upstream chart at `charts.openclaw.ai`.
 6. ✅ Add `modules/tunnels.md` for localhost public-reach (Cloudflare Tunnel / Tailscale / ngrok).
-7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.6.0).
+7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.7.0).
 
-Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here.
+Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here. Cluster-provisioning adapters (EKS / GKE / AKS / DOKS) are intentionally not in scope — open-forge orchestrates an existing cluster; users own cluster create/delete in their cloud's k8s UI.
 
 ## Behavioral guidelines (echoes of bota CLAUDE.md, kept here for autonomy)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Supported **where**:
 | **DigitalOcean** | Droplet + Docker · + native |
 | **GCP Compute Engine** | VM + Docker · + native |
 | Any Linux VM you already have (other providers, bare metal) | Docker · native |
+| **Any Kubernetes cluster** (EKS / GKE / AKS / DOKS / k3s / Docker Desktop) | Helm chart (for projects that ship one — e.g. OpenClaw via `charts.openclaw.ai`) |
 | **Your own machine** (macOS / Linux / Windows) | Docker Desktop · native |
 
 Three-question flow: what to host, where to host, how to host. Claude asks only what's genuinely ambiguous — if your prompt already names a clear cloud, the first question is skipped.
@@ -64,7 +65,7 @@ open-forge/
             ├── references/
             │   ├── projects/           # per-project recipes (ghost.md, openclaw.md, ...)
             │   ├── infra/              # per-infra adapters (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
-            │   ├── runtimes/           # docker.md, native.md
+            │   ├── runtimes/           # docker.md, native.md, kubernetes.md
             │   └── modules/            # cross-cutting (preflight, dns, tls, smtp, inbound, tunnels)
             └── scripts/
 ```

--- a/README.md
+++ b/README.md
@@ -19,12 +19,18 @@ Supported **where**:
 |---|---|
 | **AWS Lightsail** | OpenClaw blueprint (Bedrock pre-wired) · Ubuntu + Docker · Ubuntu + native · Ghost Bitnami blueprint |
 | **AWS EC2** | Ubuntu / Amazon Linux + Docker · + native |
+| **Azure VM** (Bastion-hardened, no public IP) | Ubuntu + Docker · + native |
 | **Hetzner Cloud** | CX-line VM + Docker · + native |
 | **DigitalOcean** | Droplet + Docker · + native |
 | **GCP Compute Engine** | VM + Docker · + native |
-| Any Linux VM you already have (other providers, bare metal) | Docker · native |
-| **Any Kubernetes cluster** (EKS / GKE / AKS / DOKS / k3s / Docker Desktop) | Helm chart (for projects that ship one — e.g. OpenClaw via `charts.openclaw.ai`) |
-| **Your own machine** (macOS / Linux / Windows) | Docker Desktop · native |
+| **Oracle Cloud** | Always-Free A1.Flex ARM + native (via Tailscale) |
+| **Hostinger** | Managed (1-Click) or VPS (Docker Manager via hPanel) |
+| **Raspberry Pi** | Pi 4 / Pi 5 (64-bit) + native |
+| **macOS VM** (Lume on Apple Silicon) | Sandboxed macOS + native (for iMessage via BlueBubbles) |
+| Any Linux VM you already have (other providers, bare metal) | Docker · Podman · native |
+| **Any Kubernetes cluster** (EKS / GKE / AKS / DOKS / k3s / kind / Docker Desktop) | Kustomize manifests (or community Helm charts for projects that ship them) |
+| **Fly.io** · **Render** · **Railway** · **Northflank** · **exe.dev** | PaaS one-click templates from the upstream repos |
+| **Your own machine** (macOS / Linux / Windows / WSL2) | Docker Desktop · Podman · native (`install.sh` / `install-cli.sh` / `install.ps1`) |
 
 Three-question flow: what to host, where to host, how to host. Claude asks only what's genuinely ambiguous — if your prompt already names a clear cloud, the first question is skipped.
 
@@ -65,7 +71,7 @@ open-forge/
             ├── references/
             │   ├── projects/           # per-project recipes (ghost.md, openclaw.md, ...)
             │   ├── infra/              # per-infra adapters (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
-            │   ├── runtimes/           # docker.md, native.md, kubernetes.md
+            │   ├── runtimes/           # docker.md, podman.md, native.md, kubernetes.md
             │   └── modules/            # cross-cutting (preflight, dns, tls, smtp, inbound, tunnels)
             └── scripts/
 ```

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-forge",
-  "version": "0.7.0",
-  "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, or your own laptop. Chat-friendly interface to existing tools (aws, hcloud, doctl, gcloud, kubectl, helm, docker, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw. Supported where: AWS (Lightsail + EC2), Hetzner Cloud, DigitalOcean, GCP Compute Engine, any Linux VPS (BYO), any Kubernetes cluster, and localhost. OpenClaw is supported on every upstream-blessed path: Lightsail blueprint, Docker Compose, native installer, and the official Helm chart at charts.openclaw.ai.",
+  "version": "0.8.0",
+  "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, podman, docker, lume, tailscale, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw. For OpenClaw, every upstream-blessed install path documented at docs.openclaw.ai/install/* is covered: Lightsail blueprint, Docker, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2, Azure, Hetzner, DigitalOcean, GCP, Oracle Cloud, Hostinger, Raspberry Pi, macOS-VM (Lume), BYO Linux server, localhost, Fly.io, Render, Railway, Northflank, exe.dev.",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",
   "license": "MIT"

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-forge",
-  "version": "0.6.0",
-  "description": "Self-host open-source apps on your own cloud, your own VPS, or your own laptop. Chat-friendly interface to existing tools (aws, hcloud, doctl, gcloud, docker, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw. Supported where: AWS (Lightsail + EC2), Hetzner Cloud, DigitalOcean, GCP Compute Engine, any Linux VPS (BYO), and localhost.",
+  "version": "0.7.0",
+  "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, or your own laptop. Chat-friendly interface to existing tools (aws, hcloud, doctl, gcloud, kubectl, helm, docker, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw. Supported where: AWS (Lightsail + EC2), Hetzner Cloud, DigitalOcean, GCP Compute Engine, any Linux VPS (BYO), any Kubernetes cluster, and localhost. OpenClaw is supported on every upstream-blessed path: Lightsail blueprint, Docker Compose, native installer, and the official Helm chart at charts.openclaw.ai.",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",
   "license": "MIT"

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-forge
-description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Hetzner / DigitalOcean / GCP", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw on AWS Lightsail (openclaw_ls_1_0 blueprint), AWS EC2, Hetzner Cloud, DigitalOcean, GCP Compute Engine, BYO VPS, and localhost. More projects and infras added under `references/projects/` and `references/infra/`.
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Hetzner / DigitalOcean / GCP / Kubernetes", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path — AWS Lightsail blueprint, Docker Compose on any infra (Lightsail, EC2, Hetzner, DigitalOcean, GCP, BYO VPS, localhost), native installer on Linux/macOS, and Kubernetes via the official Helm chart on any cluster (managed EKS/GKE/AKS/DOKS or self-hosted k3s). More projects and infras added under `references/projects/` and `references/infra/`.
 ---
 
 # open-forge
@@ -49,6 +49,7 @@ Supported **runtimes** (under `references/runtimes/`):
 |---|---|
 | Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
 | Native | `native.md` — OS prereqs, systemd / launchd lifecycle, reverse-proxy guidance. Reusable across every infra. |
+| Kubernetes | `kubernetes.md` — kubectl + Helm orchestration. For projects that ship an upstream-blessed chart (e.g. OpenClaw at `charts.openclaw.ai`). open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
 | Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
 
 ## Selection — ask three questions

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-forge
-description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Hetzner / DigitalOcean / GCP / Kubernetes", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path — AWS Lightsail blueprint, Docker Compose on any infra (Lightsail, EC2, Hetzner, DigitalOcean, GCP, BYO VPS, localhost), native installer on Linux/macOS, and Kubernetes via the official Helm chart on any cluster (managed EKS/GKE/AKS/DOKS or self-hosted k3s). More projects and infras added under `references/projects/` and `references/infra/`.
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / Kubernetes / Fly.io / Render / Railway / Northflank / exe.dev", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path documented at docs.openclaw.ai/install/* — AWS Lightsail blueprint, Docker Compose, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / macOS-VM (Lume) / BYO Linux server / localhost / Fly.io / Render / Railway / Northflank / exe.dev. More projects and infras added under `references/projects/` and `references/infra/`.
 ---
 
 # open-forge
@@ -34,22 +34,33 @@ Supported **software**:
 
 Supported **infras** (under `references/infra/`):
 
-| Cloud | Services |
+| Cloud / where | Adapter |
 |---|---|
-| AWS | `aws/lightsail.md` (Ghost Bitnami blueprint + OpenClaw blueprint), `aws/ec2.md` (general-purpose VM with security group + EIP) |
-| Hetzner Cloud | `hetzner/cloud-cx.md` — CX-line VPS via `hcloud` CLI |
-| DigitalOcean | `digitalocean/droplet.md` — Droplet via `doctl` CLI |
-| GCP | `gcp/compute-engine.md` — Compute Engine VM via `gcloud` CLI |
-| Any Linux VM you already have | `byo-vps.md` — SSH in, no cloud APIs |
-| Your own machine | `localhost.md` — Claude runs commands directly, no SSH |
+| AWS | `aws/lightsail.md` (Ghost Bitnami + OpenClaw blueprints), `aws/ec2.md` (general-purpose VM) |
+| Azure | `azure/vm.md` (Bastion-hardened, no public IP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` (CX-line VPS via `hcloud`) |
+| DigitalOcean | `digitalocean/droplet.md` (Droplet via `doctl`) |
+| GCP Compute Engine | `gcp/compute-engine.md` (VM via `gcloud`) |
+| Oracle Cloud | `oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
+| Hostinger | `hostinger.md` (managed via hPanel — no CLI) |
+| Raspberry Pi | `raspberry-pi.md` (Pi 4/5 64-bit, ARM64) |
+| macOS VM (Apple Silicon) | `macos-vm.md` (Lume; for iMessage via BlueBubbles) |
+| Any Linux VM (other providers, on-prem) | `byo-vps.md` (SSH-only, no cloud APIs) |
+| Your own machine | `localhost.md` (Claude runs commands directly) |
+| Fly.io | `paas/fly.md` (`fly.toml` + persistent volume; public or private mode) |
+| Render | `paas/render.md` (`render.yaml` Blueprint, one-click) |
+| Railway | `paas/railway.md` (one-click template) |
+| Northflank | `paas/northflank.md` (one-click stack) |
+| exe.dev | `paas/exe-dev.md` (Shelley agent or manual nginx) |
 
 Supported **runtimes** (under `references/runtimes/`):
 
 | Runtime | Notes |
 |---|---|
 | Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
-| Native | `native.md` — OS prereqs, systemd / launchd lifecycle, reverse-proxy guidance. Reusable across every infra. |
-| Kubernetes | `kubernetes.md` — kubectl + Helm orchestration. For projects that ship an upstream-blessed chart (e.g. OpenClaw at `charts.openclaw.ai`). open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
+| Podman | `podman.md` — rootless Docker-compatible alternative; Quadlet (systemd-user) supported. Reusable across every Linux/macOS infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd / Scheduled-Tasks lifecycle, reverse-proxy guidance. Covers `install.sh` (macOS / Linux / WSL2), `install-cli.sh` (local-prefix, no root), and `install.ps1` (native Windows). |
+| Kubernetes | `kubernetes.md` — kubectl + Kustomize (preferred, what openclaw upstream uses) and Helm orchestration. open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
 | Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
 
 ## Selection — ask three questions

--- a/plugins/open-forge/skills/open-forge/references/infra/azure/vm.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/azure/vm.md
@@ -1,0 +1,260 @@
+---
+name: azure-vm-infra
+description: Microsoft Azure Linux VM infra adapter — provision an Ubuntu VM with no public IP, NSG-hardened to allow SSH only via Azure Bastion, then install via SSH. Pair with `runtimes/native.md` or `runtimes/docker.md` for the application install. Picked when the user already has an Azure subscription, wants enterprise-grade SSH gating (Bastion), or is using GitHub Copilot as the model provider.
+---
+
+# Azure VM (Bastion-hardened) adapter
+
+Provisions an Ubuntu 24.04 LTS VM in Azure with **no public IP** — SSH access goes exclusively through **Azure Bastion**, a managed jumpbox. NSG rules allow SSH only from the Bastion subnet; everything else is denied. Mirrors openclaw upstream's `docs/install/azure.md` recipe.
+
+Worth picking when:
+- The user already has an Azure subscription with billing.
+- Enterprise security policy requires no public-IP VMs.
+- The user has GitHub Copilot licenses and wants to use Copilot as the model provider (most enterprise Azure teams do; openclaw upstream highlights this).
+
+## Prerequisites
+
+Check during preflight; stop and install/configure if missing:
+
+- `az` CLI (`az --version`)
+- `az` SSH extension (`az extension add -n ssh`) — required for Bastion native SSH tunneling
+- An Azure subscription where the user can create compute + network resources
+- Microsoft.Compute and Microsoft.Network resource providers registered
+
+### Install + auth
+
+```bash
+# macOS
+brew install azure-cli
+
+# Linux — Microsoft's apt repo
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+az --version
+
+# Auth
+az login                                     # opens browser
+az extension add -n ssh                      # for `az network bastion ssh`
+az account show                              # confirm subscription
+```
+
+For multi-subscription accounts: `az account list -o table`, then `az account set --subscription <id-or-name>`.
+
+### One-time provider registration
+
+```bash
+az provider register --namespace Microsoft.Compute
+az provider register --namespace Microsoft.Network
+
+# Wait for both to show "Registered" — usually < 1 min:
+az provider show --namespace Microsoft.Compute --query registrationState -o tsv
+az provider show --namespace Microsoft.Network --query registrationState -o tsv
+```
+
+## Inputs to collect
+
+Cross-cutting preflight collects deployment name. The Azure adapter additionally needs:
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Azure subscription?" | `AskUserQuestion`: list from `az account list -o tsv --query '[].{name:name,id:id}'` | Active default |
+| End of preflight | "Region (location)?" | `AskUserQuestion`: `westus2` / `eastus` / `westeurope` / `northeurope` / `southeastasia` / `Other` | Geographic-closest |
+| End of preflight | "VM size?" | `AskUserQuestion`, options from the table below | Project-recipe-suggested |
+| End of preflight | "OS disk size (GB)?" | `AskUserQuestion`: `30` / `64` / `128` / `Other` | `64` |
+| End of preflight | "SSH public key path?" | Free-text; default `~/.ssh/id_ed25519.pub`. If missing, offer `ssh-keygen -t ed25519 -a 100 -f ~/.ssh/id_ed25519` | `~/.ssh/id_ed25519.pub` |
+
+Derived (no prompt):
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.resource_group` | `rg-<deployment-name>` |
+| `outputs.vnet_name` | `vnet-<deployment-name>` |
+| `outputs.vm_subnet_name` | `snet-<deployment-name>-vm` |
+| `outputs.bastion_subnet_name` | `AzureBastionSubnet` (name is **required** by Azure) |
+| `outputs.nsg_name` | `nsg-<deployment-name>-vm` |
+| `outputs.vm_name` | `vm-<deployment-name>` |
+| `outputs.bastion_name` | `bas-<deployment-name>` |
+| `outputs.bastion_pip_name` | `pip-<deployment-name>-bastion` |
+| `outputs.admin_username` | `<deployment-name>` (or `azureuser`) |
+
+### Common VM-size options
+
+| Size | vCPU | RAM | Approx $/mo (us-west2, on-demand) | When |
+|---|---|---|---|---|
+| `Standard_B2as_v2` | 2 (burstable AMD) | 8 GB | $55 | OpenClaw, Ghost, anything Node — recommended default |
+| `Standard_B2s_v2` | 2 (burstable Intel) | 8 GB | $50 | Same workloads, Intel |
+| `Standard_D2as_v5` | 2 (dedicated AMD) | 8 GB | $90 | Steady-state CPU loads |
+| `Standard_B4as_v2` | 4 (burstable AMD) | 16 GB | $110 | Heavier workloads |
+| `Standard_D2pls_v5` | 2 (Ampere ARM) | 4 GB | $65 | ARM workloads (cheaper if upstream ships ARM) |
+
+List what's available: `az vm list-skus --location "$LOCATION" --resource-type virtualMachines -o table`.
+
+## Provisioning
+
+Run sequentially. Announce each command in one sentence before running.
+
+### 1. Resource group
+
+```bash
+RG="rg-${DEPLOYMENT_NAME}"
+LOCATION="$AZ_REGION"
+az group create -n "$RG" -l "$LOCATION"
+```
+
+### 2. Network + NSG (hardened ingress)
+
+CIDR ranges below are placeholders — adjust if they collide with the user's existing VNets.
+
+```bash
+VNET_NAME="vnet-${DEPLOYMENT_NAME}"
+VM_SUBNET_NAME="snet-${DEPLOYMENT_NAME}-vm"
+NSG_NAME="nsg-${DEPLOYMENT_NAME}-vm"
+
+VNET_PREFIX="10.40.0.0/16"
+VM_SUBNET_PREFIX="10.40.2.0/24"
+BASTION_SUBNET_PREFIX="10.40.1.0/26"        # /26 minimum, required by Azure Bastion
+
+# NSG with three rules: allow SSH from Bastion subnet only, deny SSH from everywhere else
+az network nsg create -g "$RG" -n "$NSG_NAME" -l "$LOCATION"
+
+az network nsg rule create -g "$RG" --nsg-name "$NSG_NAME" \
+  -n AllowSshFromBastionSubnet --priority 100 \
+  --access Allow --direction Inbound --protocol Tcp \
+  --source-address-prefixes "$BASTION_SUBNET_PREFIX" \
+  --destination-port-ranges 22
+
+az network nsg rule create -g "$RG" --nsg-name "$NSG_NAME" \
+  -n DenyInternetSsh --priority 110 \
+  --access Deny --direction Inbound --protocol Tcp \
+  --source-address-prefixes Internet \
+  --destination-port-ranges 22
+
+az network nsg rule create -g "$RG" --nsg-name "$NSG_NAME" \
+  -n DenyVnetSsh --priority 120 \
+  --access Deny --direction Inbound --protocol Tcp \
+  --source-address-prefixes VirtualNetwork \
+  --destination-port-ranges 22
+
+# VNet + VM subnet (NSG attached) + Bastion subnet
+az network vnet create \
+  -g "$RG" -n "$VNET_NAME" -l "$LOCATION" \
+  --address-prefixes "$VNET_PREFIX" \
+  --subnet-name "$VM_SUBNET_NAME" \
+  --subnet-prefixes "$VM_SUBNET_PREFIX"
+
+az network vnet subnet update \
+  -g "$RG" --vnet-name "$VNET_NAME" -n "$VM_SUBNET_NAME" --nsg "$NSG_NAME"
+
+az network vnet subnet create \
+  -g "$RG" --vnet-name "$VNET_NAME" \
+  -n AzureBastionSubnet \
+  --address-prefixes "$BASTION_SUBNET_PREFIX"
+```
+
+### 3. Create the VM (no public IP, no per-NIC NSG)
+
+```bash
+VM_NAME="vm-${DEPLOYMENT_NAME}"
+ADMIN_USERNAME="${DEPLOYMENT_NAME//[^a-zA-Z0-9]/}"     # alphanumeric only
+SSH_PUB_KEY="$(cat "$SSH_PUB_KEY_PATH")"
+
+az vm create \
+  -g "$RG" -n "$VM_NAME" -l "$LOCATION" \
+  --image "Canonical:ubuntu-24_04-lts:server:latest" \
+  --size "$VM_SIZE" \
+  --os-disk-size-gb "$OS_DISK_GB" \
+  --storage-sku StandardSSD_LRS \
+  --admin-username "$ADMIN_USERNAME" \
+  --ssh-key-values "$SSH_PUB_KEY" \
+  --vnet-name "$VNET_NAME" --subnet "$VM_SUBNET_NAME" \
+  --public-ip-address "" \
+  --nsg ""
+```
+
+`--public-ip-address ""` blocks public-IP allocation; `--nsg ""` skips a per-NIC NSG (the subnet-level NSG handles security).
+
+For reproducibility, replace `latest` with a pinned image version: `az vm image list --publisher Canonical --offer ubuntu-24_04-lts --sku server --all -o table`.
+
+### 4. Provision Azure Bastion (Standard SKU + tunneling)
+
+```bash
+BASTION_NAME="bas-${DEPLOYMENT_NAME}"
+BASTION_PIP_NAME="pip-${DEPLOYMENT_NAME}-bastion"
+
+az network public-ip create \
+  -g "$RG" -n "$BASTION_PIP_NAME" -l "$LOCATION" \
+  --sku Standard --allocation-method Static
+
+az network bastion create \
+  -g "$RG" -n "$BASTION_NAME" -l "$LOCATION" \
+  --vnet-name "$VNET_NAME" \
+  --public-ip-address "$BASTION_PIP_NAME" \
+  --sku Standard --enable-tunneling true
+```
+
+Provisioning typically takes 5–10 min, occasionally 15–30 min in some regions. Don't skip the Standard SKU — Basic doesn't support `az network bastion ssh` (CLI tunneling).
+
+## SSH convention (via Bastion only)
+
+```bash
+VM_ID="$(az vm show -g "$RG" -n "$VM_NAME" --query id -o tsv)"
+
+az network bastion ssh \
+  --name "$BASTION_NAME" --resource-group "$RG" \
+  --target-resource-id "$VM_ID" \
+  --auth-type ssh-key \
+  --username "$ADMIN_USERNAME" \
+  --ssh-key "${SSH_PUB_KEY_PATH%.pub}"
+```
+
+Plain `ssh user@<ip>` will not work — there's no public IP. All shell access flows through Bastion.
+
+For commands that runtime/project recipes want to drive non-interactively, wrap in:
+
+```bash
+az network bastion ssh ... --command 'bash -lc "openclaw gateway status"'
+```
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `az vm get-instance-view -g "$RG" -n "$VM_NAME" --query 'instanceView.statuses[?starts_with(code, `PowerState/`)].displayStatus' -o tsv` returns `VM running`.
+- `az network bastion ssh ... --command 'echo ok'` prints `ok`.
+
+## Cost considerations
+
+Azure Bastion **Standard SKU** is the largest cost (~$140/month). To reduce:
+
+- **Deallocate the VM** when not actively running OpenClaw: `az vm deallocate -g "$RG" -n "$VM_NAME"` (compute stops billing; disk continues). Restart later: `az vm start`.
+- **Delete and recreate Bastion** as needed. Recreation takes a few minutes; saves $140/month if SSH access is rare.
+- **Use Basic Bastion SKU** (~$38/month) if you only need browser-portal SSH. CLI tunneling (`az network bastion ssh`) is **not** supported on Basic.
+
+VM size `Standard_B2as_v2` is ~$55/month on-demand. Reserved 1-year/3-year instances cut that by 30–60%.
+
+## Teardown
+
+Don't auto-run; confirm with the user.
+
+```bash
+az group delete -n "$RG" --yes --no-wait
+```
+
+Deletes the resource group and everything inside it (VM, VNet, NSG, Bastion, public IPs, disks). `--no-wait` returns immediately; full deletion takes 5–15 min.
+
+## Gotchas
+
+- **Bastion subnet name is fixed.** Must be exactly `AzureBastionSubnet` — Azure rejects any other name. CIDR must be at least `/26`.
+- **`Standard` Bastion SKU mandatory for CLI SSH.** Don't downgrade to Basic and expect `az network bastion ssh` to work.
+- **`az vm create --public-ip-address ""` is the no-IP flag.** Older docs recommended `--public-ip-sku ""`, but the empty-string `--public-ip-address ""` is what the current az CLI honors. Verify post-create: `az vm show --query 'networkProfile.networkInterfaces[0].id' -o tsv` then check the NIC has no public IP attached.
+- **NSG priorities matter.** Allow rules must have lower priority numbers than deny rules. The 100 / 110 / 120 layout above is correct; reordering breaks SSH.
+- **Subscription quota.** New subscriptions often have low vCPU quotas in popular regions. `az vm list-usage --location "$LOCATION" -o table` shows current usage; request increases via the Azure Portal.
+- **`az ssh` extension drift.** `az extension update -n ssh` periodically; older versions miss `--auth-type ssh-key` for Bastion.
+- **Disk encryption** is on by default for OS disk (Azure-managed key). Customer-managed keys require additional setup not covered here.
+- **Provider registration is per-subscription, not per-region.** Once registered, `Microsoft.Compute` and `Microsoft.Network` are registered everywhere in that subscription.
+
+## Reference
+
+- Azure CLI install: <https://learn.microsoft.com/cli/azure/install-azure-cli>
+- Bastion docs: <https://learn.microsoft.com/azure/bastion/>
+- Ubuntu images on Azure: <https://documentation.ubuntu.com/azure/explanation/intro/>
+- OpenClaw on Azure (upstream): <https://docs.openclaw.ai/install/azure>

--- a/plugins/open-forge/skills/open-forge/references/infra/hostinger.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/hostinger.md
@@ -1,0 +1,116 @@
+---
+name: hostinger-infra
+description: Hostinger managed hosting + VPS infra adapter — fully Console-driven (hPanel). Two modes: 1-Click OpenClaw (Hostinger handles infrastructure + Docker + auto-updates) and OpenClaw on VPS (Hostinger deploys via Docker; you manage through hPanel's Docker Manager). Picked when the user wants the lowest-friction managed path with optional pre-purchased "Ready-to-Use AI" credits.
+---
+
+# Hostinger adapter
+
+Hostinger ships an OpenClaw-specific managed offering at <https://www.hostinger.com/openclaw>. Two modes, both Console-driven via hPanel:
+
+| Mode | What you get | When to pick |
+|---|---|---|
+| **1-Click OpenClaw** | Fully managed; Hostinger runs OpenClaw, handles Docker + updates | Lowest-friction path; user just wants chat working |
+| **OpenClaw on VPS** | A Hostinger VPS with OpenClaw deployed via Docker; manage from hPanel's **Docker Manager** | Want server-level control without leaving Hostinger's UI |
+
+Optional **"Ready-to-Use AI" credits** at checkout pre-purchase model-provider access — no Anthropic/OpenAI/Gemini account needed. Or bring your own keys during setup.
+
+This adapter is unusual: open-forge does **not** drive provisioning here. Hostinger's flow is browser-only at <https://www.hostinger.com/openclaw>. open-forge's role is to:
+
+1. Walk the user to the right Hostinger page based on their mode preference.
+2. Confirm post-deploy that the dashboard loads and chat is wired up.
+3. Document the differences from a typical SSH-driven VPS.
+
+## Prerequisites
+
+- Hostinger account ([signup](https://www.hostinger.com/openclaw)).
+- Browser only.
+- (Optional) BYO model-provider API key, or use Ready-to-Use AI credits at checkout.
+- A messaging channel choice (WhatsApp number, or Telegram bot token from BotFather).
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Mode?" | `AskUserQuestion`: `1-Click OpenClaw (managed)` / `OpenClaw on VPS (Docker Manager)` | 1-Click |
+| End of preflight | "Use Ready-to-Use AI credits, or bring your own API key?" | `AskUserQuestion`: `Ready-to-Use AI` / `BYO key (Anthropic / OpenAI / Gemini / xAI)` | Ready-to-Use AI |
+| End of preflight | "Messaging channel?" | `AskUserQuestion`: `WhatsApp (scan QR in setup)` / `Telegram (bot token)` / `Both` / `Skip — set up later` | WhatsApp |
+| At setup phase (BYO key) | "API key?" | Free-text (sensitive) | — |
+| At setup phase (Telegram) | "Bot token from BotFather?" | Free-text (sensitive) | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.dashboard_url` | Provided by hPanel after deployment (typically `https://<assigned-host>/...`) |
+| `outputs.gateway_token` | Auto-generated; visible in hPanel |
+| `outputs.mode` | `1-click` or `vps` |
+
+## Provisioning (browser-driven)
+
+### Mode A — 1-Click OpenClaw
+
+1. Walk the user to <https://www.hostinger.com/openclaw> → choose a **Managed OpenClaw** plan → checkout.
+2. At checkout, opt in to **Ready-to-Use AI** credits (or skip to bring your own keys later).
+3. After checkout, **Setup wizard** prompts:
+   - Pick channel: WhatsApp (scan QR) or Telegram (paste bot token).
+4. Click **Finish**. Hostinger deploys.
+5. Once ready: **hPanel → OpenClaw Overview → Open**. The dashboard URL loads with auth pre-wired.
+
+### Mode B — OpenClaw on VPS
+
+1. Walk the user to <https://www.hostinger.com/openclaw> → choose **OpenClaw on VPS** → checkout.
+2. (Optional) Ready-to-Use AI credits at checkout.
+3. After provisioning, **hPanel** prompts for:
+   - **Gateway token** — auto-generated; copy and save.
+   - **WhatsApp number** (with country code) — optional.
+   - **Telegram bot token** — optional.
+   - **API keys** — only if you didn't pick Ready-to-Use AI.
+4. Click **Deploy**. Hostinger's Docker Manager pulls the image and starts the container.
+5. Once running: **hPanel → click Open** for dashboard access.
+
+## Verification
+
+The user opens the dashboard from hPanel. To confirm chat is working, send "Hi" to the connected WhatsApp/Telegram channel. OpenClaw replies and walks through initial preferences.
+
+## Day-to-day operations (Mode B specifically)
+
+All in hPanel's **Docker Manager**:
+
+| Action | Where |
+|---|---|
+| Logs | Docker Manager → service → **Logs** |
+| Restart | Docker Manager → service → **Restart** |
+| Update | Docker Manager → service → **Update** (pulls latest image) |
+| Env-var changes | Docker Manager → service → **Edit** |
+
+Mode A (1-Click) is fully managed — Hostinger handles updates without user action. There's no Docker Manager view; just **OpenClaw Overview**.
+
+## SSH access?
+
+Mode A: typically not. The managed path is browser-only.
+
+Mode B: SSH **is** available on the VPS — Hostinger provides credentials in hPanel after provisioning. Once SSH'd in, this becomes a regular Linux Server / BYO VPS deployment (`infra/byo-vps.md`) on the back end. open-forge can drive the host directly from there if the user wants more advanced configuration than Docker Manager exposes.
+
+## Updates
+
+| Mode | Update path |
+|---|---|
+| 1-Click | Automatic — Hostinger pushes updates |
+| VPS | hPanel → Docker Manager → **Update** (manual) |
+
+## Teardown
+
+Cancel the plan in **hPanel → Subscriptions** (or specific service settings). Hostinger handles resource cleanup.
+
+## Gotchas
+
+- **Browser-only flow.** Unlike every other adapter in open-forge, Hostinger's setup is genuinely click-driven at <https://www.hostinger.com/openclaw>. open-forge can't automate the click steps; we read them aloud and verify the result.
+- **Ready-to-Use AI credits are pre-purchased.** They expire / get consumed; no key rotation is needed but billing is per-token. Surface the cost model so the user isn't surprised when credits run out.
+- **Telegram bot pairing flow has an extra step.** After deploy, Hostinger's docs say to send the pairing code message *from Telegram directly as a message inside your OpenClaw chat* — easy to miss.
+- **Mode A doesn't expose `openclaw devices approve`.** Hostinger's managed wrapper handles pairing automatically. Don't try to `kubectl exec`-style approve manually — it's not exposed.
+- **Mode B is fundamentally a Hostinger VPS running Docker.** If hPanel becomes limiting, SSH into the VPS and use it as a regular Docker host (`runtimes/docker.md`).
+
+## Reference
+
+- Hostinger OpenClaw page: <https://www.hostinger.com/openclaw>
+- OpenClaw on Hostinger (upstream): <https://docs.openclaw.ai/install/hostinger>

--- a/plugins/open-forge/skills/open-forge/references/infra/macos-vm.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/macos-vm.md
@@ -1,0 +1,158 @@
+---
+name: macos-vm-infra
+description: Apple Silicon macOS VM infra adapter — provision a sandboxed macOS VM on the user's M-series Mac via Lume, then install via SSH. Pair with `runtimes/native.md` for the application install. Picked when the user specifically needs macOS-only capabilities (iMessage via BlueBubbles), strict isolation from their daily Mac, or instant-reset golden images. Cloud Mac providers (MacStadium etc.) follow the same SSH-in flow once provisioned.
+---
+
+# macOS VM (Lume on Apple Silicon) adapter
+
+Run a sandboxed macOS guest on the user's existing M-series Mac via [Lume](https://cua.ai/docs/lume). Useful when the project genuinely needs macOS — typically iMessage integration via BlueBubbles, which is impossible on Linux/Windows.
+
+For most users a Linux VPS is simpler and cheaper. This adapter is for the specific case where macOS-only capabilities are required, or where the user wants instant-reset isolation from their daily Mac.
+
+## Prerequisites
+
+- Apple Silicon Mac (M1/M2/M3/M4) — Intel Macs aren't supported by Lume.
+- macOS Sequoia or later on the host.
+- ~60 GB free disk space per VM (more if you snapshot golden images).
+- ~20 minutes for first-time setup (downloads macOS into the VM image).
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "macOS VM name?" | Free-text | Deployment name |
+| End of preflight | "VM disk size (GB)?" | `AskUserQuestion`: `60` / `100` / `150` | `60` |
+| End of preflight | "macOS version?" | `AskUserQuestion`: `latest` / `Specific IPSW URL` | `latest` |
+| End of preflight | "Will you use BlueBubbles for iMessage?" | `AskUserQuestion`: `Yes` / `No` | — |
+| End of preflight | "VM user account name?" (created via Setup Assistant) | Free-text | `<deployment-name>` |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.vm_name` | Deployment name |
+| `outputs.vm_ip` | `lume get <vm-name>` output (typically `192.168.64.x`) |
+| `outputs.host_user` | The user-account name created during Setup Assistant |
+
+## Install Lume on the host Mac
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/trycua/cua/main/libs/lume/scripts/install.sh)"
+
+# If ~/.local/bin isn't on PATH already:
+echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.zshrc && source ~/.zshrc
+
+lume --version
+```
+
+## Create the VM
+
+```bash
+lume create "$VM_NAME" --os macos --ipsw latest --disk-size "${DISK_GB}G"
+```
+
+A VNC window opens automatically once the IPSW download completes (downloads can take 20+ min on slow connections).
+
+## Setup Assistant (manual — VNC window)
+
+This is the one phase open-forge can't automate; the macOS Setup Assistant needs human input. Walk the user through:
+
+1. Select language / region.
+2. **Skip** Apple ID — unless they want iMessage later, in which case sign in (the VM's Apple ID is what BlueBubbles will route through).
+3. Create a user account with the username and password they entered as inputs.
+4. Skip all optional features (Siri, analytics, screen time, etc.).
+5. Once at the desktop: **System Settings → General → Sharing → enable Remote Login**. This turns on SSH inside the VM.
+
+## Connect
+
+```bash
+lume get "$VM_NAME"
+# → look for the IP (usually 192.168.64.x). Save as VM_IP.
+
+# Set up SSH config for convenience (host alias)
+cat >> ~/.ssh/config <<EOF
+
+Host $VM_NAME
+  HostName $VM_IP
+  User $HOST_USER
+EOF
+
+# Test
+ssh "$VM_NAME" 'sw_vers'
+```
+
+The first SSH connection asks the user to accept the host key — `-o StrictHostKeyChecking=accept-new` if you want it non-interactive.
+
+## Run headless
+
+After Setup Assistant completes, swap to no-display mode:
+
+```bash
+lume stop "$VM_NAME"
+lume run "$VM_NAME" --no-display
+```
+
+The VM continues running in the background. The host Mac must stay awake (System Settings → Energy Saver → keep the Mac from sleeping; consider `caffeinate` if running on battery is unavoidable).
+
+## Save a golden image (recommended before any customization)
+
+```bash
+lume stop "$VM_NAME"
+lume clone "$VM_NAME" "${VM_NAME}-golden"
+lume run "$VM_NAME" --no-display
+```
+
+To reset to clean state later:
+
+```bash
+lume stop "$VM_NAME" && lume delete "$VM_NAME"
+lume clone "${VM_NAME}-golden" "$VM_NAME"
+lume run "$VM_NAME" --no-display
+```
+
+## SSH convention
+
+```bash
+ssh "$VM_NAME"          # via the ~/.ssh/config alias above
+# or:
+ssh "$HOST_USER@$VM_IP"
+```
+
+For one-shot remote commands the runtime / project recipes drive: `ssh "$VM_NAME" 'bash -lc "<command>"'`.
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `lume list` shows the VM as `running`.
+- `ssh "$VM_NAME" 'echo ok'` prints `ok`.
+- `ssh "$VM_NAME" 'sw_vers -productVersion'` returns the macOS version.
+
+## Teardown
+
+```bash
+lume stop "$VM_NAME"
+lume delete "$VM_NAME"
+# Optionally also:
+lume delete "${VM_NAME}-golden"
+```
+
+Disk space reclaimed immediately.
+
+## Gotchas
+
+- **Apple Silicon only.** Lume uses Apple's Virtualization framework which requires M-series silicon. Intel Macs need different tooling (UTM, Parallels) — out of scope here.
+- **Setup Assistant is unavoidable.** First-time VM creation requires ~5 minutes of human VNC interaction. Plan for it.
+- **Headless host Macs need to stay awake.** macOS will sleep aggressively on default power settings. Disable sleep in Energy Saver, or run `caffeinate -di &` in a separate Terminal session.
+- **Lume's VNC doesn't enable SSH automatically.** The user MUST enable Remote Login in the VM's System Settings before any `ssh` will work.
+- **WhatsApp / Telegram QR pairing must be done from inside the VM.** Run `openclaw channels login` over SSH to the VM, scan the QR with your phone — not from the host Mac.
+- **Cloud Mac providers (MacStadium, etc.) are an alternative.** Once you have SSH access to a hosted Mac, the install flow is the same — skip the Lume sections and start at *Initial host setup*.
+- **iMessage requires Apple ID sign-in.** If the user skipped Apple ID during Setup Assistant, BlueBubbles won't have iMessage to relay. Sign in via Settings → Apple Account before installing BlueBubbles.
+- **VM disk grows but doesn't auto-shrink.** A 60 GB VM that's run for months may show 50+ GB used even after `rm`. To compact: `lume stop`, then on the host `qemu-img convert` the disk image — fiddly; usually easier to clone fresh from the golden image.
+
+## Reference
+
+- Lume install: <https://cua.ai/docs/lume/guide/getting-started/installation>
+- Lume CLI: <https://cua.ai/docs/lume/reference/cli-reference>
+- BlueBubbles: <https://bluebubbles.app>
+- OpenClaw on macOS VM (upstream): <https://docs.openclaw.ai/install/macos-vm>

--- a/plugins/open-forge/skills/open-forge/references/infra/oracle/free-tier-arm.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/oracle/free-tier-arm.md
@@ -1,0 +1,144 @@
+---
+name: oracle-free-tier-arm-infra
+description: Oracle Cloud Infrastructure (OCI) Always-Free ARM (Ampere A1.Flex) infra adapter — provision an aarch64 Ubuntu VM at zero cost (up to 4 OCPU / 24 GB RAM / 200 GB storage), reach it via Tailscale instead of public ingress. Pair with `runtimes/native.md` for the application install. Picked when budget is the priority and the user is OK with OCI's manual capacity-pool dance and Tailscale for SSH.
+---
+
+# Oracle Cloud Free-Tier ARM (A1.Flex) adapter
+
+OCI's **Always Free** tier includes up to 4 OCPU / 24 GB RAM of Ampere ARM (A1.Flex) compute and 200 GB of storage. Genuinely free, indefinitely — but capacity is contended and creation can fail with "Out of capacity" until you find an availability domain that has space. Compensates with the best price/perf in the market once you're in.
+
+Unlike the AWS / Hetzner / DO / GCP adapters, this one **does not** automate the OCI VM provisioning via CLI — OCI's CLI flow is significantly more involved (compartments, image OCIDs, capacity reservations) and the Console-driven flow is the one openclaw upstream documents and the user is most likely to succeed with. open-forge's role here is:
+
+1. Tell the user exactly which Console buttons to click.
+2. Take over via SSH once the VM exists, via Tailscale.
+3. Lock down the VCN security list to Tailscale-only.
+
+## Prerequisites
+
+- An Oracle Cloud account ([signup](https://www.oracle.com/cloud/free/)). The signup itself can be tricky — keep [community guide](https://gist.github.com/rssnyder/51e3cfedd730e7dd5f4a816143b25dbd) handy.
+- A Tailscale account (free tier works) with the `tailscale` CLI installed locally.
+- An SSH public key.
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Do you already have an OCI free-tier instance?" | `AskUserQuestion`: `Yes — give me its public IP` / `No — walk me through Console creation` | — |
+| End of preflight (if No) | (instructions only — no prompt) | Walk through Console steps below | — |
+| End of preflight | "VM public IP?" | Free-text | Read from Console after creation |
+| End of preflight | "OCPU count (1–4)?" | `AskUserQuestion`: `2` / `4` | `2` |
+| End of preflight | "Memory (GB) — between 1 and 24, ≤ 6× OCPU count?" | Free-text or `AskUserQuestion`: `12` / `24` | `12` |
+| End of preflight | "SSH public key path?" | Free-text; default `~/.ssh/id_ed25519.pub` | `~/.ssh/id_ed25519.pub` |
+| End of preflight | "Tailscale auth — already signed in locally?" | `AskUserQuestion`: `Yes` / `No, walk me through it` | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.instance_name` | Deployment name (typed into Console) |
+| `outputs.shape` | `VM.Standard.A1.Flex` |
+| `outputs.image` | `Canonical-Ubuntu-24.04-aarch64` (latest) |
+| `outputs.public_ip` | Provided by user from Console |
+| `outputs.tailscale_hostname` | Deployment name (passed to `tailscale up --hostname=`) |
+
+## Console-driven provisioning (Claude reads aloud, user clicks)
+
+Open the [Oracle Cloud Console](https://cloud.oracle.com/) and have the user follow:
+
+1. **Compute → Instances → Create Instance.**
+2. **Name:** `<deployment-name>` (e.g. `openclaw`).
+3. **Image and shape → Edit:**
+   - Image: **Ubuntu 24.04** (`aarch64`, not the x86 variant).
+   - Shape: **VM.Standard.A1.Flex** (Ampere ARM).
+   - OCPUs: `<chosen>`. Memory (GB): `<chosen>`.
+4. **Networking:** accept defaults (the wizard creates a VCN and subnet for you the first time).
+5. **SSH key:** paste the contents of the user's public key (`cat ~/.ssh/id_ed25519.pub`).
+6. **Boot volume:** keep default size (47 GB) or bump up to 200 GB (still free).
+7. Click **Create**.
+
+If creation fails with **"Out of capacity"**:
+- Try a different **availability domain** in the same region (the dropdown right above the Image/Shape section).
+- Try a different region if your home region has no domains with capacity.
+- Retry off-peak hours.
+
+Note the assigned **public IP** once the instance reaches `Running`.
+
+## Initial host setup (over SSH)
+
+```bash
+ssh ubuntu@"$PUBLIC_IP"        # works while the VCN security list still allows public SSH
+
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y build-essential curl ca-certificates jq
+
+# Hostname for clarity
+sudo hostnamectl set-hostname "$DEPLOYMENT_NAME"
+sudo loginctl enable-linger ubuntu     # so user services survive logout (used by openclaw)
+```
+
+`build-essential` is needed for ARM compilation of native-addon Node modules.
+
+## Tailscale install + connect
+
+```bash
+# On the VM
+curl -fsSL https://tailscale.com/install.sh | sh
+sudo tailscale up --ssh --hostname="$DEPLOYMENT_NAME"
+```
+
+The `--ssh` flag enables Tailscale SSH, which means future SSH access goes through the tailnet (no public ingress needed). On the user's local machine, `tailscale ip "$DEPLOYMENT_NAME"` returns the tailnet IP; from any device in the tailnet, `ssh ubuntu@$DEPLOYMENT_NAME` works.
+
+## Lock down the VCN (Console-driven, after Tailscale is up)
+
+Once Tailscale is confirmed working from a second device, harden the VCN:
+
+1. **Networking → Virtual Cloud Networks**, click the user's VCN.
+2. **Security Lists → Default Security List** (or whatever name the wizard gave it).
+3. Under **Ingress Rules:**
+   - **Remove** the default `0.0.0.0/0 TCP 22` rule (that's the public-SSH escape hatch we no longer need).
+   - **Add:** `0.0.0.0/0 UDP 41641` — allows Tailscale's WireGuard traffic.
+4. **Egress rules:** leave the default allow-all in place.
+
+After this, public SSH (port 22 from the internet) is blocked at the VCN edge. The instance is reachable only via Tailscale.
+
+## SSH convention (after lockdown)
+
+```bash
+ssh ubuntu@"$DEPLOYMENT_NAME"   # via Tailscale magicDNS
+# or:
+ssh ubuntu@"$(tailscale ip "$DEPLOYMENT_NAME" | head -1)"
+```
+
+The original public IP is now firewalled — don't use it.
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `tailscale status` (locally) shows the instance as connected.
+- `ssh ubuntu@"$DEPLOYMENT_NAME" 'echo ok'` prints `ok`.
+- A `dig` or browser hit on `<public-ip>:22` returns no response (lockdown confirmed).
+
+## Teardown
+
+Console-driven (no CLI):
+
+1. **Compute → Instances**, click the instance, **Terminate**.
+2. Confirm. The boot volume can be preserved or deleted in the same dialog.
+
+## Gotchas
+
+- **"Out of capacity" is the dominant failure mode.** A1.Flex is the most popular free tier — Oracle rate-limits creation. Persistence wins; some users retry every hour for a day before getting in.
+- **ARM (`aarch64`) image is mandatory.** A1.Flex won't accept x86 images. Most npm packages work on ARM64; native binaries you depend on may need an `aarch64`-labeled release.
+- **Free tier can be terminated for inactivity.** OCI reclaims A1 instances that show no CPU activity for ~7 days. Keep the instance doing something (the OpenClaw gateway suffices) or expect to re-provision.
+- **Plain `tailscale up` without `--ssh`** misses the SSH-over-tailnet feature. Always use `--ssh` for openclaw deployments — pairs with the public-SSH lockdown step.
+- **Boot volume free-tier limit is per-tenancy, not per-region.** 200 GB is the total across all your free instances; allocate per VM accordingly.
+- **VCN lockdown breaks if Tailscale is down.** If the Tailscale daemon stops, you're locked out. Mitigations: enable `tailscale up --reset-on-boot=false` (default), monitor `tailscale status`, and keep a recovery path via OCI's Console "Cloud Shell" (a browser-based SSH from the Console UI).
+- **No `OCI_API_KEY` setup needed for this adapter** — we drive nothing via the OCI CLI here.
+
+## Reference
+
+- OCI Free Tier: <https://www.oracle.com/cloud/free/>
+- Tailscale install: <https://tailscale.com/kb/1031/install-linux>
+- Tailscale SSH: <https://tailscale.com/kb/1193/tailscale-ssh>
+- OpenClaw on Oracle Cloud (upstream): <https://docs.openclaw.ai/install/oracle>

--- a/plugins/open-forge/skills/open-forge/references/infra/paas/exe-dev.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/paas/exe-dev.md
@@ -1,0 +1,137 @@
+---
+name: exe-dev-paas-infra
+description: exe.dev PaaS infra adapter — provision a VM that's reachable at `https://<vm-name>.exe.xyz` via exe.dev's HTTPS proxy + email auth. Two paths: Shelley agent (one-prompt automated) or manual SSH-in setup. Picked when the user wants an integrated HTTPS proxy + auth layer without configuring a tunnel themselves.
+---
+
+# exe.dev adapter
+
+exe.dev provisions VMs accessible via `https://<vm-name>.exe.xyz`, with a built-in HTTPS proxy and email-based authentication layer in front. OpenClaw upstream documents two paths: a fully-automated "Shelley agent" prompt that does everything, or a manual SSH-driven install with nginx.
+
+## Prerequisites
+
+- exe.dev account.
+- Browser for Shelley path; SSH access to the VM for manual path.
+- API key for at least one model provider.
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Setup style?" | `AskUserQuestion`: `Shelley agent (one-prompt; recommended)` / `Manual SSH install` | Shelley |
+| End of preflight | "VM name?" (becomes `<vm-name>.exe.xyz`) | Free-text | `<deployment-name>` |
+| At secrets phase | "Shared secret for Control UI auth?" | Free-text or generated | Generated |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.vm_name` | The deployment name |
+| `outputs.public_url` | `https://<vm-name>.exe.xyz/` |
+
+## Path A — Shelley agent (recommended)
+
+The fastest path — a single agent prompt does everything.
+
+1. Walk the user to `https://exe.new/openclaw`.
+2. Sign in / supply credentials.
+3. Select **Agent** → wait for provisioning.
+4. Once provisioned, visit `https://<vm-name>.exe.xyz/` and authenticate with the shared secret Shelley printed.
+5. Approve the device pairing using the CLI command Shelley provides (typically `ssh exe.dev -t '...'`).
+
+That's it. open-forge's role here is to coordinate the user's clicks, then verify access once the URL is live.
+
+## Path B — Manual SSH install
+
+For users who want full control or are debugging Shelley issues.
+
+### 1. Create the VM
+
+```bash
+ssh exe.dev new
+# Follow prompts to name the VM; you'll get an SSH endpoint like <user>@<vm-name>.exe.dev
+```
+
+### 2. Install dependencies + OpenClaw on the VM
+
+```bash
+ssh "<user>@<vm-name>.exe.dev"
+
+sudo apt-get update
+sudo apt-get install -y git curl jq ca-certificates nginx
+
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash
+exec $SHELL -l
+openclaw onboard --install-daemon
+```
+
+### 3. Configure nginx to proxy port 18789 → exe.dev's port 8000
+
+```bash
+sudo tee /etc/nginx/sites-available/openclaw <<'EOF'
+server {
+  listen 8000;
+
+  location / {
+    proxy_pass http://127.0.0.1:18789;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400s;
+  }
+}
+EOF
+sudo ln -sf /etc/nginx/sites-available/openclaw /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+The `Upgrade` and `Connection: upgrade` headers are mandatory for the WebSocket gateway. `proxy_read_timeout 86400s` keeps long-lived connections alive — the gateway holds WebSockets open for hours.
+
+### 4. Get the gateway token + approve devices
+
+```bash
+TOKEN=$(jq -r .gateway.auth.token ~/.openclaw/openclaw.json)
+echo "$TOKEN"
+openclaw devices approve --latest --token "$TOKEN"
+```
+
+## Verification
+
+```bash
+curl -sIo /dev/null -w '%{http_code}\n' "https://<vm-name>.exe.xyz/"
+# Expect: 2xx or 3xx (after exe.dev's email auth gate clears)
+```
+
+Open `https://<vm-name>.exe.xyz/#token=<TOKEN>` in a browser. exe.dev's email-auth screen appears first; once authenticated, the OpenClaw Control UI loads.
+
+## Updates
+
+```bash
+# On the VM (Path B)
+ssh "<user>@<vm-name>.exe.dev" 'curl -fsSL https://openclaw.ai/install.sh | bash -s -- --no-onboard'
+# or via openclaw's own update flow:
+ssh "<user>@<vm-name>.exe.dev" 'openclaw update'
+```
+
+For Path A (Shelley), re-run the Shelley prompt at `https://exe.new/openclaw`.
+
+## Teardown
+
+```bash
+ssh exe.dev delete <vm-name>
+```
+
+(Or via the exe.dev dashboard if available.)
+
+## Gotchas
+
+- **WebSocket headers in nginx are mandatory.** Without `Upgrade` / `Connection: upgrade`, the Control UI loads but pairing requests time out. Symptom: chat box appears but messages never send.
+- **`proxy_read_timeout` defaults to 60s.** OpenClaw's WebSocket sits idle longer than that; raise to 86400s (24h) or higher.
+- **exe.dev email auth is in front of openclaw's gateway token.** Two auth layers; users see exe.dev's login first, then openclaw's. Tell users to expect two prompts.
+- **Path B port number (8000) is exe.dev-specific.** That's the port their proxy forwards from `*.exe.xyz` HTTPS to your VM. If exe.dev changes it, the nginx config breaks — verify against current exe.dev docs.
+- **Shelley is opaque automation.** When it works it's great; when it fails, the user is back to Path B. Have the manual path ready.
+
+## Reference
+
+- exe.dev: <https://exe.dev>
+- OpenClaw on exe.dev (upstream): <https://docs.openclaw.ai/install/exe-dev>

--- a/plugins/open-forge/skills/open-forge/references/infra/paas/fly.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/paas/fly.md
@@ -1,0 +1,239 @@
+---
+name: fly-paas-infra
+description: Fly.io PaaS infra adapter — deploy via the upstream-shipped fly.toml + Dockerfile from the openclaw repo. The `flyctl` CLI does provisioning + deploy + secrets in one tool. Two modes: public (default — Fly assigns a *.fly.dev URL with auto-HTTPS) and private (no public IP; access via WireGuard / fly proxy). Picked when the user wants minimal infra ops + global edge networking.
+---
+
+# Fly.io adapter
+
+A PaaS that builds the project's `Dockerfile`, runs it on Firecracker microVMs, and provides:
+
+- Persistent volumes mounted into the container (survive deploys).
+- Auto-HTTPS at `<app>.fly.dev` (or a custom domain).
+- Secrets management via the `flyctl` CLI.
+- Optional **private mode** with no public IP — accessed via WireGuard or `fly proxy`.
+
+OpenClaw upstream ships the `fly.toml` and `Dockerfile` in the repo root. open-forge's job: clone, customize the toml, set secrets, deploy.
+
+## Prerequisites
+
+- Fly.io account ([signup](https://fly.io)). Free tier covers small workloads but is not always-on.
+- `flyctl` CLI installed locally and authenticated.
+
+### Install + auth
+
+```bash
+# macOS
+brew install flyctl
+
+# Linux / WSL
+curl -L https://fly.io/install.sh | sh
+flyctl version
+
+# One-time auth
+fly auth login            # opens browser
+fly auth whoami           # confirm
+```
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Fly app name?" | Free-text (lowercase, hyphens, globally unique on Fly) | `<deployment-name>` |
+| End of preflight | "Region?" | `AskUserQuestion`: `iad` (Virginia) / `ord` (Chicago) / `sjc` (San Jose) / `lhr` (London) / `fra` (Frankfurt) / `sin` (Singapore) / `Other` | Geographic-closest |
+| End of preflight | "VM size?" | `AskUserQuestion`: `shared-cpu-1x / 1024mb` (free-tier-eligible) / `shared-cpu-2x / 2048mb` (recommended) / `Other` | `shared-cpu-2x / 2048mb` |
+| End of preflight | "Volume size (GB)?" | `AskUserQuestion`: `1` / `3` / `10` | `1` |
+| End of preflight | "Public or private?" | `AskUserQuestion`: `Public — *.fly.dev URL` / `Private — WireGuard / fly proxy access only` | `Public` |
+| At secrets phase | "Anthropic / OpenAI / Gemini API key?" | Free-text (sensitive) | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.app_name` | The Fly app name |
+| `outputs.region` | The Fly region |
+| `outputs.volume_name` | `${app}_data` |
+| `outputs.public_url` | `https://<app>.fly.dev` (public mode) or `none` (private) |
+
+## Provisioning
+
+### 1. Clone the project repo
+
+```bash
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
+```
+
+The repo ships `fly.toml` (default config) and `fly.private.toml` (no-public-IP variant) at the root.
+
+### 2. Create the Fly app + volume
+
+```bash
+fly apps create "$APP_NAME"
+fly volumes create "${APP_NAME}_data" --size "$VOLUME_GB" --region "$FLY_REGION"
+```
+
+### 3. Customize `fly.toml`
+
+The default `fly.toml` needs the app name and region updated. Minimum diffs:
+
+```toml
+app = "<your-app-name>"          # was: "openclaw" or similar placeholder
+primary_region = "<your-region>"
+
+# everything else can stay as upstream ships it; the key invariants:
+# [processes].app must include `--bind lan` (so Fly's proxy can reach the gateway)
+# [http_service].internal_port must equal --port from [processes].app
+# [mounts].destination must equal /data, source must match the volume name
+# [[vm]].memory should be 2048mb minimum (1024mb OOMs under load)
+```
+
+For private mode, use `fly.private.toml` instead — it removes `[http_service]` so no public IP is allocated.
+
+### 4. Set secrets
+
+```bash
+# Required: bootstrap gateway auth
+fly secrets set OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)" --app "$APP_NAME"
+
+# Required: at least one model provider
+fly secrets set ANTHROPIC_API_KEY="<paste>" --app "$APP_NAME"
+# Optional: more providers
+fly secrets set OPENAI_API_KEY="<paste>" --app "$APP_NAME"
+fly secrets set GEMINI_API_KEY="<paste>" --app "$APP_NAME"
+
+# Optional: messaging tokens
+fly secrets set DISCORD_BOT_TOKEN="<paste>" --app "$APP_NAME"
+fly secrets set TELEGRAM_BOT_TOKEN="<paste>" --app "$APP_NAME"
+```
+
+Treat these tokens like passwords. Prefer secrets over editing `openclaw.json` for any API key — keeps them out of the file (and out of any backup that includes the volume).
+
+### 5. Deploy
+
+```bash
+# Public mode (default)
+fly deploy --app "$APP_NAME"
+
+# Private mode (no public IP)
+fly deploy --app "$APP_NAME" -c fly.private.toml
+```
+
+First deploy builds the Docker image (~2–3 min). Subsequent deploys hit the build cache.
+
+### 6. Create config inside the volume (one-time, after first deploy)
+
+The container starts with `--allow-unconfigured` so it can boot without `/data/openclaw.json`. Once running, SSH in to seed the real config:
+
+```bash
+fly ssh console --app "$APP_NAME"
+
+# Inside the container:
+mkdir -p /data
+cat > /data/openclaw.json <<'EOF'
+{
+  "agents": { "defaults": { "model": { "primary": "anthropic/claude-sonnet-4-6" } } },
+  "gateway": {
+    "mode": "local",
+    "bind": "auto",
+    "controlUi": {
+      "allowedOrigins": [
+        "https://<your-app>.fly.dev",
+        "http://localhost:3000",
+        "http://127.0.0.1:3000"
+      ]
+    }
+  }
+}
+EOF
+exit
+
+fly machine restart $(fly machines list --app "$APP_NAME" --json | jq -r '.[0].id')
+```
+
+`gateway.controlUi.allowedOrigins` MUST include the public Fly URL — the container's `--bind lan` advertises `0.0.0.0` but browsers from `*.fly.dev` are origin-checked separately.
+
+## SSH convention
+
+```bash
+fly ssh console --app "$APP_NAME"               # interactive shell
+fly ssh console --app "$APP_NAME" -C 'cat /data/openclaw.json'   # one-shot
+fly sftp shell --app "$APP_NAME"                # file transfer
+```
+
+Note: `fly ssh console -C` doesn't honor shell redirection; for writing files, pipe via `tee` or use `fly sftp`.
+
+## Public access (public mode)
+
+```bash
+fly open --app "$APP_NAME"                      # opens https://<app>.fly.dev
+# Or directly: https://<app>.fly.dev/
+```
+
+Authenticate with `OPENCLAW_GATEWAY_TOKEN` (use `#token=<TOKEN>` URL fragment, not `?token=`).
+
+## Private access (private mode)
+
+No public URL. Pick one:
+
+```bash
+# Option 1 — local proxy (simplest)
+fly proxy 3000:3000 --app "$APP_NAME"
+# then open http://localhost:3000
+
+# Option 2 — WireGuard
+fly wireguard create
+# import the printed config to your WireGuard client; then open http://[fdaa:x:x:x::x]:3000
+
+# Option 3 — SSH only
+fly ssh console --app "$APP_NAME"
+```
+
+For inbound webhooks (Telegram, Discord) in private mode, use a tunnel inside the container (ngrok, Tailscale Funnel) — see `references/modules/tunnels.md`.
+
+## Logs / lifecycle
+
+```bash
+fly logs --app "$APP_NAME"                              # live tail
+fly logs --no-tail --app "$APP_NAME" | tail -200        # recent
+fly status --app "$APP_NAME"
+fly machines list --app "$APP_NAME"
+fly machine restart <machine-id> --app "$APP_NAME"
+fly deploy --app "$APP_NAME"                            # redeploy after a git pull
+```
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `fly status --app "$APP_NAME"` shows `started` for the machine.
+- `fly logs` shows `[gateway] listening on …`.
+- (Public) `curl -sIo /dev/null -w '%{http_code}\n' https://<app>.fly.dev/` returns 2xx/3xx.
+- (Private) `fly proxy 3000:3000` then `curl -sI http://127.0.0.1:3000/` returns 2xx/3xx.
+
+## Teardown
+
+Don't auto-run; confirm.
+
+```bash
+fly apps destroy "$APP_NAME" -y
+fly volumes destroy "${APP_NAME}_data" -y     # if not auto-deleted with the app
+```
+
+## Gotchas
+
+- **`--bind lan` is required.** Default openclaw bind is loopback; Fly's proxy needs `0.0.0.0`. Fly's health check fails silently if you forget. Symptom: `App is not listening on expected address`.
+- **`internal_port` must match `--port`.** Mismatch silently fails health checks.
+- **Memory: 1024mb is too small.** OOM kills during build or under load. Default to 2048mb. Symptom: `SIGABRT`, `v8::internal::Runtime_AllocateInYoungGeneration`, or silent restarts.
+- **Lock file at `/data/gateway.*.lock`.** Survives container restart. If gateway refuses to start with "already running", `fly ssh console -C 'rm -f /data/gateway.*.lock'` then `fly machine restart`.
+- **`fly deploy` resets the machine command.** Manual `fly machine update --command ...` overrides drop after the next `fly deploy`. Keep machine command in `fly.toml`.
+- **`OPENCLAW_STATE_DIR=/data` is critical for persistence.** Without it, state writes to the container filesystem and disappears on every restart. Confirm in `fly.toml` `[env]` block.
+- **`allowedOrigins` must list the public Fly URL.** Browser WebSocket connections from `<app>.fly.dev` get rejected by origin check otherwise. The default config seeds local origins only — patch via SSH after first deploy.
+- **Signal Messenger requires Java + signal-cli.** Default Dockerfile doesn't ship them. Use a custom image; keep memory ≥ 2048mb.
+- **x86 only on Fly.** No ARM/Graviton machines. Don't try ARM tags.
+- **Free tier sleeps after 15 min idle.** Set `min_machines_running = 1` in `[http_service]` to keep always-on (counts against free allowance).
+
+## Reference
+
+- Fly.io docs: <https://fly.io/docs/>
+- `flyctl` reference: <https://fly.io/docs/flyctl/>
+- OpenClaw on Fly (upstream): <https://docs.openclaw.ai/install/fly>

--- a/plugins/open-forge/skills/open-forge/references/infra/paas/northflank.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/paas/northflank.md
@@ -1,0 +1,92 @@
+---
+name: northflank-paas-infra
+description: Northflank PaaS infra adapter — deploy via the upstream-shipped one-click stack template. Northflank runs the project's Docker image and mounts a persistent volume at `/data`. Picked when the user wants a Heroku/Railway-style "no terminal on the server" path with the option to add managed Postgres/Redis later from the same console.
+---
+
+# Northflank adapter
+
+Northflank is a PaaS that builds and runs services from Git, with managed databases, queues, and persistent volumes available from the same dashboard. OpenClaw upstream ships a one-click stack template (`Deploy OpenClaw`) that pre-wires the service + volume.
+
+## Prerequisites
+
+- Northflank account ([signup](https://app.northflank.com/signup)).
+- Browser only — no CLI required for the one-click flow.
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Project / stack name?" | Free-text | `<deployment-name>` |
+| At secrets phase | "Gateway token?" | `AskUserQuestion`: `Generate a strong random` / `I'll paste my own` | Generate |
+| At secrets phase | "Model-provider API key?" | Free-text (sensitive) | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.public_url` | The public URL Northflank assigns to the OpenClaw service (visible in **View resources**) |
+| `outputs.volume_mount_path` | `/data` |
+
+## Provisioning (browser-driven)
+
+1. Walk the user to the upstream template URL: `https://northflank.com/stacks/deploy-openclaw`.
+2. Sign in to Northflank if not already.
+3. Click **Deploy OpenClaw now**.
+4. Set required environment variable: `OPENCLAW_GATEWAY_TOKEN` — strong random value (generate with `openssl rand -hex 32`).
+5. (Optional but recommended) add `ANTHROPIC_API_KEY` (or your provider key) under the same env-var screen.
+6. Click **Deploy stack**. Northflank builds the Docker image and runs it.
+7. When deployment completes, click **View resources** → open the **OpenClaw** service → note the public URL.
+
+## Verification
+
+```bash
+curl -sIo /dev/null -w '%{http_code}\n' "<the-public-url>/"
+# Expect: 2xx or 3xx
+```
+
+Open `<public-url>/openclaw` in a browser and authenticate with `OPENCLAW_GATEWAY_TOKEN`.
+
+## Day-to-day operations
+
+Northflank provides:
+
+| Action | Where |
+|---|---|
+| Live logs | Service → **Logs** |
+| Shell access (browser) | Service → **Console** (browser-based; no SSH key) |
+| Env-var changes | Service → **Environment** → save → auto-redeploys |
+| Volume browser | Service → **Storage** → `/data` |
+| Restart | Service → **Restart** |
+
+Inside the shell, persistent storage is at `/data`:
+
+```bash
+cat /data/.openclaw/openclaw.json
+openclaw backup create
+openclaw devices approve --latest --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+## Updates
+
+Northflank auto-redeploys on push to the connected repo (your fork of openclaw, if you forked). For deployments tied directly to the upstream template, manual redeploy from the dashboard pulls the latest image.
+
+## Teardown
+
+```
+Northflank → stack → Settings → Delete stack
+```
+
+Persistent volumes are deleted with the stack unless individually snapshotted first.
+
+## Gotchas
+
+- **No CLI deploy step.** Northflank is dashboard-driven for the initial setup. Document this clearly to the user — open-forge can't automate the click flow.
+- **`OPENCLAW_GATEWAY_TOKEN` is the only required env var.** If you forget the API key on first deploy, the gateway boots in unconfigured mode; add the key after deploy and redeploy from the dashboard.
+- **`/data` mount is part of the template.** Don't delete the volume binding when customizing other settings — state will reset on every redeploy.
+- **Service URLs come from Northflank's domain pool** (`*.northflank.app` or similar). Custom domain available on paid tiers.
+- **Northflank's build cache is generous** but not unlimited; expect occasional full rebuilds (~5 min) after long idle.
+
+## Reference
+
+- Northflank docs: <https://northflank.com/docs>
+- OpenClaw on Northflank (upstream): <https://docs.openclaw.ai/install/northflank>

--- a/plugins/open-forge/skills/open-forge/references/infra/paas/railway.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/paas/railway.md
@@ -1,0 +1,99 @@
+---
+name: railway-paas-infra
+description: Railway PaaS infra adapter — deploy via the upstream-shipped one-click template. Railway builds the project's Docker image, mounts a persistent volume, and provides a public domain with auto-HTTPS. Picked when the user wants the simplest possible PaaS UX (no terminal on the server).
+---
+
+# Railway adapter
+
+Railway is a PaaS focused on developer experience: connect a GitHub repo (or use a one-click template), set env vars, click deploy. OpenClaw upstream ships a one-click template that pre-wires the Dockerfile, a `/data` volume, and the required env vars.
+
+## Prerequisites
+
+- Railway account ([signup](https://railway.com)). Free trial credit; paid usage after.
+- Browser only — no CLI required for the one-click flow.
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Service name on Railway?" | Free-text | `<deployment-name>` |
+| End of preflight | "Custom domain or use the auto-generated `*.up.railway.app`?" | `AskUserQuestion` | Auto-generated |
+| At secrets phase | "Model-provider API key?" | Free-text (sensitive) | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.public_url` | `https://<service>.up.railway.app` (or custom) |
+| `outputs.gateway_token` | Set by user as `OPENCLAW_GATEWAY_TOKEN` env var |
+| `outputs.volume_mount_path` | `/data` |
+
+## Provisioning (browser-driven)
+
+1. Walk the user to the upstream template URL: `https://railway.com/deploy/clawdbot-railway-template`.
+2. Click **Deploy on Railway**. Railway clones the openclaw repo into a new service.
+3. **Add a Volume** mounted at `/data` (Railway → service → **Volumes** → **New Volume**, mount path `/data`).
+4. **Set Variables** (Railway → service → **Variables**):
+   - `OPENCLAW_GATEWAY_PORT=8080` (required — must match Public Networking port)
+   - `OPENCLAW_GATEWAY_TOKEN=<random>` — generate with `openssl rand -hex 32`, treat as admin secret
+   - `OPENCLAW_STATE_DIR=/data/.openclaw` (recommended)
+   - `OPENCLAW_WORKSPACE_DIR=/data/workspace` (recommended)
+   - `ANTHROPIC_API_KEY` (or your provider key)
+5. **Enable HTTP Proxy** on port `8080` (Railway → service → **Settings** → **Networking** → **Generate Domain**).
+6. Get the public URL from **Settings → Domains** (`https://<service>.up.railway.app` by default).
+
+## Verification
+
+```bash
+curl -sIo /dev/null -w '%{http_code}\n' "https://<your-railway-domain>/"
+# Expect: 2xx or 3xx
+```
+
+Then open `https://<your-railway-domain>/openclaw` (note the `/openclaw` path) in a browser and authenticate with `OPENCLAW_GATEWAY_TOKEN`.
+
+## Day-to-day operations
+
+Railway has a built-in shell:
+
+```
+Railway → service → ⋯ menu → Open Shell
+```
+
+Inside the shell, persistent storage is at `/data`:
+
+```bash
+cat /data/.openclaw/openclaw.json
+openclaw backup create
+openclaw devices approve --latest --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+For automation, the `railway` CLI works too — `npm i -g @railway/cli`, `railway login`, `railway shell`.
+
+## Logs / lifecycle
+
+All in the Railway Dashboard: **service → Deployments / Logs / Metrics**. Restart via **Deployments → ⋯ → Restart**.
+
+## Updates
+
+Railway auto-redeploys on push to the connected repo. If you used the upstream template, Railway connected your account to a fork — push to the fork's main branch to redeploy. To pull upstream openclaw changes, merge them into your fork.
+
+## Teardown
+
+```
+Railway → service → Settings → Delete Service
+```
+
+Volume is deleted with the service unless explicitly snapshotted.
+
+## Gotchas
+
+- **`OPENCLAW_GATEWAY_PORT` must match Public Networking port.** Both default to 8080 in the template; don't change one without the other.
+- **`/openclaw` path matters.** The template's HTTP Proxy is configured for the OpenClaw Control UI at `/openclaw`, not the root. `https://<domain>/` may 404; `https://<domain>/openclaw` is the correct entry.
+- **Volume isn't auto-attached.** If you skipped step 3, state writes to ephemeral container storage and disappears on every redeploy. Always add the volume before enabling networking.
+- **Auto-generated `up.railway.app` domains rotate** if you delete + recreate the service. Custom domain protects against this.
+- **No free always-on.** Trial credits run out; expect a small monthly bill (~$5–10) for a real always-on deployment.
+
+## Reference
+
+- Railway docs: <https://docs.railway.com/>
+- OpenClaw on Railway (upstream): <https://docs.openclaw.ai/install/railway>

--- a/plugins/open-forge/skills/open-forge/references/infra/paas/render.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/paas/render.md
@@ -1,0 +1,150 @@
+---
+name: render-paas-infra
+description: Render PaaS infra adapter — deploy via the upstream-shipped `render.yaml` Blueprint from the openclaw repo. Render builds the Dockerfile, runs the container, and mounts a persistent disk. Picked when the user wants "Heroku-style" UX with a free starter tier and infrastructure-as-code via the Blueprint file.
+---
+
+# Render adapter
+
+Render is a PaaS that builds and runs containers from a Git repo, configured declaratively via `render.yaml` (Render's "Blueprint" format). OpenClaw upstream ships the Blueprint file; Render reads it on first deploy and provisions the service + persistent disk + env vars in one step.
+
+## Prerequisites
+
+- Render account ([signup](https://render.com)). Free tier available but spins down after 15 min idle.
+- A GitHub account linked to Render (Render reads the upstream `openclaw/openclaw` repo or your fork).
+- An API key for at least one model provider (Anthropic, OpenAI, Gemini, OpenRouter).
+
+No CLI install required — Render is browser-driven for the deploy step. Day-to-day operations (logs, shell, env vars) happen in the Render Dashboard or via `render` CLI (optional).
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Render service name?" | Free-text (lowercase, hyphens) | `<deployment-name>` |
+| End of preflight | "Plan?" | `AskUserQuestion`: `Free (spin-down after 15 min idle, no disk)` / `Starter ($7/mo, always-on, 1 GB disk)` / `Standard+ ($25+/mo, more CPU)` | `Starter` |
+| End of preflight | "Region?" | `AskUserQuestion`: Render auto-picks; rarely user-set | (auto) |
+| At secrets phase | "API key for model provider?" | Free-text (sensitive) | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.service_name` | The Render service name |
+| `outputs.public_url` | `https://<service>.onrender.com` |
+| `outputs.disk_name` | `openclaw-data` (defined in upstream `render.yaml`) |
+
+## Provisioning
+
+### 1. Click the deploy button (browser-driven)
+
+The fastest path uses Render's one-click deploy URL pre-wired to the upstream repo:
+
+```
+https://render.com/deploy?repo=https://github.com/openclaw/openclaw
+```
+
+Walk the user through the browser flow:
+
+1. Sign in to Render if not already.
+2. Render reads `render.yaml` from the openclaw repo and shows the planned resources (service + 1 GB disk + auto-generated `OPENCLAW_GATEWAY_TOKEN`).
+3. Choose the plan (Starter recommended for always-on + persistent disk).
+4. Click **Apply**. Render builds the Dockerfile (~3–5 min) and deploys.
+
+### 2. Set the model-provider API key
+
+The Blueprint generates `OPENCLAW_GATEWAY_TOKEN` automatically but doesn't include API keys (security). After the first deploy:
+
+1. **Render Dashboard → your service → Environment.**
+2. **Add Environment Variable:**
+   - `ANTHROPIC_API_KEY=<paste>` (or `OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.)
+3. Save — Render auto-redeploys with the new env.
+
+### 3. Retrieve the gateway token
+
+```
+Render Dashboard → your service → Environment → OPENCLAW_GATEWAY_TOKEN → Reveal
+```
+
+Save it for the Control UI authentication step.
+
+## Custom domain (optional)
+
+```
+Render Dashboard → your service → Settings → Custom Domains → Add Domain
+```
+
+Render auto-provisions a TLS cert via Let's Encrypt. DNS instructions show the CNAME target (`<service>.onrender.com`).
+
+## SSH / shell access
+
+Render provides a browser-based shell — no SSH key required:
+
+```
+Render Dashboard → your service → Shell
+```
+
+Persistent disk is mounted at `/data` inside the shell. Useful commands once inside:
+
+```bash
+ls -la /data
+cat /data/.openclaw/openclaw.json
+openclaw backup create                # creates a portable archive
+openclaw devices approve --latest --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+## Logs / lifecycle
+
+All in the Render Dashboard:
+
+| Action | Where |
+|---|---|
+| Live logs | **Logs** tab — filter by build / deploy / runtime |
+| Restart | **Manual Deploy** menu → **Clear build cache & deploy** (or **Restart service**) |
+| Pause / resume | **Settings** → **Suspend Service** (keeps state, stops billing) |
+| Roll back | **Events** → click any prior deploy → **Rollback** |
+
+`render` CLI is optional and supports the same operations from the terminal.
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- Render Dashboard shows the service as **Live** (green dot).
+- `curl -sI https://<service>.onrender.com/` returns 2xx/3xx.
+- The Render shell can read `/data/.openclaw/openclaw.json` (persistence confirmed).
+
+## Updates
+
+Render auto-deploys on every push to the upstream OpenClaw repo's main branch — **but only if the Render service is connected to your fork**, not the upstream repo. If you used the one-click deploy linked to `openclaw/openclaw` directly, Render does **not** auto-deploy on upstream changes.
+
+To pick up new openclaw versions:
+
+```
+Render Dashboard → your service → Manual Deploy → Sync Blueprint
+```
+
+Or fork the openclaw repo, point Render at your fork, and merge from upstream when you want updates (Render auto-deploys your fork on push).
+
+## Teardown
+
+```
+Render Dashboard → your service → Settings → Delete Service
+```
+
+Confirm. Persistent disk is deleted with the service unless you explicitly snapshot first.
+
+## Gotchas
+
+- **Free plan = no persistent disk.** State resets on every redeploy. For any real use, upgrade to Starter ($7/mo). Periodically `openclaw backup create` if you must use Free.
+- **Free plan cold starts.** First request after 15 min idle takes 30–60s while the container spins up. Health-check window is 30s — services that take longer to start fail their first health check and Render marks them unhealthy. Mitigation: upgrade to Starter (always-on).
+- **`OPENCLAW_GATEWAY_PORT=8080` is mandatory.** Render expects services to bind to the port in `$PORT`. Upstream's `render.yaml` sets it to 8080 already; don't override.
+- **`healthCheckPath: /health` must return 200.** If the openclaw build doesn't expose `/health`, Render keeps redeploying and failing. Verify via the Render shell: `curl -sI http://127.0.0.1:8080/health`.
+- **Auto-deploy off by default for upstream-direct.** Renders linked to `openclaw/openclaw` (read-only fork relationship) won't auto-update. Document this for the user — they'll need to manual-sync when they want a new version.
+- **Custom domain requires Starter+ plan.** Free tier domains are `*.onrender.com` only.
+- **No SSH; shell is browser-only.** Some workflows that depend on local SSH config (file uploads from a laptop) don't work cleanly. Use `openclaw backup create` to export state, then download via the dashboard's file viewer.
+- **Build cache eviction.** Render's free build cache is shared across all your services. Heavy concurrent deploys evict; expect occasional 5+ min full rebuilds.
+
+## Reference
+
+- Render Blueprints: <https://render.com/docs/blueprint-spec>
+- Render CLI (optional): <https://render.com/docs/cli>
+- OpenClaw on Render (upstream): <https://docs.openclaw.ai/install/render>

--- a/plugins/open-forge/skills/open-forge/references/infra/raspberry-pi.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/raspberry-pi.md
@@ -1,0 +1,176 @@
+---
+name: raspberry-pi-infra
+description: Raspberry Pi infra adapter — install OpenClaw on a Pi 4 or Pi 5 running 64-bit Raspberry Pi OS for an always-on home self-host. Pair with `runtimes/native.md` for the install. Picked when the user has a Pi (or a small ARM SBC) and wants always-on operation with no recurring cloud bill.
+---
+
+# Raspberry Pi adapter
+
+A Raspberry Pi 4 or 5 with 4 GB+ RAM is a great always-on host for OpenClaw — the gateway is lightweight (models run in the cloud via API), so even a Pi 4 handles it well. Power draw is ~5 W, so total electricity cost is < $1/month.
+
+This is structurally a `byo-vps`-style adapter — open-forge does not flash the SD card or boot the Pi (that's a one-time physical act). Once the Pi is on the network with SSH enabled, we drive everything over SSH.
+
+## Prerequisites
+
+- Pi 4 or Pi 5 with 2 GB+ RAM (4 GB strongly recommended).
+- 16 GB+ MicroSD card or USB SSD (SSD is dramatically faster + lasts longer).
+- Official Pi power supply (under-volt warnings throttle CPU).
+- 64-bit Raspberry Pi OS (**not** the 32-bit variant — many Node modules need ARM64).
+- Network: Ethernet preferred; Wi-Fi works but flakier.
+
+## Inputs to collect
+
+| When | Question | Tool / format | Default |
+|---|---|---|---|
+| End of preflight | "Already flashed + booted?" | `AskUserQuestion`: `Yes — give me SSH details` / `No — walk me through Imager` | — |
+| End of preflight (if No) | (instructions only) | Walk through Imager steps below | — |
+| End of preflight | "Pi hostname?" | Free-text | `gateway-host` |
+| End of preflight | "SSH user?" | Free-text | `<user from Imager>` |
+| End of preflight | "Pi IP or hostname?" | Free-text | `<hostname>.local` (mDNS) |
+| End of preflight | "RAM?" | `AskUserQuestion`: `2 GB` / `4 GB` / `8 GB` | — |
+| End of preflight | "Timezone?" | Free-text (IANA, e.g. `America/Chicago`) | — |
+
+Derived:
+
+| Recorded as | Derived from |
+|---|---|
+| `outputs.host_user` | The user account from Imager |
+| `outputs.public_address` | Pi's LAN IP or `<hostname>.local` |
+| `outputs.add_swap` | `true` if RAM ≤ 2 GB |
+
+## Flashing the OS (one-time, user-driven)
+
+Walk the user through **Raspberry Pi Imager** (<https://www.raspberrypi.com/software/>):
+
+1. Open Imager.
+2. **Choose OS:** Raspberry Pi OS Lite (64-bit). Lite is headless — no desktop, smaller footprint, faster boot.
+3. **Choose Storage:** SD card or USB SSD.
+4. **Settings (gear icon):**
+   - **Hostname:** `<user-chosen>`
+   - **Enable SSH:** yes (use password or paste public key)
+   - **Username + password:** save these — open-forge needs them later
+   - **Wi-Fi:** if not Ethernet
+   - **Locale + keyboard**
+5. **Write.** Eject. Insert into the Pi. Boot.
+
+After ~60s, the Pi joins the network. mDNS name is `<hostname>.local` from any LAN device that supports mDNS (most do).
+
+## SSH in
+
+```bash
+ssh "<user>@<hostname>.local"
+# or by IP from the user's router admin page
+```
+
+If the connection hangs, check that the LED on the Pi is steady (booted) and that mDNS resolution works (`ping <hostname>.local`). On Linux mDNS may need `avahi-daemon` running.
+
+## Initial host setup
+
+```bash
+sudo apt-get update && sudo apt-get upgrade -y
+sudo apt-get install -y git curl ca-certificates build-essential
+
+# Timezone (matters for cron + reminders)
+sudo timedatectl set-timezone "$TIMEZONE"
+```
+
+`build-essential` is required because Node modules sometimes compile from source on ARM64.
+
+### Add swap (mandatory for ≤ 2 GB Pis)
+
+```bash
+sudo fallocate -l 2G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+
+# Reduce swappiness — better for low-RAM ARM
+echo 'vm.swappiness=10' | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+```
+
+Skip on Pi 4/5 with 8 GB if you'd rather not add swap.
+
+### Install Node.js 24
+
+The openclaw native installer auto-installs Node, but on Pi we pre-install via NodeSource for predictability:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+sudo apt-get install -y nodejs
+node --version       # expect v24.x
+```
+
+## Lightweight tweaks (optional but recommended)
+
+```bash
+# Free GPU memory on a headless Pi
+echo 'gpu_mem=16' | sudo tee -a /boot/config.txt
+
+# Disable services you won't use
+sudo systemctl disable bluetooth cups avahi-daemon
+
+# Disable Wi-Fi power management (drops are common otherwise)
+sudo iwconfig wlan0 power off
+
+# Wake-and-keep-CPU-cache for low-power Pi
+grep -q 'NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache' ~/.bashrc || cat >> ~/.bashrc <<'EOF'
+export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
+mkdir -p /var/tmp/openclaw-compile-cache
+export OPENCLAW_NO_RESPAWN=1
+EOF
+```
+
+`NODE_COMPILE_CACHE` speeds up repeated `openclaw` invocations on lower-power Pis.
+
+## Now hand off to runtimes/native.md
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash
+exec $SHELL -l
+openclaw onboard --install-daemon
+sudo loginctl enable-linger "$USER"     # daemon survives logout
+```
+
+For ARM (aarch64), most Node modules work; native binaries occasionally need `linux-arm64` or `aarch64` releases. Check `uname -m` (should print `aarch64`) before troubleshooting.
+
+## Access
+
+Gateway binds to `127.0.0.1:18789`. Two paths:
+
+```bash
+# From a laptop on the same LAN — SSH tunnel
+ssh -N -L 18789:127.0.0.1:18789 "<user>@<hostname>.local"
+# Open: http://localhost:18789/#token=<TOKEN>
+
+# Print the dashboard URL with token:
+ssh "<user>@<hostname>.local" 'openclaw dashboard --no-open'
+```
+
+For remote-from-anywhere access, see [Tailscale integration](https://docs.openclaw.ai/gateway/tailscale) — install Tailscale on the Pi (`curl -fsSL https://tailscale.com/install.sh | sh && sudo tailscale up --ssh`) and access from any device on the tailnet.
+
+## Verification
+
+Mark `provision` done only when all of:
+
+- `ssh "<user>@<host>" 'openclaw status'` returns healthy.
+- `ssh "<user>@<host>" 'systemctl --user is-active openclaw-gateway.service'` prints `active`.
+- `free -h` shows swap configured (if RAM ≤ 2 GB).
+- `vcgencmd get_throttled` returns `0x0` (no thermal/voltage throttling).
+
+## Gotchas
+
+- **32-bit Raspberry Pi OS will not work.** OpenClaw needs ARM64 (aarch64). Confirm with `uname -m`.
+- **SD-card wear.** Heavy write workloads (logs, swap) wear out SD cards in months. USB SSD is strongly recommended for any always-on Pi.
+- **Under-voltage throttles CPU silently.** `vcgencmd get_throttled` returns non-zero if the power supply is undersized. Use the official Pi PSU (5 V / 3 A for Pi 4, 5 V / 5 A for Pi 5).
+- **Swap is mandatory on 2 GB Pis.** OpenClaw + Node fits in 2 GB at idle but spikes during plugin work — OOM-kill is common without swap.
+- **Wi-Fi power management drops connections.** `iwconfig wlan0 power off` is a stable workaround; alternatively use Ethernet.
+- **`enable-linger` is mandatory for headless reboot.** Without it, the gateway dies on logout and never starts back up.
+- **Pi 4 + 4 GB is the practical minimum.** Pi 3 / Zero 2 W technically run aarch64 Linux but openclaw + Node makes them very slow; not recommended.
+
+## Reference
+
+- Raspberry Pi OS download: <https://www.raspberrypi.com/software/>
+- USB SSD boot guide: <https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#usb-mass-storage-boot>
+- Tailscale on Linux: <https://tailscale.com/kb/1031/install-linux>
+- OpenClaw on Pi (upstream): <https://docs.openclaw.ai/install/raspberry-pi>

--- a/plugins/open-forge/skills/open-forge/references/modules/preflight.md
+++ b/plugins/open-forge/skills/open-forge/references/modules/preflight.md
@@ -24,14 +24,21 @@ Usually inferred from the user's prompt ("self-host Ghost" → ghost). If ambigu
 Use `AskUserQuestion`:
 
 > **Where should this run?**
-> - AWS
-> - Hetzner
+> - AWS (Lightsail or EC2)
+> - Azure
+> - Hetzner Cloud
 > - DigitalOcean
-> - GCP
-> - Bring-your-own VPS (any Linux VM you already have)
-> - **localhost** (your own machine)
+> - GCP Compute Engine
+> - Oracle Cloud (Always-Free ARM)
+> - Hostinger (managed)
+> - Raspberry Pi (your own Pi)
+> - macOS VM (Lume on Apple Silicon)
+> - Bring-your-own VPS / Linux server (any other provider, on-prem, etc.)
+> - **localhost** (your own machine — macOS / Linux / Windows / WSL2)
+> - PaaS — Fly.io / Render / Railway / Northflank / exe.dev (one-click templates)
+> - Kubernetes (any cluster you already have access to)
 
-Loads the matching infra adapter — `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`. Today AWS (Lightsail + EC2), Hetzner Cloud, DigitalOcean, and GCP Compute Engine each have a dedicated adapter; anything else (other providers, on-prem, etc.) goes through `byo-vps.md`.
+Loads the matching infra adapter under `references/infra/`. Today AWS (Lightsail + EC2), Azure, Hetzner Cloud, DigitalOcean, GCP Compute Engine, Oracle Cloud (free-tier ARM), Hostinger, Raspberry Pi, macOS-VM (Lume), and the PaaS group (Fly.io, Render, Railway, Northflank, exe.dev under `infra/paas/`) each have a dedicated adapter; anything else (other providers, on-prem, etc.) goes through `byo-vps.md`. Localhost (the user's own machine) uses `localhost.md`.
 
 ### 1c. How? (service + runtime)
 
@@ -62,19 +69,29 @@ Infra-conditional:
 | If infra ∈ | Also required |
 |---|---|
 | AWS (Lightsail or EC2) | `aws` (v2) CLI |
+| Azure | `az` CLI + `az extension add -n ssh` |
 | Hetzner | `hcloud` CLI |
 | DigitalOcean | `doctl` CLI |
 | GCP | `gcloud` CLI |
+| Oracle Cloud | `tailscale` CLI (provisioning is Console-driven) |
+| Hostinger | none — fully browser-driven via hPanel |
+| Raspberry Pi | `ssh` (after the user flashed + booted the Pi) |
+| macOS VM (Lume) | `lume` CLI (installed during preflight) |
 | BYO VPS | `ssh` (usually preinstalled) |
 | localhost | none — Claude runs local Bash |
+| Fly.io | `flyctl` CLI |
+| Render / Railway / Northflank / exe.dev | none — browser-driven (or vendor CLI optional) |
 
 Runtime-conditional:
 
 | If runtime = | Also required |
 |---|---|
 | Docker | `docker` (engine + compose v2) on the *target host* (local or remote). Not on the user's machine unless infra = localhost. |
-| Native | build tools on the target host; usually installed by the project's installer script |
-| Kubernetes | `kubectl` + `helm` v3 on the user's machine. The cluster is the user's responsibility — open-forge does not provision clusters today (point `kubectl` at one and we deploy into it). |
+| Podman | `podman` + `podman-compose` (or Quadlet via systemd-user) on the target host. Rootless by default. |
+| Native | build tools on the target host; usually installed by the project's installer script. Three modes: `install.sh` (macOS/Linux/WSL2), `install-cli.sh` (local-prefix, no root), `install.ps1` (native Windows). |
+| Kubernetes | `kubectl` (and optionally `helm` v3) on the user's machine. The cluster is the user's responsibility — open-forge does not provision clusters today (point `kubectl` at one and we deploy into it). |
+| Ansible (openclaw production hardening) | `ansible` on the local control machine; SSH access to the target Debian/Ubuntu host. |
+| Nix (declarative install) | `nix` (Determinate Nix recommended); `home-manager` if using the Home Manager module. |
 
 Project-conditional inputs (collected at their specific phases, not here):
 
@@ -122,8 +139,14 @@ Announce in one sentence, then run. Verify after (`<tool> --version`).
 | `hcloud` | `brew install hcloud` | binary release (see `infra/hetzner/cloud-cx.md`) | binary release | binary release | <https://github.com/hetznercloud/cli/releases> |
 | `doctl` | `brew install doctl` | binary release (see `infra/digitalocean/droplet.md`) | binary release | binary release | <https://docs.digitalocean.com/reference/doctl/how-to/install/> |
 | `gcloud` | `brew install --cask google-cloud-sdk` | Google's apt repo (see `infra/gcp/compute-engine.md`) | Google's dnf repo | AUR `google-cloud-sdk` | <https://cloud.google.com/sdk/docs/install> |
+| `az` | `brew install azure-cli` | `curl -sL https://aka.ms/InstallAzureCLIDeb \| sudo bash` | Microsoft's dnf repo | AUR `azure-cli` | <https://learn.microsoft.com/cli/azure/install-azure-cli> |
+| `flyctl` | `brew install flyctl` | `curl -L https://fly.io/install.sh \| sh` | (binary release) | (binary release) | <https://fly.io/docs/hands-on/install-flyctl/> |
 | `kubectl` | `brew install kubectl` | Google's apt repo for kubernetes-tools | `sudo dnf install -y kubectl` | `sudo pacman -S kubectl` | <https://kubernetes.io/docs/tasks/tools/> |
-| `helm` v3 | `brew install helm` | `curl https://baltocdn.com/helm/signing.asc \| sudo …` (Helm's apt repo) | `sudo dnf install -y helm` | `sudo pacman -S helm` | <https://helm.sh/docs/intro/install/> |
+| `helm` v3 (optional, only if a Helm chart) | `brew install helm` | `curl https://baltocdn.com/helm/signing.asc \| sudo …` (Helm's apt repo) | `sudo dnf install -y helm` | `sudo pacman -S helm` | <https://helm.sh/docs/intro/install/> |
+| `podman` | `brew install podman` | `sudo apt-get install -y podman podman-compose` | `sudo dnf install -y podman podman-compose` | `sudo pacman -S podman` | <https://podman.io/docs/installation> |
+| `tailscale` (Oracle Cloud, etc.) | `brew install tailscale` | `curl -fsSL https://tailscale.com/install.sh \| sh` | (same script) | (same script) | <https://tailscale.com/kb/1031/install-linux> |
+| `lume` (macOS-VM) | (Lume install script) | n/a (Apple Silicon only) | n/a | n/a | <https://cua.ai/docs/lume/guide/getting-started/installation> |
+| `ansible` (production-hardened openclaw install) | `brew install ansible` | `sudo apt-get install -y ansible` | `sudo dnf install -y ansible` | `sudo pacman -S ansible` | <https://docs.ansible.com/> |
 
 `aws` note: `apt-get install awscli` installs v1 on older Ubuntu/Debian. Prefer the official v2 installer:
 

--- a/plugins/open-forge/skills/open-forge/references/modules/preflight.md
+++ b/plugins/open-forge/skills/open-forge/references/modules/preflight.md
@@ -74,7 +74,7 @@ Runtime-conditional:
 |---|---|
 | Docker | `docker` (engine + compose v2) on the *target host* (local or remote). Not on the user's machine unless infra = localhost. |
 | Native | build tools on the target host; usually installed by the project's installer script |
-| Kubernetes | `kubectl` on the user's machine |
+| Kubernetes | `kubectl` + `helm` v3 on the user's machine. The cluster is the user's responsibility — open-forge does not provision clusters today (point `kubectl` at one and we deploy into it). |
 
 Project-conditional inputs (collected at their specific phases, not here):
 
@@ -122,6 +122,8 @@ Announce in one sentence, then run. Verify after (`<tool> --version`).
 | `hcloud` | `brew install hcloud` | binary release (see `infra/hetzner/cloud-cx.md`) | binary release | binary release | <https://github.com/hetznercloud/cli/releases> |
 | `doctl` | `brew install doctl` | binary release (see `infra/digitalocean/droplet.md`) | binary release | binary release | <https://docs.digitalocean.com/reference/doctl/how-to/install/> |
 | `gcloud` | `brew install --cask google-cloud-sdk` | Google's apt repo (see `infra/gcp/compute-engine.md`) | Google's dnf repo | AUR `google-cloud-sdk` | <https://cloud.google.com/sdk/docs/install> |
+| `kubectl` | `brew install kubectl` | Google's apt repo for kubernetes-tools | `sudo dnf install -y kubectl` | `sudo pacman -S kubectl` | <https://kubernetes.io/docs/tasks/tools/> |
+| `helm` v3 | `brew install helm` | `curl https://baltocdn.com/helm/signing.asc \| sudo …` (Helm's apt repo) | `sudo dnf install -y helm` | `sudo pacman -S helm` | <https://helm.sh/docs/intro/install/> |
 
 `aws` note: `apt-get install awscli` installs v1 on older Ubuntu/Debian. Prefer the official v2 installer:
 
@@ -210,6 +212,18 @@ Ask for the SSH details specified in `references/infra/byo-vps.md` (host, user, 
 ### localhost
 
 Nothing to collect. Skip this step.
+
+### Kubernetes (when runtime = kubernetes)
+
+Before any cluster operation, confirm `kubectl` points at the cluster the user actually wants:
+
+```bash
+kubectl config current-context
+kubectl cluster-info
+kubectl get nodes
+```
+
+Show the user the active context name. If multiple contexts exist (`kubectl config get-contexts`), use `AskUserQuestion` to confirm. open-forge does not provision clusters; the user owns that step in their cloud's k8s-cluster UI / CLI (`eksctl`, `gcloud container clusters create`, `doctl kubernetes cluster create`, k3s installer, etc.). See `references/runtimes/kubernetes.md` for the per-cluster `kubeconfig` setup commands.
 
 ## Step 6 — region (only when applicable)
 

--- a/plugins/open-forge/skills/open-forge/references/projects/openclaw.md
+++ b/plugins/open-forge/skills/open-forge/references/projects/openclaw.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-project
-description: OpenClaw recipe for open-forge — a self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game). Covers install on AWS Lightsail (vendor blueprint or Ubuntu VM), AWS EC2, Hetzner Cloud, DigitalOcean, GCP Compute Engine, any Linux VPS (bring-your-own), and localhost. Supports any model provider (Anthropic / OpenAI / Google / Bedrock / local). Pairs with references/runtimes/{docker,native}.md, references/infra/*.md, and references/modules/tunnels.md as needed.
+description: OpenClaw recipe for open-forge — a self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game). Covers all upstream-blessed install paths: AWS Lightsail (vendor blueprint), Docker Compose (any infra), native installer (any Linux/macOS), and Kubernetes via the official Helm chart (any k8s cluster — managed EKS/GKE/AKS/DOKS, self-hosted k3s, or local Docker Desktop). Supports any model provider (Anthropic / OpenAI / Google / Bedrock / local). Pairs with references/runtimes/{docker,native,kubernetes}.md, references/infra/*.md, and references/modules/tunnels.md as needed.
 ---
 
 # OpenClaw
@@ -23,9 +23,10 @@ Self-hosted personal AI agent with web browsing, file access, shell execution, a
 | GCP | Docker | `infra/gcp/compute-engine.md` + `runtimes/docker.md` | Compute Engine VM; needs `gcloud` configured |
 | GCP | native | `infra/gcp/compute-engine.md` + `runtimes/native.md` | |
 | BYO VPS (any other provider, on-prem) | Docker or native | `infra/byo-vps.md` + `runtimes/{docker,native}.md` | Catch-all when no dedicated adapter exists |
-| **localhost** | Docker Desktop / native | `infra/localhost.md` + `runtimes/{docker,native}.md` | Upstream's default path (openclaw.ai's installer is designed for local). Public reach via `references/modules/tunnels.md`. |
+| Any k8s cluster (EKS / GKE / AKS / DOKS / k3s on a VM) | Kubernetes (Helm) | user-provisioned cluster + `runtimes/kubernetes.md` | Uses the upstream Helm chart at `charts.openclaw.ai`. open-forge does **not** provision the cluster — point `kubectl` at one and we'll deploy into it. |
+| **localhost** | Docker Desktop / native / Docker-Desktop-Kubernetes | `infra/localhost.md` + `runtimes/{docker,native,kubernetes}.md` | Upstream's default path (openclaw.ai's installer is designed for local). Public reach via `references/modules/tunnels.md`. |
 
-The dynamic **how** question's options come from this table filtered by the user's **where** answer. On AWS the blueprint is the recommended default; on localhost the native installer is (simpler than Docker Desktop for most users).
+The dynamic **how** question's options come from this table filtered by the user's **where** answer. On AWS the blueprint is the recommended default; on localhost the native installer is (simpler than Docker Desktop for most users); for k8s the official Helm chart is the only path.
 
 ## Inputs to collect
 
@@ -397,6 +398,82 @@ For public reach on a remote host, see `runtimes/native.md` § *Reverse proxy* (
 
 ---
 
+## Kubernetes (any cluster — managed or self-hosted)
+
+When the user picks **any k8s cluster → Helm chart**. Pair with [`references/runtimes/kubernetes.md`](../runtimes/kubernetes.md) for kubectl/Helm prereqs, namespace + secret hygiene, ingress/cert-manager guidance.
+
+Upstream docs: <https://docs.openclaw.ai/install/kubernetes>. Official chart repo: `https://charts.openclaw.ai`.
+
+### Prereqs (cluster-side)
+
+- A reachable k8s cluster (`kubectl get nodes` returns ready nodes).
+- A default `StorageClass` (the chart creates a PVC for `~/.openclaw/`).
+- An ingress controller (nginx-ingress, Traefik, or a cloud-native one) **if** you want public reach via Ingress; not required if you'll use a `LoadBalancer` Service or just `kubectl port-forward`.
+- cert-manager (only if using Ingress + automatic Let's Encrypt).
+
+### Install
+
+```bash
+helm repo add openclaw https://charts.openclaw.ai
+helm repo update
+
+kubectl create namespace openclaw
+
+# Inline secret — fine for hobby; pre-create a Secret for shared clusters (see runtimes/kubernetes.md)
+helm install openclaw openclaw/openclaw \
+  --namespace openclaw \
+  --set config.anthropicApiKey="<paste>" \
+  --set ingress.enabled=true \
+  --set ingress.host=<your-domain> \
+  --set ingress.tls.enabled=true \
+  --set ingress.tls.issuer=letsencrypt-prod
+```
+
+For other model providers, the chart accepts `config.openaiApiKey`, `config.googleApiKey`, etc. — confirm exact value paths via `helm show values openclaw/openclaw` before installing.
+
+### Verify
+
+```bash
+kubectl -n openclaw get pods,svc,ingress,pvc
+kubectl -n openclaw rollout status deploy/openclaw
+kubectl -n openclaw logs deploy/openclaw -f         # watch onboarding output
+kubectl -n openclaw port-forward svc/openclaw 18789:18789   # local probe before DNS lands
+```
+
+Health: `curl -sI http://127.0.0.1:18789/healthz` through the port-forward should return `200`. The chart wires the gateway token into the pod's environment + `~/.openclaw/openclaw.json`.
+
+### Pairing approval (Kubernetes)
+
+`openclaw devices approve` must run inside the gateway pod where the device-pairing state lives:
+
+```bash
+kubectl -n openclaw exec deploy/openclaw -- bash -lc \
+  'TOKEN=$(jq -r .gateway.auth.token ~/.openclaw/openclaw.json); openclaw devices approve --latest --token "$TOKEN"'
+```
+
+Same `--latest` rule applies (see *Two-layer auth model* above).
+
+### Upgrades
+
+```bash
+helm repo update
+helm upgrade openclaw openclaw/openclaw \
+  --namespace openclaw \
+  --reuse-values
+```
+
+The chart uses `strategy: Recreate` (single-instance — can't run two replicas). Expect a brief downtime gap during upgrades.
+
+### Kubernetes-specific gotchas (OpenClaw-only)
+
+- **PVC survives `helm uninstall`.** The gateway's identity, paired devices, and `openclaw.json` (with the gateway token) all live on the PVC. Reinstalling the chart in the same namespace re-binds to the existing data — paired browsers keep working. To wipe state, delete the PVC explicitly. (See `runtimes/kubernetes.md` § *Persistent storage*.)
+- **No automatic Bedrock cross-account assumption.** Like Docker, the chart has no equivalent of the Lightsail blueprint's IAM scaffolding. Pass an Anthropic / OpenAI / Google key directly, or set up your own AWS credentials (IRSA on EKS, Workload Identity on GKE) inside the pod.
+- **`onboard` is interactive — chart side-steps it.** The chart sets `gateway.mode=local`, generates a token, and bakes the API key from the Secret directly into `openclaw.json` — `openclaw onboard` is **not** invoked at startup. If you need to switch providers post-install, edit values + `helm upgrade`, don't `kubectl exec` into the pod and run `openclaw configure`.
+- **Single-instance only.** OpenClaw holds local browser-pairing state — replicas would diverge. Don't `--set replicaCount=2` even if the chart accepts the value.
+- **`openclaw devices approve` must run in the pod**, not on the user's laptop, because the pairing state is in the pod's PVC. The exec line above handles this.
+
+---
+
 ## Verification before marking `provision` done
 
 - Gateway process alive: `systemctl --user is-active openclaw-gateway` (native) or `docker compose ps` (Docker).
@@ -415,7 +492,7 @@ Universal:
 - **`openclaw onboard` / `openclaw configure` are interactive.** Don't try to automate — pause open-forge's autonomous mode.
 - **Model costs compound.** Long agent runs can burn tokens fast. Set spend limits at the provider dashboard before first real use.
 
-AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — see *Docker-specific gotchas* + `runtimes/docker.md` § *Common gotchas*. Native — see *Native-specific gotchas* + `runtimes/native.md` § *Common gotchas*.
+AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — see *Docker-specific gotchas* + `runtimes/docker.md` § *Common gotchas*. Native — see *Native-specific gotchas* + `runtimes/native.md` § *Common gotchas*. Kubernetes — see *Kubernetes-specific gotchas* + `runtimes/kubernetes.md` § *Common gotchas*.
 
 ---
 
@@ -426,3 +503,9 @@ AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — se
 - Behavior when both Bedrock and a non-Bedrock provider are configured simultaneously.
 - Native installer on macOS (only exercised on Linux so far).
 - Docker runtime end-to-end (verified commands only; first full deploy will surface gotchas to fold back here).
+- Kubernetes / Helm chart end-to-end. Open questions to resolve on the first real cluster deploy:
+  - Exact value paths for non-Anthropic providers (`config.openaiApiKey` etc. is assumed; verify against `helm show values openclaw/openclaw`).
+  - Whether the chart pre-creates an Ingress + cert-manager `Issuer`, or expects them externally.
+  - Whether `--set existingSecret=<name>` is supported and how the chart looks up keys inside it.
+  - Whether `openclaw devices approve` has any chart-provided wrapper (CronJob, Helm hook, sidecar) that obviates `kubectl exec`.
+  - Behavior of `helm uninstall` on the auto-generated gateway token Secret (deleted with the release? orphaned?).

--- a/plugins/open-forge/skills/open-forge/references/projects/openclaw.md
+++ b/plugins/open-forge/skills/open-forge/references/projects/openclaw.md
@@ -1,6 +1,6 @@
 ---
 name: openclaw-project
-description: OpenClaw recipe for open-forge — a self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game). Covers all upstream-blessed install paths: AWS Lightsail (vendor blueprint), Docker Compose (any infra), native installer (any Linux/macOS), and Kubernetes via the official Helm chart (any k8s cluster — managed EKS/GKE/AKS/DOKS, self-hosted k3s, or local Docker Desktop). Supports any model provider (Anthropic / OpenAI / Google / Bedrock / local). Pairs with references/runtimes/{docker,native,kubernetes}.md, references/infra/*.md, and references/modules/tunnels.md as needed.
+description: OpenClaw recipe for open-forge — a self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game). Covers every upstream-blessed install path documented under docs.openclaw.ai/install/* — Containers (Docker, Podman, Kubernetes/Kustomize, ClawDock, Ansible, Nix, Bun) and Hosting (AWS Lightsail blueprint, Azure VM, DigitalOcean, GCP, Hetzner, Hostinger, Oracle Cloud free-tier ARM, Raspberry Pi, macOS VMs via Lume, Linux Server via BYO VPS, native installers including install.sh / install-cli.sh / install.ps1, plus PaaS one-clicks: Fly.io, Render, Railway, Northflank, exe.dev). Supports any model provider (Anthropic / OpenAI / Google / Bedrock / GitHub Copilot / xAI / local). Pairs with references/runtimes/{docker,native,kubernetes,podman}.md, references/infra/*.md, and references/modules/tunnels.md as needed.
 ---
 
 # OpenClaw
@@ -9,24 +9,48 @@ Self-hosted personal AI agent with web browsing, file access, shell execution, a
 
 ## Compatible combos
 
-| Where (infra) | How (service × runtime) | Adapter / runtime | Notes |
-|---|---|---|---|
-| **AWS Lightsail** | **OpenClaw blueprint** | `infra/aws/lightsail.md` (vendor-bundled runtime) | Fastest on AWS; Bedrock pre-wired via cross-account role. Requires a one-time IAM setup script. |
-| AWS Lightsail | Ubuntu VM + Docker | `infra/aws/lightsail.md` + `runtimes/docker.md` | Use this if you don't want the vendor blueprint's Bedrock lock-in |
-| AWS Lightsail | Ubuntu VM + native installer | `infra/aws/lightsail.md` + `runtimes/native.md` | Same as above, no container |
-| AWS EC2 | Docker | `infra/aws/ec2.md` + `runtimes/docker.md` | More control than Lightsail; security groups and AMI choice |
-| AWS EC2 | native | `infra/aws/ec2.md` + `runtimes/native.md` | Same as above, no container |
-| Hetzner Cloud | Docker | `infra/hetzner/cloud-cx.md` + `runtimes/docker.md` | Cheapest VPS option; EU-regulated |
-| Hetzner Cloud | native | `infra/hetzner/cloud-cx.md` + `runtimes/native.md` | |
-| DigitalOcean | Docker | `infra/digitalocean/droplet.md` + `runtimes/docker.md` | Single-click droplets; integrated firewall |
-| DigitalOcean | native | `infra/digitalocean/droplet.md` + `runtimes/native.md` | |
-| GCP | Docker | `infra/gcp/compute-engine.md` + `runtimes/docker.md` | Compute Engine VM; needs `gcloud` configured |
-| GCP | native | `infra/gcp/compute-engine.md` + `runtimes/native.md` | |
-| BYO VPS (any other provider, on-prem) | Docker or native | `infra/byo-vps.md` + `runtimes/{docker,native}.md` | Catch-all when no dedicated adapter exists |
-| Any k8s cluster (EKS / GKE / AKS / DOKS / k3s on a VM) | Kubernetes (Helm) | user-provisioned cluster + `runtimes/kubernetes.md` | Uses the upstream Helm chart at `charts.openclaw.ai`. open-forge does **not** provision the cluster — point `kubectl` at one and we'll deploy into it. |
-| **localhost** | Docker Desktop / native / Docker-Desktop-Kubernetes | `infra/localhost.md` + `runtimes/{docker,native,kubernetes}.md` | Upstream's default path (openclaw.ai's installer is designed for local). Public reach via `references/modules/tunnels.md`. |
+OpenClaw upstream documents two parallel axes — **how to package it** (Containers) and **where to host it** (Hosting). open-forge maps these onto our 3-layer model: a where-answer picks an infra adapter, a how-answer picks a runtime module, and the upstream-specific commands live in the per-method sections below.
 
-The dynamic **how** question's options come from this table filtered by the user's **where** answer. On AWS the blueprint is the recommended default; on localhost the native installer is (simpler than Docker Desktop for most users); for k8s the official Helm chart is the only path.
+### Hosting (where) — picks the infra adapter
+
+| Where | Adapter | Recommended runtime | Notes |
+|---|---|---|---|
+| **AWS Lightsail** (OpenClaw blueprint) | `infra/aws/lightsail.md` | vendor-bundled (native) | Fastest on AWS; Bedrock pre-wired via cross-account role. Requires a one-time IAM setup script. |
+| **AWS Lightsail** (Ubuntu VM) | `infra/aws/lightsail.md` | `docker` or `native` | When you don't want the blueprint's Bedrock lock-in |
+| **AWS EC2** | `infra/aws/ec2.md` | `docker` or `native` | More control than Lightsail; security groups and AMI choice |
+| **Azure** | `infra/azure/vm.md` | `docker` or `native` | Bastion-hardened (no public IP); good for enterprise + GitHub Copilot users |
+| **Hetzner Cloud** | `infra/hetzner/cloud-cx.md` | `docker` or `native` | Cheapest serious-VPS tier; EU-regulated |
+| **DigitalOcean** | `infra/digitalocean/droplet.md` | `docker` or `native` | Polished UX; integrated firewall |
+| **GCP Compute Engine** | `infra/gcp/compute-engine.md` | `docker` or `native` | Tag-targeted firewall, static IP |
+| **Oracle Cloud** (Always-Free ARM) | `infra/oracle/free-tier-arm.md` | `native` | Genuinely free, indefinitely; ARM (aarch64); reach via Tailscale |
+| **Hostinger** (Managed OpenClaw) | (none — Hostinger Console drives it) | vendor-bundled | 1-click managed; or "OpenClaw on VPS" via Hostinger Docker Manager |
+| **Raspberry Pi** | `infra/byo-vps.md` (host, 64-bit Pi OS) | `native` | Pi 4/5 (4 GB+); ARM; always-on home self-host |
+| **macOS VM** (Lume on Apple Silicon) | `infra/macos-vm.md` | `native` | Use only when you need iMessage via BlueBubbles or strict isolation from your daily Mac |
+| **Linux Server / BYO VPS** | `infra/byo-vps.md` | `docker` or `native` | Catch-all for any provisioned Linux box (Vultr, Linode, on-prem, etc.) |
+| **localhost** | `infra/localhost.md` | `docker` or `native` | Upstream's default path. Public reach via `references/modules/tunnels.md`. |
+| **Fly.io** | `infra/paas/fly.md` | (PaaS bundles runtime) | Persistent volumes + auto-HTTPS. Two modes: public + private (no public IP). |
+| **Render** | `infra/paas/render.md` | (PaaS bundles runtime) | Blueprint-based (`render.yaml` lives in upstream repo). |
+| **Railway** | `infra/paas/railway.md` | (PaaS bundles runtime) | One-click template; required env vars + volume at `/data`. |
+| **Northflank** | `infra/paas/northflank.md` | (PaaS bundles runtime) | One-click stack; persistent `/data` volume. |
+| **exe.dev** | `infra/paas/exe-dev.md` | (PaaS bundles runtime) | Shelley agent does provisioning; `<vm>.exe.xyz` HTTPS proxy. |
+| **Any Kubernetes cluster** (EKS / GKE / AKS / DOKS / k3s / kind / Docker-Desktop-K8s) | user-provisioned cluster | `kubernetes` | Upstream uses **Kustomize** via `scripts/k8s/deploy.sh` (Helm is community-only). |
+
+### Containers (how) — picks the runtime module
+
+| How | Runtime | Notes |
+|---|---|---|
+| **Docker** | `runtimes/docker.md` | The upstream-recommended default for VPS-style hosts. Setup script: `./scripts/docker/setup.sh` from the openclaw repo. |
+| **Podman** | `runtimes/podman.md` | Rootless Docker-compatible alternative. Setup: `./scripts/podman/setup.sh`. Quadlet (systemd-user) supported. |
+| **Kubernetes** | `runtimes/kubernetes.md` | **Kustomize-first** — `./scripts/k8s/deploy.sh` from the openclaw repo. Community Helm charts exist but are not upstream-blessed. |
+| **Native** (`install.sh`) | `runtimes/native.md` | macOS / Linux / WSL2 — global Node + project install. systemd / launchd daemon. |
+| **Native** (`install-cli.sh`) | `runtimes/native.md` | macOS / Linux / WSL2 — local-prefix install (`~/.openclaw` by default). No root required. |
+| **Native** (`install.ps1`) | `runtimes/native.md` | Native Windows (PowerShell 5+). Scheduled Task daemon. |
+| **ClawDock** | (shell wrapper over Docker — see project-specific section below) | Optional UX layer: `clawdock-start`, `clawdock-dashboard` instead of `docker compose ...`. |
+| **Ansible** | (production hardening — see project-specific section below) | The `openclaw-ansible` upstream repo: UFW + Tailscale + Docker-isolated sandbox + systemd-hardened gateway. Native (not containerized) gateway. |
+| **Nix** | (declarative — see project-specific section below) | The `nix-openclaw` Home Manager module: rollback-able, deterministic, launchd-managed (macOS). |
+| **Bun** (experimental) | (dev-only — see project-specific section below) | TypeScript runtime swap for `bun run` / `bun --watch`. **Not recommended for gateway runtime** (WhatsApp + Telegram issues). |
+
+The dynamic **how** question's options come from filtering this table by the user's **where** answer. On AWS the blueprint is the recommended default; on localhost the native installer is simpler than Docker Desktop for most users; for k8s the upstream Kustomize flow is the supported path.
 
 ## Inputs to collect
 
@@ -356,29 +380,86 @@ docker compose run --rm openclaw-cli devices approve --latest \
 
 ---
 
-## Native installer (any Linux/macOS host without Docker)
+## Native installer (Linux / macOS / Windows / WSL)
 
-When the user picks **any Linux/macOS host → native installer** or **localhost → native**. Pair with [`references/runtimes/native.md`](../runtimes/native.md) for the host-level prereqs (build tools, systemd/launchd lifecycle, reverse proxy guidance).
+Three official installer scripts, served from `openclaw.ai`. Pair with [`references/runtimes/native.md`](../runtimes/native.md) for the host-level prereqs (build tools, systemd/launchd/Scheduled-Tasks lifecycle, reverse proxy guidance).
 
-### Install
+| Script | Platform | When |
+|---|---|---|
+| `install.sh` | macOS / Linux / WSL2 | Default. Global install (system-wide Node). |
+| `install-cli.sh` | macOS / Linux / WSL2 | Local prefix (default `~/.openclaw`). No root required. |
+| `install.ps1` | Native Windows (PS 5+) | Installs Node via winget/Chocolatey/Scoop, then OpenClaw via npm. |
+
+Upstream docs: <https://docs.openclaw.ai/install/installer> and `<https://docs.openclaw.ai/install/installer#installsh>` / `#install-clish` / `#installps1`.
+
+### `install.sh` — macOS / Linux / WSL2 (default)
 
 ```bash
-# Linux: native.md installs build-essential / curl / ca-certificates first.
-# macOS: native.md installs Xcode CLI tools first.
-
-# Official installer (same on Linux + macOS)
-curl -fsSL https://openclaw.ai/install.sh | bash
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install.sh | bash
 exec $SHELL -l
 openclaw --version
 openclaw onboard --install-daemon    # interactive — pause autonomous mode; user picks provider, pastes API key
 openclaw gateway status
 ```
 
-The installer drops a systemd user unit on Linux and a launchd plist on macOS. Lifecycle commands (`status` / `restart` / `journalctl`) are in `runtimes/native.md`.
+The installer drops a systemd **user** unit on Linux and a launchd plist on macOS. Lifecycle commands (`status` / `restart` / `journalctl`) are in `runtimes/native.md`. Defaults to **Node 24** (Node 22.14+ also supported); installs Git if missing; sets `SHARP_IGNORE_GLOBAL_LIBVIPS=1`.
 
-### Access
+Useful flags / env:
 
-Gateway binds to `127.0.0.1:18789`. Two paths to reach it:
+| Flag / env | Effect |
+|---|---|
+| `--no-onboard` / `OPENCLAW_NO_ONBOARD=1` | Skip the post-install wizard (Claude pre-stages config later) |
+| `--no-prompt` / `OPENCLAW_NO_PROMPT=1` | Disable interactive prompts |
+| `--install-method git\|npm` | npm registry vs git checkout (default `npm`) |
+| `--version <ver>` | Pin a version, dist-tag (`latest` / `next` / `main`), or full package spec |
+| `--beta` / `OPENCLAW_BETA=1` | Use the beta dist-tag if published |
+| `--dry-run` | Print actions without executing — confirm before committing |
+
+### `install-cli.sh` — local prefix (no root)
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash
+# or pin a custom prefix:
+curl -fsSL --proto '=https' --tlsv1.2 https://openclaw.ai/install-cli.sh | bash -s -- --prefix /opt/openclaw
+exec $SHELL -l
+"$HOME/.openclaw/bin/openclaw" --version
+```
+
+Downloads a pinned Node tarball (SHA-256 verified) into `<prefix>/tools/node-v<version>` and writes the wrapper at `<prefix>/bin/openclaw`. Useful when:
+
+- You can't write to `/usr/local/`.
+- The host has a Node version openclaw can't use (or none at all).
+- You want multiple openclaw versions side-by-side under different prefixes.
+
+Useful flags:
+
+| Flag | Effect |
+|---|---|
+| `--prefix <path>` | Install root (default `~/.openclaw`) |
+| `--node-version <ver>` | Pin Node version inside the prefix |
+| `--json` | Emit NDJSON events — for CI/automation |
+| `--onboard` | Run the wizard after install (default skips) |
+
+### `install.ps1` — native Windows
+
+```powershell
+iwr -useb https://openclaw.ai/install.ps1 | iex
+openclaw --version
+openclaw onboard --install-daemon
+openclaw gateway status
+```
+
+Installs Node via `winget` → `Chocolatey` → `Scoop` (first available wins). Daemon autostart uses **Scheduled Tasks**; manage via PowerShell's `Get-ScheduledTask -TaskName "openclaw*"`. Requires PS 5+.
+
+For non-interactive runs:
+
+```powershell
+& ([scriptblock]::Create((iwr -useb https://openclaw.ai/install.ps1))) -NoOnboard
+```
+
+### Access (all three modes)
+
+Gateway binds to `127.0.0.1:18789`. Three paths to reach it:
 
 ```bash
 # Remote host — SSH tunnel
@@ -387,90 +468,359 @@ ssh -L 18789:127.0.0.1:18789 <user>@<host>
 
 # Localhost — open directly
 # http://localhost:18789/#token=<TOKEN>
+
+# `openclaw dashboard` prints the URL with token fragment
+openclaw dashboard --no-open
 ```
 
-For public reach on a remote host, see `runtimes/native.md` § *Reverse proxy* (Caddy is recommended for new installs; if you're on a Bitnami/Lightsail-blueprint host, Apache is already wired).
+For public reach on a remote host, see `runtimes/native.md` § *Reverse proxy* (Caddy is recommended for new installs; on a Bitnami/Lightsail-blueprint host, Apache is already wired).
 
 ### Native-specific gotchas (OpenClaw-only)
 
-- **Node version mismatch after reboot.** The installer pins a specific Node. If the user has nvm or a system Node, verify `openclaw gateway status` after a deliberate reboot, not just right after install. (See `runtimes/native.md` § *PATH not refreshed* and *Node / Python version pinning* for general handling.)
-- **`openclaw onboard` and `openclaw configure` are interactive** — pause autonomous mode. The native installer never has a non-interactive flow today.
+- **Three installers don't share state.** A user who ran `install.sh` and later `install-cli.sh` has two `openclaw` binaries on PATH; whichever appears first in shell rc wins. Pick one and stick with it.
+- **Node version mismatch after reboot.** `install.sh` and `install.ps1` use the system Node. If the user has nvm / `pyenv`-style Node managers / a system Node from another package, verify `openclaw gateway status` after a deliberate reboot. `install-cli.sh` ships its own pinned Node and is immune to this.
+- **`openclaw onboard` and `openclaw configure` are interactive** — pause autonomous mode. There is no fully non-interactive onboarding today; `--no-onboard` skips the wizard but then the user must `openclaw configure` or hand-edit `openclaw.json` later.
+- **Windows: `iwr | iex` errors are non-fatal to the shell.** A failure inside the piped script reports a terminating error but doesn't close the PowerShell window. Always check the explicit success line — silent partial installs happen on Windows more than elsewhere.
+- **Local-prefix mode + GUI app on macOS.** The macOS GUI app doesn't inherit shell PATH. For Nix-style local-prefix installs the GUI won't see `openclaw`; the CLI still works.
 
 ---
 
 ## Kubernetes (any cluster — managed or self-hosted)
 
-When the user picks **any k8s cluster → Helm chart**. Pair with [`references/runtimes/kubernetes.md`](../runtimes/kubernetes.md) for kubectl/Helm prereqs, namespace + secret hygiene, ingress/cert-manager guidance.
+When the user picks **any k8s cluster → Kustomize**. Pair with [`references/runtimes/kubernetes.md`](../runtimes/kubernetes.md) for kubectl prereqs, namespace + Secret hygiene, ingress/cert-manager guidance.
 
-Upstream docs: <https://docs.openclaw.ai/install/kubernetes>. Official chart repo: `https://charts.openclaw.ai`.
+Upstream docs: <https://docs.openclaw.ai/install/kubernetes>. The supported path is **Kustomize**, not Helm. Upstream explicitly says: *"OpenClaw is a single container with some config files. The interesting customization is in agent content (markdown files, skills, config overrides), not infrastructure templating. Kustomize handles overlays without the overhead of a Helm chart."* Community Helm charts exist (`Chrisbattarbee/openclaw-helm`, `serhanekicii/openclaw-helm`) but are not upstream-blessed.
 
 ### Prereqs (cluster-side)
 
-- A reachable k8s cluster (`kubectl get nodes` returns ready nodes).
-- A default `StorageClass` (the chart creates a PVC for `~/.openclaw/`).
-- An ingress controller (nginx-ingress, Traefik, or a cloud-native one) **if** you want public reach via Ingress; not required if you'll use a `LoadBalancer` Service or just `kubectl port-forward`.
-- cert-manager (only if using Ingress + automatic Let's Encrypt).
+- A reachable k8s cluster (`kubectl get nodes` returns ready nodes). Local testing: `kind create cluster` works (upstream ships `./scripts/k8s/create-kind.sh`).
+- A default `StorageClass` (`scripts/k8s/manifests/pvc.yaml` requests 10 GiB).
+- An API key for at least one model provider (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `OPENROUTER_API_KEY`).
 
-### Install
+No ingress controller required for the default flow — upstream's manifests bind the gateway to **loopback inside the pod** and expect access via `kubectl port-forward`. Public access requires switching the bind to non-loopback (see *Going beyond port-forward* below).
+
+### Install (upstream `deploy.sh`)
 
 ```bash
-helm repo add openclaw https://charts.openclaw.ai
-helm repo update
+git clone https://github.com/openclaw/openclaw.git
+cd openclaw
 
-kubectl create namespace openclaw
-
-# Inline secret — fine for hobby; pre-create a Secret for shared clusters (see runtimes/kubernetes.md)
-helm install openclaw openclaw/openclaw \
-  --namespace openclaw \
-  --set config.anthropicApiKey="<paste>" \
-  --set ingress.enabled=true \
-  --set ingress.host=<your-domain> \
-  --set ingress.tls.enabled=true \
-  --set ingress.tls.issuer=letsencrypt-prod
+# Replace ANTHROPIC with your provider as needed: GEMINI / OPENAI / OPENROUTER
+export ANTHROPIC_API_KEY="..."
+./scripts/k8s/deploy.sh
 ```
 
-For other model providers, the chart accepts `config.openaiApiKey`, `config.googleApiKey`, etc. — confirm exact value paths via `helm show values openclaw/openclaw` before installing.
+The script creates a namespace (`openclaw` by default; override with `OPENCLAW_NAMESPACE=...`), generates a gateway token, creates the `openclaw-secrets` Secret with your API key + token, then `kubectl apply -k`s the manifests. It's idempotent — re-running preserves existing keys not being changed.
+
+For local debug runs, `./scripts/k8s/deploy.sh --show-token` prints the gateway token to stdout. Otherwise:
+
+```bash
+kubectl get secret openclaw-secrets -n openclaw \
+  -o jsonpath='{.data.OPENCLAW_GATEWAY_TOKEN}' | base64 -d
+```
 
 ### Verify
 
 ```bash
-kubectl -n openclaw get pods,svc,ingress,pvc
+kubectl -n openclaw get pods,svc,pvc,configmap,secret
 kubectl -n openclaw rollout status deploy/openclaw
-kubectl -n openclaw logs deploy/openclaw -f         # watch onboarding output
-kubectl -n openclaw port-forward svc/openclaw 18789:18789   # local probe before DNS lands
+kubectl -n openclaw logs deploy/openclaw -f
+kubectl -n openclaw port-forward svc/openclaw 18789:18789
 ```
 
-Health: `curl -sI http://127.0.0.1:18789/healthz` through the port-forward should return `200`. The chart wires the gateway token into the pod's environment + `~/.openclaw/openclaw.json`.
-
-### Pairing approval (Kubernetes)
-
-`openclaw devices approve` must run inside the gateway pod where the device-pairing state lives:
+Then open `http://localhost:18789` and authenticate with the gateway token (from the Secret). Pairing approval flows through the same `openclaw devices approve --latest --token "$TOKEN"` command as elsewhere — but it must run **inside the pod** where the pairing state lives:
 
 ```bash
 kubectl -n openclaw exec deploy/openclaw -- bash -lc \
   'TOKEN=$(jq -r .gateway.auth.token ~/.openclaw/openclaw.json); openclaw devices approve --latest --token "$TOKEN"'
 ```
 
-Same `--latest` rule applies (see *Two-layer auth model* above).
+### Customization
 
-### Upgrades
+| Change | How |
+|---|---|
+| Agent instructions | Edit `AGENTS.md` in `scripts/k8s/manifests/configmap.yaml`, then re-run `./scripts/k8s/deploy.sh` |
+| Gateway config (`openclaw.json`) | Edit `scripts/k8s/manifests/configmap.yaml`; same redeploy |
+| Add provider keys | Re-run `./scripts/k8s/deploy.sh --create-secret` with new env vars exported. Existing keys stay unless overwritten. |
+| Custom namespace | `OPENCLAW_NAMESPACE=my-namespace ./scripts/k8s/deploy.sh` |
+| Custom image / version | Edit `image:` in `scripts/k8s/manifests/deployment.yaml` (e.g. pin `ghcr.io/openclaw/openclaw:v<version>`) |
+
+Direct Secret patch (skips re-running `deploy.sh`):
 
 ```bash
-helm repo update
-helm upgrade openclaw openclaw/openclaw \
-  --namespace openclaw \
-  --reuse-values
+kubectl patch secret openclaw-secrets -n openclaw \
+  -p '{"stringData":{"OPENAI_API_KEY":"..."}}'
+kubectl rollout restart deployment/openclaw -n openclaw
 ```
 
-The chart uses `strategy: Recreate` (single-instance — can't run two replicas). Expect a brief downtime gap during upgrades.
+### Going beyond port-forward (Service / Ingress)
+
+The default manifests bind the gateway to loopback **inside the pod**, so a Kubernetes `Service` or Ingress that targets the pod IP won't reach it. To expose:
+
+1. Edit `scripts/k8s/manifests/configmap.yaml` and change the gateway bind from `loopback` to a non-loopback mode that matches your deployment (e.g. `lan` if behind a TLS-terminating proxy).
+2. Keep gateway auth enabled.
+3. Add an Ingress + cert-manager `ClusterIssuer` (see `runtimes/kubernetes.md` § *Reaching the service from outside*).
+4. Set `gateway.controlUi.allowedOrigins` to include your public origin.
+
+Or use Tailscale Serve / Funnel side-channel instead of opening the cluster — see `references/modules/tunnels.md`.
+
+### Teardown
+
+```bash
+./scripts/k8s/deploy.sh --delete
+```
+
+Deletes the namespace and everything in it — **including the PVC**. The gateway token and paired-device state are gone. To preserve, snapshot the PVC first or take a backup via `openclaw backup create` before deleting.
 
 ### Kubernetes-specific gotchas (OpenClaw-only)
 
-- **PVC survives `helm uninstall`.** The gateway's identity, paired devices, and `openclaw.json` (with the gateway token) all live on the PVC. Reinstalling the chart in the same namespace re-binds to the existing data — paired browsers keep working. To wipe state, delete the PVC explicitly. (See `runtimes/kubernetes.md` § *Persistent storage*.)
-- **No automatic Bedrock cross-account assumption.** Like Docker, the chart has no equivalent of the Lightsail blueprint's IAM scaffolding. Pass an Anthropic / OpenAI / Google key directly, or set up your own AWS credentials (IRSA on EKS, Workload Identity on GKE) inside the pod.
-- **`onboard` is interactive — chart side-steps it.** The chart sets `gateway.mode=local`, generates a token, and bakes the API key from the Secret directly into `openclaw.json` — `openclaw onboard` is **not** invoked at startup. If you need to switch providers post-install, edit values + `helm upgrade`, don't `kubectl exec` into the pod and run `openclaw configure`.
-- **Single-instance only.** OpenClaw holds local browser-pairing state — replicas would diverge. Don't `--set replicaCount=2` even if the chart accepts the value.
-- **`openclaw devices approve` must run in the pod**, not on the user's laptop, because the pairing state is in the pod's PVC. The exec line above handles this.
+- **Kustomize, not Helm — even though community Helm charts exist.** Don't trust a `helm install openclaw/openclaw` snippet from a third-party blog as upstream-blessed; it isn't. Stick with `./scripts/k8s/deploy.sh` unless the user explicitly chose a community chart.
+- **Loopback-bind by default.** `kubectl port-forward` is the access path. A `Service` of type `LoadBalancer` or `ClusterIP` won't work without first switching the bind in the ConfigMap. Symptom: pod healthy but `curl <svc-ip>:18789` hangs.
+- **Re-running `deploy.sh` preserves existing Secret keys.** Adding `OPENAI_API_KEY` to a previously Anthropic-only deploy works; both stay in the Secret. Removing a key requires explicit `kubectl patch` (or editing the Secret YAML and re-applying).
+- **Single-instance only.** OpenClaw holds local pairing state — replicas would diverge. Don't increase replica count even if the deployment YAML accepts it.
+- **`openclaw devices approve` must run in the pod**, not on the user's laptop, because pairing state is in the pod's PVC. The `kubectl exec` line above handles this.
+- **No automatic Bedrock IAM.** No equivalent of the Lightsail blueprint's cross-account assume-role. Pass an Anthropic / OpenAI / Gemini / OpenRouter key directly via env vars to `deploy.sh`, or set up IRSA (EKS) / Workload Identity (GKE) yourself.
+- **Hardened pod security context.** The pod runs as UID 1000, `readOnlyRootFilesystem: true`, all capabilities dropped. If you customize the image, preserve these or things break.
+- **Kind cluster ergonomics.** `./scripts/k8s/create-kind.sh` auto-detects Docker vs Podman; `--delete` tears down. Useful for verifying the deploy flow before pointing at a real managed cluster.
+
+---
+
+## Podman runtime (rootless container alternative to Docker)
+
+When the user picks **any Linux host → Podman**. Pair with [`references/runtimes/podman.md`](../runtimes/podman.md) for rootless setup, Quadlet integration, and SELinux quirks.
+
+Upstream docs: <https://docs.openclaw.ai/install/podman>. The intended model is "Podman runs the container; the host `openclaw` CLI is the control plane via `OPENCLAW_CONTAINER=openclaw`."
+
+### Install
+
+```bash
+git clone https://github.com/openclaw/openclaw.git ~/openclaw
+cd ~/openclaw
+./scripts/podman/setup.sh                 # rootless build + ~/.openclaw seeding
+# Optional, for systemd-user auto-start:
+./scripts/podman/setup.sh --quadlet
+```
+
+`setup.sh` builds `openclaw:local` in the rootless Podman store, creates `~/.openclaw/openclaw.json` with `gateway.mode: "local"`, generates `~/.openclaw/.env` with `OPENCLAW_GATEWAY_TOKEN`, and (with `--quadlet`) installs `~/.config/containers/systemd/openclaw.container`.
+
+### Run
+
+```bash
+./scripts/run-openclaw-podman.sh launch          # start the container
+./scripts/run-openclaw-podman.sh launch setup    # start + run onboarding inside
+
+# Day-to-day from the host CLI:
+export OPENCLAW_CONTAINER=openclaw               # makes openclaw commands target the container
+openclaw dashboard --no-open
+openclaw gateway status --deep
+openclaw doctor
+openclaw channels login
+```
+
+Quadlet commands (if installed):
+
+```bash
+systemctl --user start openclaw.service
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -f
+sudo loginctl enable-linger "$(whoami)"          # for boot persistence on headless hosts
+```
+
+### Podman-specific gotchas (OpenClaw-only)
+
+- **`OPENCLAW_CONTAINER=openclaw` is the magic env var.** Without it, host `openclaw` commands run on the host (not the container) and act on a non-existent install. Always export it.
+- **`openclaw update --container` doesn't work.** Rebuild the image with `setup.sh` (or pull a new tag) and restart the container/Quadlet service instead.
+- **macOS Podman machine + browser device-auth.** On macOS, the Podman VM presents the gateway as non-local to the browser, which can fail device-auth checks. Use Tailscale Serve instead of ad hoc local tunnels (see [Podman + Tailscale upstream notes](https://docs.openclaw.ai/install/podman)).
+- **SELinux `:Z` is mandatory** on Fedora/RHEL/Amazon Linux. The launch helper auto-adds it; if you script your own `podman run`, don't forget.
+- **Quadlet locks down ports to `127.0.0.1:18789` + `127.0.0.1:18790`.** Override only by editing the `.container` file; don't shadow it via the env file.
+
+---
+
+## ClawDock (shell helpers over Docker Compose)
+
+Optional UX layer for Docker-based deploys — short commands like `clawdock-start`, `clawdock-dashboard`, `clawdock-fix-token` instead of long `docker compose ...` lines. Not a separate runtime — it's a shell-helpers wrapper over the existing Docker Compose flow.
+
+Upstream docs: <https://docs.openclaw.ai/install/clawdock>.
+
+### Install
+
+```bash
+mkdir -p ~/.clawdock
+curl -sL https://raw.githubusercontent.com/openclaw/openclaw/main/scripts/clawdock/clawdock-helpers.sh \
+  -o ~/.clawdock/clawdock-helpers.sh
+echo 'source ~/.clawdock/clawdock-helpers.sh' >> ~/.zshrc       # or ~/.bashrc
+source ~/.zshrc
+```
+
+### Use
+
+```bash
+clawdock-start            # docker compose up -d
+clawdock-status           # status + container ps
+clawdock-logs             # docker compose logs -f
+clawdock-fix-token        # regenerate gateway token
+clawdock-dashboard        # print Control UI URL with token fragment
+clawdock-devices          # list paired devices
+clawdock-approve          # approve --latest
+clawdock-shell            # shell into the gateway container
+clawdock-update           # pull latest image
+clawdock-rebuild          # rebuild image from source
+clawdock-cleanup          # remove containers + volumes (destructive)
+clawdock-config           # cat openclaw.json
+```
+
+### ClawDock-specific gotchas
+
+- **Helper location moved from `scripts/shell-helpers/` to `scripts/clawdock/`.** Old install commands won't find the file.
+- **Helpers wrap `docker compose` (v2) — not `docker-compose` (v1).** If a host has only v1 installed, helpers silently fail. Upgrade to Compose v2.
+- **Not exclusive with the host `openclaw` CLI.** You can use both — `clawdock-*` for compose lifecycle, `openclaw` (with `OPENCLAW_CONTAINER=...` set if needed) for everything else.
+
+---
+
+## Ansible — production-hardened native install
+
+For production servers where the gateway runs **directly on the host** (not in a container) with strict security hardening. Upstream maintains a separate repo: [openclaw-ansible](https://github.com/openclaw/openclaw-ansible). The playbook installs Tailscale + UFW + Docker (only as a sandbox backend) + Node 24 + OpenClaw + a hardened systemd unit.
+
+Upstream docs: <https://docs.openclaw.ai/install/ansible>.
+
+### What you get
+
+- **Firewall (UFW)** — only SSH (port 22) + Tailscale (UDP 41641) exposed to the public internet.
+- **Tailscale VPN** — gateway accessible only via tailnet.
+- **Docker** — installed for **agent sandboxes** (isolated tool execution), not for running the gateway itself.
+- **systemd hardening** — `NoNewPrivileges`, `PrivateTmp`, unprivileged `openclaw` user.
+- **Defense in depth** — UFW + Tailscale + Docker isolation + systemd hardening = 4 layers.
+
+### Install
+
+```bash
+# One-command install on a Debian 11+ / Ubuntu 20.04+ host
+curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/install.sh | bash
+```
+
+That bootstraps Ansible itself if missing, then runs the playbook.
+
+For manual control:
+
+```bash
+sudo apt-get update && sudo apt-get install -y ansible git
+git clone https://github.com/openclaw/openclaw-ansible.git
+cd openclaw-ansible
+ansible-galaxy collection install -r requirements.yml
+./run-playbook.sh                                                 # idempotent
+```
+
+### Post-install
+
+```bash
+sudo -i -u openclaw                                               # switch to the dedicated user
+openclaw onboard                                                  # interactive: model provider + API key
+openclaw channels login                                           # connect WhatsApp / Telegram / Discord / Signal
+
+sudo systemctl status openclaw                                    # daemon running?
+sudo journalctl -u openclaw -f                                    # live logs
+```
+
+Then join the user's tailnet (`tailscale up`) on a second device — the gateway is reachable only via Tailscale by design.
+
+### Ansible-specific gotchas (OpenClaw-only)
+
+- **Gateway runs as `openclaw` user, NOT as a system service or root.** Provider login (`openclaw channels login`) must run as that user: `sudo -i -u openclaw`.
+- **No public ingress at all.** UFW blocks everything except SSH + Tailscale. If you can't reach the gateway, you're not on the tailnet — `tailscale status` is the first check.
+- **Docker is for sandboxes only.** The playbook installs Docker but does **not** run the gateway in a container. Don't conflate this with the Docker runtime — different deploy.
+- **`./run-playbook.sh` is idempotent.** Safe to re-run for config changes; it won't break a working install.
+- **Verify external attack surface.** `nmap -p- <server-ip>` should return only port 22 open (and Tailscale's UDP isn't TCP-scannable).
+
+---
+
+## Nix — declarative, rollback-able install
+
+For users on NixOS, Home Manager, or Determinate Nix. Upstream maintains a Home Manager module: [nix-openclaw](https://github.com/openclaw/nix-openclaw). Installs the gateway + macOS app + tools (whisper, spotify, cameras), pinned to specific versions, with launchd integration on macOS and instant rollback via `home-manager switch --rollback`.
+
+Upstream docs: <https://docs.openclaw.ai/install/nix>.
+
+### Install
+
+```bash
+# Install Determinate Nix if not present:
+curl -fsSL https://install.determinate.systems/nix | sh
+
+# Bootstrap a local flake from the upstream template:
+mkdir -p ~/code/openclaw-local
+# Copy templates/agent-first/flake.nix from https://github.com/openclaw/nix-openclaw
+# Configure secrets at ~/.secrets/ (plain files work)
+# Fill in placeholders in the flake, then:
+home-manager switch
+```
+
+The module installs the launchd service that survives reboots; verify by `launchctl list | grep openclaw`.
+
+### Nix-mode runtime behavior
+
+When `OPENCLAW_NIX_MODE=1` is set (auto via nix-openclaw, or manually via `export OPENCLAW_NIX_MODE=1` / on macOS `defaults write ai.openclaw.mac openclaw.nixMode -bool true`):
+
+- Auto-install + self-mutation flows are **disabled**.
+- Missing dependencies surface Nix-specific remediation messages.
+- The UI shows a read-only "Nix mode" banner.
+
+### Nix-specific gotchas (OpenClaw-only)
+
+- **Source of truth lives in `nix-openclaw`, not `openclaw`.** Module updates don't necessarily track openclaw releases 1:1 — read both repos' release notes when upgrading.
+- **`OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` should be Nix-managed** — never default into the immutable Nix store. The module sets these to writable paths under `~/.openclaw` by default.
+- **Launchd PATH discovery via `NIX_PROFILES`.** The service auto-adds every entry in `NIX_PROFILES` to its PATH (right-to-left precedence). Plugins that shell out to nix-installed binaries work without manual PATH wrangling.
+- **Rollback is your safety net.** A bad config can `home-manager switch --rollback` you back to a known-good state in seconds. Use it.
+
+---
+
+## Bun runtime (experimental, dev-only)
+
+Bun is a faster JavaScript runtime + bundler. OpenClaw upstream supports Bun for **local development** (`bun run`, `bun --watch`) but explicitly recommends **against** using Bun for the gateway runtime in production. WhatsApp + Telegram channels have known issues under Bun.
+
+Upstream docs: <https://docs.openclaw.ai/install/bun>.
+
+```bash
+# Inside an openclaw checkout:
+bun install
+bun run build
+bun run vitest run
+
+# If lifecycle scripts are blocked:
+bun pm trust @whiskeysockets/baileys protobufjs
+```
+
+`pnpm-lock.yaml` is ignored by Bun — `bun.lock` is gitignored too, so no repo churn. Some scripts (`docs:build`, `ui:*`, `protocol:check`) hardcode pnpm; run those via pnpm even when otherwise on Bun.
+
+### Bun-specific gotchas
+
+- **Don't use Bun for the gateway in production.** Stick to Node 24 (or Node 22.14+).
+- **Bun's lockfile mode differs from pnpm.** Don't expect `bun install` to read `pnpm-lock.yaml` — it doesn't.
+- **Lifecycle script trust.** Some upstream deps (Baileys, protobufjs) have lifecycle scripts Bun blocks by default. The `bun pm trust` line above unblocks them.
+
+---
+
+## Per-cloud / per-PaaS pointers
+
+The combo table at the top of this file already lists every (where × how) combination. For deployment paths beyond AWS Lightsail / Docker / Native / Kubernetes / Podman / ClawDock / Ansible / Nix / Bun, see the dedicated infra adapter:
+
+| Where | Adapter / recipe |
+|---|---|
+| AWS EC2 | [`references/infra/aws/ec2.md`](../infra/aws/ec2.md) — runtime: Docker or native |
+| Azure VM (Bastion-hardened) | [`references/infra/azure/vm.md`](../infra/azure/vm.md) — runtime: Docker or native |
+| Hetzner Cloud (CX) | [`references/infra/hetzner/cloud-cx.md`](../infra/hetzner/cloud-cx.md) — runtime: Docker or native |
+| DigitalOcean Droplet | [`references/infra/digitalocean/droplet.md`](../infra/digitalocean/droplet.md) — runtime: Docker or native |
+| GCP Compute Engine | [`references/infra/gcp/compute-engine.md`](../infra/gcp/compute-engine.md) — runtime: Docker or native |
+| Oracle Cloud (Always-Free ARM) | [`references/infra/oracle/free-tier-arm.md`](../infra/oracle/free-tier-arm.md) — Tailscale-only access |
+| Hostinger (managed or VPS) | [`references/infra/hostinger.md`](../infra/hostinger.md) — browser-driven via hPanel |
+| Raspberry Pi | [`references/infra/raspberry-pi.md`](../infra/raspberry-pi.md) — ARM64 always-on home host |
+| macOS VM (Lume on Apple Silicon) | [`references/infra/macos-vm.md`](../infra/macos-vm.md) — for iMessage via BlueBubbles |
+| Linux Server / BYO VPS (Vultr, Linode, on-prem, etc.) | [`references/infra/byo-vps.md`](../infra/byo-vps.md) — catch-all |
+| **Fly.io** | [`references/infra/paas/fly.md`](../infra/paas/fly.md) — `fly.toml` + persistent volume; public or private mode |
+| **Render** | [`references/infra/paas/render.md`](../infra/paas/render.md) — `render.yaml` Blueprint, one-click |
+| **Railway** | [`references/infra/paas/railway.md`](../infra/paas/railway.md) — one-click template, browser-driven |
+| **Northflank** | [`references/infra/paas/northflank.md`](../infra/paas/northflank.md) — one-click stack |
+| **exe.dev** | [`references/infra/paas/exe-dev.md`](../infra/paas/exe-dev.md) — Shelley agent or manual |
+
+Each adapter handles infra-level provisioning + access; once SSH/console works, the **Docker runtime**, **Native installer**, or **Kubernetes** sections of this file (or `runtimes/podman.md`, etc.) take over for the openclaw install.
 
 ---
 
@@ -492,7 +842,15 @@ Universal:
 - **`openclaw onboard` / `openclaw configure` are interactive.** Don't try to automate — pause open-forge's autonomous mode.
 - **Model costs compound.** Long agent runs can burn tokens fast. Set spend limits at the provider dashboard before first real use.
 
-AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — see *Docker-specific gotchas* + `runtimes/docker.md` § *Common gotchas*. Native — see *Native-specific gotchas* + `runtimes/native.md` § *Common gotchas*. Kubernetes — see *Kubernetes-specific gotchas* + `runtimes/kubernetes.md` § *Common gotchas*.
+Per-method gotchas live alongside each section above:
+
+- **AWS Lightsail blueprint** — see *Blueprint gotchas* in the Lightsail section.
+- **Docker runtime** — see *Docker-specific gotchas* + `runtimes/docker.md` § *Common gotchas*.
+- **Native installers** (`install.sh` / `install-cli.sh` / `install.ps1`) — see *Native-specific gotchas* + `runtimes/native.md` § *Common gotchas*.
+- **Kubernetes** (Kustomize) — see *Kubernetes-specific gotchas* + `runtimes/kubernetes.md` § *Common gotchas*.
+- **Podman** — see *Podman-specific gotchas* + `runtimes/podman.md` § *Common gotchas*.
+- **ClawDock / Ansible / Nix / Bun** — see the per-method sections above.
+- **Per-cloud / per-PaaS** — see each adapter's *Gotchas* section under `references/infra/`.
 
 ---
 
@@ -502,10 +860,22 @@ AWS Lightsail blueprint — see *Blueprint gotchas* above. Docker runtime — se
 - Whether `openclaw configure` has non-interactive flags (so model swap can be scripted).
 - Behavior when both Bedrock and a non-Bedrock provider are configured simultaneously.
 - Native installer on macOS (only exercised on Linux so far).
-- Docker runtime end-to-end (verified commands only; first full deploy will surface gotchas to fold back here).
-- Kubernetes / Helm chart end-to-end. Open questions to resolve on the first real cluster deploy:
-  - Exact value paths for non-Anthropic providers (`config.openaiApiKey` etc. is assumed; verify against `helm show values openclaw/openclaw`).
-  - Whether the chart pre-creates an Ingress + cert-manager `Issuer`, or expects them externally.
-  - Whether `--set existingSecret=<name>` is supported and how the chart looks up keys inside it.
-  - Whether `openclaw devices approve` has any chart-provided wrapper (CronJob, Helm hook, sidecar) that obviates `kubectl exec`.
-  - Behavior of `helm uninstall` on the auto-generated gateway token Secret (deleted with the release? orphaned?).
+- Native installer on **Windows (`install.ps1`)** — never exercised; Scheduled-Task autostart, PATH after install, and `iwr | iex` failure modes are documented from upstream but unverified by open-forge.
+- Native **`install-cli.sh`** local-prefix mode — never exercised end-to-end.
+- **Docker runtime** end-to-end (verified commands only; first full deploy will surface gotchas to fold back here).
+- **Kubernetes (Kustomize)** end-to-end — open questions for the first real cluster deploy:
+  - Whether `./scripts/k8s/deploy.sh --create-secret` followed by `./scripts/k8s/deploy.sh` is the standard re-run pattern when adding new provider keys.
+  - Whether the bundled Service binds to a non-loopback by default in any updated upstream version (current docs say loopback).
+  - PVC reclaim behavior on `./scripts/k8s/deploy.sh --delete` vs `kubectl delete namespace openclaw` (script should delete the PVC; upstream says "deletes namespace and all resources in it").
+  - Whether `openclaw backup create` works inside the pod against the mounted PVC.
+- **Podman runtime** end-to-end — Quadlet-managed flow, `OPENCLAW_CONTAINER` interaction with multi-container setups, `podman machine` on macOS.
+- **Ansible** path end-to-end — UFW + Tailscale + Docker-sandbox-only + systemd hardening combo from `openclaw-ansible` repo.
+- **Nix** path on Linux (only macOS+Home Manager covered upstream); `OPENCLAW_NIX_MODE=1` interaction with our state file.
+- **PaaS adapters** — Fly.io, Render, Railway, Northflank, exe.dev all written from upstream docs only; first real deploy on each will surface gotchas. Specifically:
+  - Whether `OPENCLAW_GATEWAY_PORT` overrides on Render survive Blueprint sync.
+  - Whether Railway's auto-generated `*.up.railway.app` requires re-setting `controlUi.allowedOrigins` on every redeploy.
+  - exe.dev nginx config WebSocket timeout interaction with very long-running plugin operations.
+  - Whether `fly.private.toml` deploy correctly skips public IP allocation on first deploy (vs requiring the post-hoc `fly ips release` dance).
+- **Cloud-VM adapters** (Azure, Oracle) — both written from upstream docs but unexercised. Azure Bastion provisioning timing, Oracle "Out of capacity" workarounds.
+- **macOS VM (Lume)** path — Setup Assistant scripting (currently manual VNC), BlueBubbles webhook origin verification, golden-image clone vs fresh-create cost trade-off.
+- **Hostinger** managed flow — open-forge can't drive it; verify the user-facing checklist actually works on the latest hPanel UI.

--- a/plugins/open-forge/skills/open-forge/references/runtimes/kubernetes.md
+++ b/plugins/open-forge/skills/open-forge/references/runtimes/kubernetes.md
@@ -1,41 +1,43 @@
 ---
 name: kubernetes-runtime
-description: Cross-cutting runtime module for Kubernetes deployments. Loaded whenever a project ships an upstream-blessed Helm chart or Kustomize bundle and the user has (or wants) a k8s cluster. Owns kubectl + Helm install / lifecycle / values handling / namespace + secret hygiene. Project recipes own which chart to use, which values matter, and any project-specific pairing/onboarding flow.
+description: Cross-cutting runtime module for Kubernetes deployments. Loaded whenever a project ships upstream-blessed Kubernetes manifests (Kustomize / Helm / plain YAML) and the user has (or wants) a k8s cluster. Owns kubectl + Kustomize/Helm tooling, namespace + secret hygiene, persistent storage, ingress patterns, and common gotchas. Project recipes own which manifests to apply, which env vars matter, and any project-specific onboarding flow.
 ---
 
 # Kubernetes runtime
 
 Reusable across every infra that exposes a k8s API — managed (EKS, GKE, AKS, DOKS, OKE, Linode LKE, Hetzner managed-k8s), self-hosted (k3s, kubeadm, microk8s), or local (Docker Desktop's bundled k8s, kind, minikube, OrbStack).
 
-The project recipe specifies *what* to deploy (chart name, repo URL, the values that matter); this module specifies *how* — install client tools, manage namespaces / secrets / releases, troubleshoot the common k8s issues new self-hosts hit.
+The project recipe specifies *what* to deploy (manifests, env vars, persistent paths); this module specifies *how* — install client tools, connect to a cluster, manage namespaces / secrets, troubleshoot the common k8s issues new self-hosts hit.
 
-> **Don't invent.** This module is for projects whose upstream ships a chart or manifests. If a project has no upstream chart, do **not** author one here — pick Docker or native instead. See `CLAUDE.md` § *Don't invent — interface.*
+> **Don't invent.** This module is for projects whose upstream ships manifests (Kustomize bundle, Helm chart, plain YAML, or a `deploy.sh`). If a project has no upstream Kubernetes path, do **not** author one here — pick Docker / native / a vendor PaaS instead. See `CLAUDE.md` § *Don't invent — interface.*
 
 ## When this module is loaded
 
 User answered the **how** question with anything Kubernetes-flavored:
 
-- "EKS / GKE / AKS / DOKS"
+- "EKS / GKE / AKS / DOKS / OKE / Linode LKE"
 - "k3s on a VM" (BYO VPS + k3s)
-- "Docker Desktop with Kubernetes enabled" (localhost)
+- "kind / minikube / Docker Desktop's bundled k8s" (localhost)
 
-Skipped when the runtime is bundled by a vendor blueprint (the blueprint's k8s wrapper handles itself), or when the chosen path is plain Docker / native.
+Skipped when the runtime is bundled by a vendor blueprint, or when the chosen path is plain Docker / native.
 
 ## Client-side prerequisites
 
-Installed on the **user's machine** (not the cluster nodes — managed clusters provision nodes themselves; self-hosted runtimes are out of this module's scope, see your cluster installer).
+Installed on the **user's machine** (not the cluster nodes — managed clusters provision nodes themselves; self-hosted k8s installation is out of scope, see your distro's installer).
 
 | Tool | Why | Install |
 |---|---|---|
 | `kubectl` | Talk to any k8s cluster | `brew install kubectl` / `sudo apt-get install -y kubectl` (after Google's apt repo) / <https://kubernetes.io/docs/tasks/tools/> |
-| `helm` v3 | Install the project's chart | `brew install helm` / <https://helm.sh/docs/intro/install/> |
-| `kubectx` / `kubens` (optional) | Switch context + namespace quickly | `brew install kubectx` |
+| `kustomize` (optional, modern kubectl bundles it) | Apply Kustomize overlays | `brew install kustomize` / <https://kubectl.docs.kubernetes.io/installation/kustomize/> |
+| `helm` v3 (only if the project ships a chart) | Install upstream Helm charts | `brew install helm` / <https://helm.sh/docs/intro/install/> |
+
+`kubectl` ships with `kustomize` built-in (`kubectl apply -k <path>`), so a separate `kustomize` binary is only needed if the project's `deploy.sh` invokes `kustomize build` directly.
 
 Verify after install:
 
 ```bash
 kubectl version --client --output=yaml
-helm version
+helm version              # only if the project uses Helm
 ```
 
 ## Connect to the cluster
@@ -50,6 +52,7 @@ How `kubectl` reaches a cluster depends on where the cluster lives. Each managed
 | DOKS | `doctl kubernetes cluster kubeconfig save <cluster>` |
 | k3s on a VM | `scp <user>@<host>:/etc/rancher/k3s/k3s.yaml ~/.kube/k3s.yaml && KUBECONFIG=~/.kube/k3s.yaml` (replace `127.0.0.1` in the file with the VM's public IP) |
 | Docker Desktop | Enabled in Docker Desktop settings; context is `docker-desktop` |
+| kind | `kind create cluster --name <name>` (auto-writes kubeconfig) |
 
 Confirm before going further:
 
@@ -59,91 +62,109 @@ kubectl cluster-info
 kubectl get nodes
 ```
 
-## Namespaces, releases, secrets
+## The two install patterns
 
-Project recipes pick a namespace (default: the deployment name). Keep one project per namespace.
+Most projects ship one of these.
+
+### Pattern A — Kustomize (or plain manifests + a deploy script)
+
+The project's repo contains a folder like `scripts/k8s/`, `deploy/k8s/`, or `manifests/` with:
+
+- `kustomization.yaml` — Kustomize base
+- `deployment.yaml`, `service.yaml`, `configmap.yaml`, `secret.yaml`, `pvc.yaml` — individual resources
+- `deploy.sh` (optional) — wraps namespace creation, secret seeding, and `kubectl apply -k`
+
+Generic flow (project recipe specifies the exact paths):
 
 ```bash
-kubectl create namespace "$DEPLOYMENT_NAME"
+git clone <project-repo>
+cd <project-repo>
+
+# Most projects' deploy.sh handles namespace + secret + apply
+./scripts/k8s/deploy.sh
+
+# Or raw Kustomize:
+kubectl apply -k scripts/k8s/manifests/
 ```
 
-API keys and any other secret values go through `Secret` objects, **never** committed `values.yaml`. Two patterns:
+Customize by editing the manifests in your fork (or via Kustomize overlays in a separate dir that references `scripts/k8s/manifests/` as base). Re-running `deploy.sh` is idempotent.
 
-### Pattern 1 — let the chart create the secret from --set / values
+### Pattern B — Helm chart
 
-Most charts have `existingSecret` and inline-value paths. Inline is convenient but the value ends up in the Helm release manifest (stored in-cluster). Acceptable for hobby; not for shared clusters.
-
-```bash
-helm install "$RELEASE_NAME" "$CHART" \
-  --namespace "$DEPLOYMENT_NAME" \
-  --set someApiKey="<paste>" \
-  --create-namespace
-```
-
-### Pattern 2 — pre-create the Secret, point the chart at it
-
-Cleaner; the secret is rotatable independently of the chart release.
+The project ships (or community ships) a Helm chart at a `helm repo add` URL.
 
 ```bash
-kubectl create secret generic "$DEPLOYMENT_NAME-keys" \
-  --namespace "$DEPLOYMENT_NAME" \
-  --from-literal=apiKey='<paste>'
-
-helm install "$RELEASE_NAME" "$CHART" \
-  --namespace "$DEPLOYMENT_NAME" \
-  --set existingSecret="$DEPLOYMENT_NAME-keys"
-```
-
-Project recipes specify which keys the chart looks up.
-
-## Helm lifecycle
-
-```bash
-# Add the upstream repo + refresh
 helm repo add <name> <url>
 helm repo update
 
 # Inspect what'll be installed
 helm show values <name>/<chart> > /tmp/<chart>-defaults.yaml
-helm template "$RELEASE_NAME" "<name>/<chart>" --namespace "$DEPLOYMENT_NAME" -f my-values.yaml | kubectl diff -f -
 
 # Install
 helm install "$RELEASE_NAME" "<name>/<chart>" \
   --namespace "$DEPLOYMENT_NAME" --create-namespace \
   -f my-values.yaml
 
-# Upgrade
-helm upgrade "$RELEASE_NAME" "<name>/<chart>" \
-  --namespace "$DEPLOYMENT_NAME" \
+# Upgrade (idempotent — works for first install too)
+helm upgrade --install "$RELEASE_NAME" "<name>/<chart>" \
+  --namespace "$DEPLOYMENT_NAME" --create-namespace \
   -f my-values.yaml
 
-# Roll back
+# Roll back / status / uninstall
 helm rollback "$RELEASE_NAME" <revision> --namespace "$DEPLOYMENT_NAME"
-
-# Status / history
 helm status   "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
-helm history  "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
-
-# Uninstall (PVCs may persist — see Gotchas)
 helm uninstall "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
 ```
+
+Project recipes that use Helm specify the repo URL, chart name, required values, and any pre-existing Secret support.
+
+## Namespaces, releases, secrets
+
+Project recipes pick a namespace (often the project name itself). Keep one project per namespace.
+
+```bash
+kubectl create namespace "$NAMESPACE"
+```
+
+API keys and any other secret values go through `Secret` objects, **never** committed `values.yaml` / `kustomization.yaml`. Two patterns:
+
+### Pattern 1 — Secret created by the project's deploy script
+
+Most projects' `deploy.sh` reads env vars (`ANTHROPIC_API_KEY`, etc.) and creates a `Secret` from them. Convenient; keeps secrets out of repo files.
+
+```bash
+export ANTHROPIC_API_KEY="..."
+./scripts/k8s/deploy.sh
+```
+
+### Pattern 2 — Pre-create the Secret, point manifests at it
+
+Cleaner; the secret is rotatable independently of the manifest apply.
+
+```bash
+kubectl create secret generic "$NAMESPACE-keys" \
+  --namespace "$NAMESPACE" \
+  --from-literal=apiKey='<paste>'
+```
+
+Then the project's manifests reference the secret name (project recipe specifies which keys it looks up).
 
 ## Pod / service troubleshooting
 
 ```bash
 # What's running
-kubectl -n "$DEPLOYMENT_NAME" get pods,svc,ingress,pvc
+kubectl -n "$NAMESPACE" get pods,svc,ingress,pvc
 
 # Why won't it start
-kubectl -n "$DEPLOYMENT_NAME" describe pod <pod>
-kubectl -n "$DEPLOYMENT_NAME" logs <pod>            # add -p for the previous container after a crash
-kubectl -n "$DEPLOYMENT_NAME" logs -f <pod>          # tail
+kubectl -n "$NAMESPACE" describe pod <pod>
+kubectl -n "$NAMESPACE" logs <pod>            # add -p for the previous container after a crash
+kubectl -n "$NAMESPACE" logs -f <pod>          # tail
 
 # Get a shell
-kubectl -n "$DEPLOYMENT_NAME" exec -it <pod> -- sh
+kubectl -n "$NAMESPACE" exec -it <pod> -- sh
 
 # Local probe through a port-forward
-kubectl -n "$DEPLOYMENT_NAME" port-forward svc/<svc-name> <local-port>:<svc-port>
+kubectl -n "$NAMESPACE" port-forward svc/<svc-name> <local-port>:<svc-port>
 # Test: curl -sI http://127.0.0.1:<local-port>/healthz
 ```
 
@@ -153,9 +174,11 @@ Three patterns; project recipes pick:
 
 | Pattern | When | Notes |
 |---|---|---|
-| `Ingress` + ingress controller (nginx, Traefik, AWS ALB) | Standard for cloud k8s | Cluster needs an ingress controller installed. Managed services often pre-install one. |
+| `kubectl port-forward` | Local-only access during setup | Not for production — terminates on disconnect. Many projects' default manifests assume this. |
 | `Service` of type `LoadBalancer` | Simplest on managed clouds | Provider provisions a real LB and external IP. Charges apply. |
-| `port-forward` | Local-only access during setup | Not for production — terminates on disconnect. |
+| `Ingress` + ingress controller (nginx, Traefik, AWS ALB) | Standard for cloud k8s | Cluster needs an ingress controller installed. Managed services often pre-install one. |
+
+When a project's default manifests bind to **loopback inside the pod**, `port-forward` works but `Service`/`Ingress` won't reach it. Switching to a non-loopback bind requires both manifest and config changes — read the project recipe before changing.
 
 For TLS via Ingress, pair with cert-manager (most charts assume this is installed):
 
@@ -166,11 +189,11 @@ helm install cert-manager jetstack/cert-manager \
   --set crds.enabled=true
 ```
 
-Then a `ClusterIssuer` for Let's Encrypt and the project's chart references it via annotations. See `references/modules/tls-letsencrypt.md` for the issuer YAML.
+Then a `ClusterIssuer` for Let's Encrypt and the project's manifests reference it via annotations. See `references/modules/tls-letsencrypt.md` for the issuer YAML.
 
 ## Persistent storage
 
-Most projects with state (databases, file storage) need a `PersistentVolumeClaim`. Charts default to either:
+Most projects with state need a `PersistentVolumeClaim`. Manifests default to either:
 
 - **Default StorageClass** — ✅ on managed clouds (EBS / Persistent Disk / Azure Disk / DO Block Storage). Confirm: `kubectl get sc` shows one marked `(default)`.
 - **No default** — common on k3s + minikube; install `local-path-provisioner` (k3s ships it but unprovisioned), `longhorn`, or supply your own.
@@ -178,30 +201,30 @@ Most projects with state (databases, file storage) need a `PersistentVolumeClaim
 PVC reclaim policy matters on uninstall:
 
 ```bash
-kubectl -n "$DEPLOYMENT_NAME" get pvc           # before uninstall
-helm uninstall "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
-kubectl -n "$DEPLOYMENT_NAME" get pvc           # PVCs usually survive — Helm does not delete them
-kubectl -n "$DEPLOYMENT_NAME" delete pvc <name> # explicit, only if you're sure the data should go
+kubectl -n "$NAMESPACE" get pvc           # before uninstall
+# delete release / kustomization
+kubectl -n "$NAMESPACE" get pvc           # PVC may survive — depends on namespace deletion vs targeted uninstall
+kubectl -n "$NAMESPACE" delete pvc <name> # explicit, only if you're sure the data should go
 ```
 
-This is intentional in Helm — it protects against accidental data loss. Reinstalling the same release in the same namespace re-binds to the surviving PVC.
+For Kustomize: deleting the namespace deletes everything in it (including PVCs unless StorageClass reclaim policy is `Retain`). For Helm: `helm uninstall` typically does **not** delete PVCs. Project recipes specify which.
 
 ## Common gotchas
 
 - **Wrong context.** `kubectl config current-context` first, every time. Multi-cluster setups silently apply to the wrong place.
-- **Default StorageClass missing.** Symptom: PVC stuck in `Pending` forever, `kubectl describe pvc` shows `no persistent volumes available for this claim and no storage class is set`. Fix: install one (`kubectl annotate sc <name> storageclass.kubernetes.io/is-default-class=true`) or set `persistence.storageClass` in values.
-- **Ingress without controller.** An Ingress object with no controller installed is a no-op. Symptom: `kubectl describe ingress` shows no Address. Install nginx-ingress / Traefik / the cloud-native one before the chart, or use `LoadBalancer` Service type instead.
-- **`helm uninstall` leaves PVCs (and Secrets created outside the chart).** Plan for cleanup; document in the project recipe.
-- **`Recreate` deployment strategy.** Some charts (single-instance apps that hold local state) set `strategy: Recreate` so old + new can't run simultaneously. During upgrades there's a brief downtime gap. Don't switch to `RollingUpdate` without checking the chart README.
-- **Chart version vs app version.** `helm install --version 1.2.3` pins the **chart** version, not the app's container tag. Pin both: chart version via `--version`, app version via `image.tag` in values.
-- **Resource requests / limits.** Charts often default to "small" or unset. On a tight cluster (3-node k3s, 2-node DOKS), unset limits can starve other workloads. Set explicitly during first install.
+- **Default StorageClass missing.** Symptom: PVC stuck in `Pending` forever, `kubectl describe pvc` shows `no persistent volumes available for this claim and no storage class is set`. Fix: install one (`kubectl annotate sc <name> storageclass.kubernetes.io/is-default-class=true`) or set the storage class explicitly in the manifest.
+- **Ingress without controller.** An Ingress object with no controller installed is a no-op. Symptom: `kubectl describe ingress` shows no Address. Install nginx-ingress / Traefik / the cloud-native one before the project, or use `LoadBalancer` Service type instead.
+- **Pod binds to loopback inside the container.** Default in many self-host projects (security-by-default). `kubectl port-forward` works; `Service`/`Ingress` need a non-loopback bind change in the project's config (not just the Service spec).
+- **`Recreate` deployment strategy.** Projects with single-instance state use `strategy: Recreate` so old + new can't run simultaneously. Brief downtime gap during upgrades is by design.
 - **Secret values in `kubectl describe`.** They're base64, not encrypted. Anyone with `get secrets` permission sees them. Use Sealed Secrets / External Secrets / SOPS if multiple humans share the cluster.
+- **Re-running `deploy.sh` overwrites Secret values?** Most upstream scripts preserve existing keys and only update what you pass via env vars — but verify per project. If unsure, snapshot the Secret first: `kubectl get secret <name> -n <ns> -o yaml > secret-backup.yaml`.
 - **`helm upgrade --install` is your friend.** Idempotent — works for both first install and subsequent upgrades. Prefer it over branching on "does the release exist".
-- **Local k8s is heavy.** Docker Desktop's k8s, kind, and minikube each consume 2–4 GB RAM at idle. For localhost openclaw / ghost, plain Docker is lighter.
+- **Local k8s is heavy.** Docker Desktop's k8s, kind, and minikube each consume 2–4 GB RAM at idle. For localhost-only deployments, plain Docker is lighter.
+- **`kubectl apply -k` vs `kubectl create -k`.** Use `apply -k` — idempotent. `create -k` errors if anything already exists.
 
 ## Reference
 
 - kubectl reference: <https://kubernetes.io/docs/reference/kubectl/>
+- Kustomize: <https://kubectl.docs.kubernetes.io/references/kustomize/>
 - Helm v3 docs: <https://helm.sh/docs/>
 - cert-manager: <https://cert-manager.io/docs/>
-- Kustomize (alternative to Helm for projects shipping plain manifests): <https://kustomize.io/>

--- a/plugins/open-forge/skills/open-forge/references/runtimes/kubernetes.md
+++ b/plugins/open-forge/skills/open-forge/references/runtimes/kubernetes.md
@@ -1,0 +1,207 @@
+---
+name: kubernetes-runtime
+description: Cross-cutting runtime module for Kubernetes deployments. Loaded whenever a project ships an upstream-blessed Helm chart or Kustomize bundle and the user has (or wants) a k8s cluster. Owns kubectl + Helm install / lifecycle / values handling / namespace + secret hygiene. Project recipes own which chart to use, which values matter, and any project-specific pairing/onboarding flow.
+---
+
+# Kubernetes runtime
+
+Reusable across every infra that exposes a k8s API — managed (EKS, GKE, AKS, DOKS, OKE, Linode LKE, Hetzner managed-k8s), self-hosted (k3s, kubeadm, microk8s), or local (Docker Desktop's bundled k8s, kind, minikube, OrbStack).
+
+The project recipe specifies *what* to deploy (chart name, repo URL, the values that matter); this module specifies *how* — install client tools, manage namespaces / secrets / releases, troubleshoot the common k8s issues new self-hosts hit.
+
+> **Don't invent.** This module is for projects whose upstream ships a chart or manifests. If a project has no upstream chart, do **not** author one here — pick Docker or native instead. See `CLAUDE.md` § *Don't invent — interface.*
+
+## When this module is loaded
+
+User answered the **how** question with anything Kubernetes-flavored:
+
+- "EKS / GKE / AKS / DOKS"
+- "k3s on a VM" (BYO VPS + k3s)
+- "Docker Desktop with Kubernetes enabled" (localhost)
+
+Skipped when the runtime is bundled by a vendor blueprint (the blueprint's k8s wrapper handles itself), or when the chosen path is plain Docker / native.
+
+## Client-side prerequisites
+
+Installed on the **user's machine** (not the cluster nodes — managed clusters provision nodes themselves; self-hosted runtimes are out of this module's scope, see your cluster installer).
+
+| Tool | Why | Install |
+|---|---|---|
+| `kubectl` | Talk to any k8s cluster | `brew install kubectl` / `sudo apt-get install -y kubectl` (after Google's apt repo) / <https://kubernetes.io/docs/tasks/tools/> |
+| `helm` v3 | Install the project's chart | `brew install helm` / <https://helm.sh/docs/intro/install/> |
+| `kubectx` / `kubens` (optional) | Switch context + namespace quickly | `brew install kubectx` |
+
+Verify after install:
+
+```bash
+kubectl version --client --output=yaml
+helm version
+```
+
+## Connect to the cluster
+
+How `kubectl` reaches a cluster depends on where the cluster lives. Each managed provider has its own one-liner that writes a kubeconfig entry; project recipes assume that's already done.
+
+| Cluster | Set kubeconfig |
+|---|---|
+| EKS | `aws eks update-kubeconfig --region <r> --name <cluster>` |
+| GKE | `gcloud container clusters get-credentials <cluster> --region <r>` |
+| AKS | `az aks get-credentials --resource-group <rg> --name <cluster>` |
+| DOKS | `doctl kubernetes cluster kubeconfig save <cluster>` |
+| k3s on a VM | `scp <user>@<host>:/etc/rancher/k3s/k3s.yaml ~/.kube/k3s.yaml && KUBECONFIG=~/.kube/k3s.yaml` (replace `127.0.0.1` in the file with the VM's public IP) |
+| Docker Desktop | Enabled in Docker Desktop settings; context is `docker-desktop` |
+
+Confirm before going further:
+
+```bash
+kubectl config current-context
+kubectl cluster-info
+kubectl get nodes
+```
+
+## Namespaces, releases, secrets
+
+Project recipes pick a namespace (default: the deployment name). Keep one project per namespace.
+
+```bash
+kubectl create namespace "$DEPLOYMENT_NAME"
+```
+
+API keys and any other secret values go through `Secret` objects, **never** committed `values.yaml`. Two patterns:
+
+### Pattern 1 — let the chart create the secret from --set / values
+
+Most charts have `existingSecret` and inline-value paths. Inline is convenient but the value ends up in the Helm release manifest (stored in-cluster). Acceptable for hobby; not for shared clusters.
+
+```bash
+helm install "$RELEASE_NAME" "$CHART" \
+  --namespace "$DEPLOYMENT_NAME" \
+  --set someApiKey="<paste>" \
+  --create-namespace
+```
+
+### Pattern 2 — pre-create the Secret, point the chart at it
+
+Cleaner; the secret is rotatable independently of the chart release.
+
+```bash
+kubectl create secret generic "$DEPLOYMENT_NAME-keys" \
+  --namespace "$DEPLOYMENT_NAME" \
+  --from-literal=apiKey='<paste>'
+
+helm install "$RELEASE_NAME" "$CHART" \
+  --namespace "$DEPLOYMENT_NAME" \
+  --set existingSecret="$DEPLOYMENT_NAME-keys"
+```
+
+Project recipes specify which keys the chart looks up.
+
+## Helm lifecycle
+
+```bash
+# Add the upstream repo + refresh
+helm repo add <name> <url>
+helm repo update
+
+# Inspect what'll be installed
+helm show values <name>/<chart> > /tmp/<chart>-defaults.yaml
+helm template "$RELEASE_NAME" "<name>/<chart>" --namespace "$DEPLOYMENT_NAME" -f my-values.yaml | kubectl diff -f -
+
+# Install
+helm install "$RELEASE_NAME" "<name>/<chart>" \
+  --namespace "$DEPLOYMENT_NAME" --create-namespace \
+  -f my-values.yaml
+
+# Upgrade
+helm upgrade "$RELEASE_NAME" "<name>/<chart>" \
+  --namespace "$DEPLOYMENT_NAME" \
+  -f my-values.yaml
+
+# Roll back
+helm rollback "$RELEASE_NAME" <revision> --namespace "$DEPLOYMENT_NAME"
+
+# Status / history
+helm status   "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
+helm history  "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
+
+# Uninstall (PVCs may persist — see Gotchas)
+helm uninstall "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
+```
+
+## Pod / service troubleshooting
+
+```bash
+# What's running
+kubectl -n "$DEPLOYMENT_NAME" get pods,svc,ingress,pvc
+
+# Why won't it start
+kubectl -n "$DEPLOYMENT_NAME" describe pod <pod>
+kubectl -n "$DEPLOYMENT_NAME" logs <pod>            # add -p for the previous container after a crash
+kubectl -n "$DEPLOYMENT_NAME" logs -f <pod>          # tail
+
+# Get a shell
+kubectl -n "$DEPLOYMENT_NAME" exec -it <pod> -- sh
+
+# Local probe through a port-forward
+kubectl -n "$DEPLOYMENT_NAME" port-forward svc/<svc-name> <local-port>:<svc-port>
+# Test: curl -sI http://127.0.0.1:<local-port>/healthz
+```
+
+## Reaching the service from outside
+
+Three patterns; project recipes pick:
+
+| Pattern | When | Notes |
+|---|---|---|
+| `Ingress` + ingress controller (nginx, Traefik, AWS ALB) | Standard for cloud k8s | Cluster needs an ingress controller installed. Managed services often pre-install one. |
+| `Service` of type `LoadBalancer` | Simplest on managed clouds | Provider provisions a real LB and external IP. Charges apply. |
+| `port-forward` | Local-only access during setup | Not for production — terminates on disconnect. |
+
+For TLS via Ingress, pair with cert-manager (most charts assume this is installed):
+
+```bash
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true
+```
+
+Then a `ClusterIssuer` for Let's Encrypt and the project's chart references it via annotations. See `references/modules/tls-letsencrypt.md` for the issuer YAML.
+
+## Persistent storage
+
+Most projects with state (databases, file storage) need a `PersistentVolumeClaim`. Charts default to either:
+
+- **Default StorageClass** — ✅ on managed clouds (EBS / Persistent Disk / Azure Disk / DO Block Storage). Confirm: `kubectl get sc` shows one marked `(default)`.
+- **No default** — common on k3s + minikube; install `local-path-provisioner` (k3s ships it but unprovisioned), `longhorn`, or supply your own.
+
+PVC reclaim policy matters on uninstall:
+
+```bash
+kubectl -n "$DEPLOYMENT_NAME" get pvc           # before uninstall
+helm uninstall "$RELEASE_NAME" --namespace "$DEPLOYMENT_NAME"
+kubectl -n "$DEPLOYMENT_NAME" get pvc           # PVCs usually survive — Helm does not delete them
+kubectl -n "$DEPLOYMENT_NAME" delete pvc <name> # explicit, only if you're sure the data should go
+```
+
+This is intentional in Helm — it protects against accidental data loss. Reinstalling the same release in the same namespace re-binds to the surviving PVC.
+
+## Common gotchas
+
+- **Wrong context.** `kubectl config current-context` first, every time. Multi-cluster setups silently apply to the wrong place.
+- **Default StorageClass missing.** Symptom: PVC stuck in `Pending` forever, `kubectl describe pvc` shows `no persistent volumes available for this claim and no storage class is set`. Fix: install one (`kubectl annotate sc <name> storageclass.kubernetes.io/is-default-class=true`) or set `persistence.storageClass` in values.
+- **Ingress without controller.** An Ingress object with no controller installed is a no-op. Symptom: `kubectl describe ingress` shows no Address. Install nginx-ingress / Traefik / the cloud-native one before the chart, or use `LoadBalancer` Service type instead.
+- **`helm uninstall` leaves PVCs (and Secrets created outside the chart).** Plan for cleanup; document in the project recipe.
+- **`Recreate` deployment strategy.** Some charts (single-instance apps that hold local state) set `strategy: Recreate` so old + new can't run simultaneously. During upgrades there's a brief downtime gap. Don't switch to `RollingUpdate` without checking the chart README.
+- **Chart version vs app version.** `helm install --version 1.2.3` pins the **chart** version, not the app's container tag. Pin both: chart version via `--version`, app version via `image.tag` in values.
+- **Resource requests / limits.** Charts often default to "small" or unset. On a tight cluster (3-node k3s, 2-node DOKS), unset limits can starve other workloads. Set explicitly during first install.
+- **Secret values in `kubectl describe`.** They're base64, not encrypted. Anyone with `get secrets` permission sees them. Use Sealed Secrets / External Secrets / SOPS if multiple humans share the cluster.
+- **`helm upgrade --install` is your friend.** Idempotent — works for both first install and subsequent upgrades. Prefer it over branching on "does the release exist".
+- **Local k8s is heavy.** Docker Desktop's k8s, kind, and minikube each consume 2–4 GB RAM at idle. For localhost openclaw / ghost, plain Docker is lighter.
+
+## Reference
+
+- kubectl reference: <https://kubernetes.io/docs/reference/kubectl/>
+- Helm v3 docs: <https://helm.sh/docs/>
+- cert-manager: <https://cert-manager.io/docs/>
+- Kustomize (alternative to Helm for projects shipping plain manifests): <https://kustomize.io/>

--- a/plugins/open-forge/skills/open-forge/references/runtimes/native.md
+++ b/plugins/open-forge/skills/open-forge/references/runtimes/native.md
@@ -1,11 +1,11 @@
 ---
 name: native-runtime
-description: Cross-cutting runtime module for native (non-containerized) deployments. Loaded whenever the user picks the native installer / curl-pipe-bash / package-manager path on any infra (Lightsail Ubuntu, EC2, Hetzner, DO, GCP, BYO VPS, localhost). Owns OS prereqs, daemon lifecycle, reverse-proxy guidance, and common gotchas. Project recipes own their own installer command, config paths, and app-specific service unit.
+description: Cross-cutting runtime module for native (non-containerized) deployments. Loaded whenever the user picks the native installer / curl-pipe-bash / package-manager / PowerShell-installer / local-prefix path on any infra (Lightsail Ubuntu, EC2, Hetzner, DO, GCP, BYO VPS, Raspberry Pi, localhost — Linux/macOS/Windows). Owns OS prereqs, daemon lifecycle (systemd / launchd / Scheduled Tasks), reverse-proxy guidance, and common gotchas. Project recipes own their own installer command, config paths, and app-specific service unit.
 ---
 
 # Native runtime
 
-Reusable across every Linux/macOS host where the project ships a native installer (no container). The project recipe specifies *what* to run (installer URL, config paths, the service unit's exact `ExecStart`); this module specifies *how* — install OS prereqs, manage the daemon's lifecycle, set up a reverse proxy, troubleshoot common native-install issues.
+Reusable across every Linux / macOS / Windows host where the project ships a native installer (no container). The project recipe specifies *what* to run (installer URL, config paths, the service unit's exact `ExecStart`); this module specifies *how* — install OS prereqs, manage the daemon's lifecycle, set up a reverse proxy, troubleshoot common native-install issues.
 
 ## When this module is loaded
 
@@ -13,16 +13,29 @@ User answered the **how** question with anything native:
 
 - "Lightsail Ubuntu + native installer", "EC2 + native", "Hetzner CX + native"
 - "BYO VPS + native"
-- "localhost + native" (macOS / Linux home directory install)
+- "localhost + native" (macOS, Linux, Windows-via-WSL2, or native Windows PowerShell)
+- "Raspberry Pi + native"
 
-Skipped when the runtime is bundled by the infra (e.g. Lightsail vendor blueprint) or when the user picked Docker.
+Skipped when the runtime is bundled by the infra (e.g. Lightsail vendor blueprint) or when the user picked Docker / Podman / Kubernetes.
+
+## Three installer modes
+
+Most projects with a `curl | bash` story actually ship *three* installer scripts — pick the right one:
+
+| Mode | Platform | When to use |
+|---|---|---|
+| **Global** (`install.sh`) | macOS / Linux / WSL2 | Default — installs Node + project globally via npm. Good for single-user VPS or laptop where you can write to `/usr/local/`. |
+| **Local prefix** (`install-cli.sh`) | macOS / Linux / WSL2 | No root. Installs Node + project under `~/.openclaw` (or a custom `--prefix`). Good for shared hosts, CI, restricted environments, or running multiple versions side-by-side. |
+| **Windows PowerShell** (`install.ps1`) | Native Windows (PS 5+) | Installs Node via winget/Chocolatey/Scoop; project via npm. Also works inside WSL2 but Linux installer is preferred there. |
+
+Project recipes name the URLs explicitly (e.g. `https://openclaw.ai/install.sh`, `https://openclaw.ai/install-cli.sh`, `https://openclaw.ai/install.ps1`); this module describes the surrounding host concerns.
 
 ## Host requirements
 
-- **Linux**: kernel ≥ 4.x, systemd (for daemon supervision), `curl`, `bash`. ARM and x86_64 both supported by most upstream installers; verify with the project's matrix.
-- **macOS** (only valid for `infra/localhost.md`): Homebrew preinstalled by the user; `launchd` is built-in for autostart.
-- **Windows** (only valid for `infra/localhost.md`): native installs are project-by-project; many projects only ship Linux/macOS native and recommend WSL or Docker on Windows.
-- **Disk**: ≥ 5 GB free for most native installs (much smaller than Docker-based — no image cache).
+- **Linux**: kernel ≥ 4.x, systemd (for daemon supervision), `curl`, `bash`, Node 22+ (most installers fetch a pinned Node themselves). ARM and x86_64 both supported by most upstream installers; verify with the project's matrix.
+- **macOS** (only valid for `infra/localhost.md`): Homebrew preinstalled by the user; `launchd` is built-in for autostart. Apple Silicon and Intel both supported by most installers.
+- **Windows**: PowerShell 5+; native install via `install.ps1`, or run inside WSL2 (which acts like Linux). Daemon autostart on native Windows uses **Scheduled Tasks** (the installer creates them); no systemd.
+- **Disk**: ≥ 5 GB free for global installs; ≥ 1 GB for local-prefix mode.
 - **RAM**: project-dependent. Native runs lighter than Docker because no container overhead.
 
 ## Install OS prereqs
@@ -56,26 +69,69 @@ xcode-select --install        # one-time; installs Apple's CLI tools (clang, mak
 # Homebrew should already be installed; if not: https://brew.sh
 ```
 
-Project recipes will list any **additional** prereqs (e.g. `nodejs`, `python3`, `imagemagick`). Install those with the matching package manager — never fall back to `pip`/`npm` global installs without the user's approval.
+### Windows (native, no WSL)
+
+PowerShell 5+ is bundled with Windows 10/11. Most native-Windows installers will install Node via one of these (in order of preference):
+
+```powershell
+# winget — built into Windows 11 and recent 10
+winget install OpenJS.NodeJS.LTS
+
+# Chocolatey
+Set-ExecutionPolicy Bypass -Scope Process -Force; iwr https://community.chocolatey.org/install.ps1 -useb | iex
+choco install nodejs-lts -y
+
+# Scoop
+iwr -useb get.scoop.sh | iex
+scoop install nodejs-lts
+```
+
+The project's `install.ps1` typically tries `winget` → `chocolatey` → `scoop` automatically. Git for Windows is also required if the installer falls back to a git checkout — install ahead of time: `winget install Git.Git`.
+
+### Windows (WSL2)
+
+Inside WSL2, follow the Debian/Ubuntu path above — WSL2 looks like Linux to installers. The `install.sh` script is preferred over `install.ps1` from inside WSL.
+
+Project recipes will list any **additional** prereqs (e.g. `python3`, `imagemagick`, `ffmpeg`). Install those with the matching package manager — never fall back to `pip`/`npm` global installs without the user's approval.
 
 ## Run the project installer
 
 Project recipes own the exact command. Generic patterns:
 
 ```bash
-# curl | bash (most common)
-curl -fsSL https://<project>.example/install.sh | bash
+# Global curl | bash (most common — macOS / Linux / WSL2)
+curl -fsSL --proto '=https' --tlsv1.2 https://<project>.example/install.sh | bash
 
-# package manager
+# Local prefix (no root; installs to ~/.<project>/ or --prefix <path>)
+curl -fsSL --proto '=https' --tlsv1.2 https://<project>.example/install-cli.sh | bash
+# or pin a custom prefix:
+curl -fsSL --proto '=https' --tlsv1.2 https://<project>.example/install-cli.sh | bash -s -- --prefix /opt/<project>
+
+# Native Windows (PowerShell 5+)
+iwr -useb https://<project>.example/install.ps1 | iex
+# or with flags:
+& ([scriptblock]::Create((iwr -useb https://<project>.example/install.ps1))) -NoOnboard
+
+# Package manager
 sudo apt-get install -y <project>          # Debian/Ubuntu
 brew install <project>                     # macOS
 
-# binary release
+# Binary release
 curl -fsSL -o /tmp/<project> https://github.com/<org>/<project>/releases/latest/download/<project>-linux-x86_64
 sudo install -m 0755 /tmp/<project> /usr/local/bin/<project>
 ```
 
-Always announce in one sentence before piping a remote script to a shell. Some users want to inspect first — offer `curl -fsSL <url> -o /tmp/install.sh && less /tmp/install.sh` as an alternative.
+Always announce in one sentence before piping a remote script to a shell. Some users want to inspect first — offer `curl -fsSL <url> -o /tmp/install.sh && less /tmp/install.sh` (or PowerShell's `iwr -useb <url> -OutFile install.ps1; Get-Content install.ps1 | more`) as an alternative.
+
+Common non-interactive flags (most upstream installers support):
+
+| Flag | Effect |
+|---|---|
+| `--no-onboard` / `-NoOnboard` / `OPENCLAW_NO_ONBOARD=1` | Skip the post-install setup wizard (useful in autonomous flows where Claude pre-stages config) |
+| `--no-prompt` / `OPENCLAW_NO_PROMPT=1` | Disable any interactive prompts during install |
+| `--dry-run` / `-DryRun` | Print actions without applying — confirm before committing |
+| `--install-method git\|npm` | Pick installation source (npm registry vs git checkout) |
+| `--version <ver>` | Pin a specific version, dist-tag, or git ref |
 
 ## Daemon lifecycle
 
@@ -116,6 +172,30 @@ launchctl list | grep <project>                              # status
 ```
 
 Logs go to wherever the plist's `StandardOutPath` / `StandardErrorPath` point — usually `~/Library/Logs/<project>.log`.
+
+### Scheduled Tasks (native Windows)
+
+Most Windows installers create a Scheduled Task that runs at user login. Manage with PowerShell:
+
+```powershell
+Get-ScheduledTask -TaskName "<project>*"
+Start-ScheduledTask -TaskName "<project>"
+Stop-ScheduledTask -TaskName "<project>"
+Disable-ScheduledTask -TaskName "<project>"
+
+# Logs (if the project writes to event log)
+Get-WinEvent -LogName Application -MaxEvents 50 | Where-Object { $_.ProviderName -like "*<project>*" }
+```
+
+For projects that don't auto-create a task, manual creation:
+
+```powershell
+$action = New-ScheduledTaskAction -Execute "C:\Path\To\<project>.exe" -Argument "gateway run"
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+Register-ScheduledTask -TaskName "<project>" -Action $action -Trigger $trigger -RunLevel Limited
+```
+
+Native Windows has no exact systemd-linger equivalent — Scheduled Tasks tied to user login require the user to log in at least once after reboot. For true headless persistence, run inside WSL2 with `loginctl enable-linger`, or run the project as a Windows Service via `nssm` / `sc.exe` (project recipe specific).
 
 ### Foreground (no daemon)
 
@@ -180,16 +260,21 @@ sudo ufw enable
 
 ## Common gotchas
 
-- **PATH not refreshed after install.** Many installers drop a binary in `~/.local/bin` or `/usr/local/bin` and rely on shell rc to pick it up. After install, run `exec $SHELL -l` (or open a new shell) before invoking the binary. Symptom: `command not found` immediately after a successful install.
+- **PATH not refreshed after install.** Many installers drop a binary in `~/.local/bin` or `/usr/local/bin` and rely on shell rc to pick it up. After install, run `exec $SHELL -l` (or open a new shell) before invoking the binary. Symptom: `command not found` immediately after a successful install. On Windows, `npm config get prefix` shows where the global binary lives — add that directory to user PATH and reopen PowerShell.
 - **Node / Python version pinning.** Installers that bundle a runtime (Node 22, Python 3.11) often pin a specific version. If the user has `nvm` / `pyenv` / a system Node, the wrong one can shadow the bundled one after `exec $SHELL -l`. Verify with `which <runtime> && <runtime> --version` and `<project> --version`. Mitigations: project-specific shims, asdf, or `update-alternatives`.
 - **systemd user unit dies on reboot without linger.** `systemctl --user enable <project>` alone doesn't survive logout. Pair with `sudo loginctl enable-linger "$USER"` once.
 - **`sudo` doesn't inherit user DBUS.** Symptoms like `Failed to connect to bus: No medium found` when running `sudo systemctl --user …` or any command that talks to the user's DBUS — run as the unprivileged user instead, or `sudo -i -u <user>` to get a full login env.
 - **Reboot loses the running daemon, not the data.** Config and state under `$HOME` / `/var/lib/<project>` survive. The service comes back only if `enable`d (and lingered, for user units). Verify after a deliberate reboot, not just right after install.
 - **No automatic TLS** — unlike vendor blueprints (Lightsail) or tunnels (Cloudflare/Tailscale), bare native installs don't ship with a cert. Pair with `references/modules/tls-letsencrypt.md` (or Caddy, which automates it).
 - **Permissions on `/usr/local/bin`** — on some macOS installs, `/usr/local/bin` isn't writable without `sudo`. Homebrew handles this; manual `install -m 0755` may need `sudo`.
+- **Local-prefix mode + global mode collide.** If the user installed once with `install.sh` (global) and again with `install-cli.sh` (local prefix), there are now two binaries on PATH and the wrong one wins depending on shell rc order. Either uninstall the old one or alias the prefix binary explicitly.
+- **WSL2 vs native Windows path confusion.** A WSL2 install lives in the Linux filesystem and isn't visible to native PowerShell, and vice versa. Pick one and stick with it; if the user is on Windows, ask which they want before running an installer.
+- **Windows: `iwr | iex` errors are non-fatal to the shell.** A failure in the piped script reports a terminating error but doesn't close the PowerShell window. Always check `$?` or look for an explicit success line — silent partial installs happen.
+- **`SHARP_IGNORE_GLOBAL_LIBVIPS=1`** is the installer default to avoid building Sharp against system libvips. If a project legitimately needs system libvips, override with `SHARP_IGNORE_GLOBAL_LIBVIPS=0` before running the installer.
 
 ## Reference
 
 - systemd service docs: <https://www.freedesktop.org/software/systemd/man/systemd.service.html>
 - launchd docs (macOS): <https://www.launchd.info/>
+- Windows Scheduled Tasks: <https://learn.microsoft.com/en-us/windows/win32/taskschd/task-scheduler-start-page>
 - Caddy: <https://caddyserver.com/docs/>

--- a/plugins/open-forge/skills/open-forge/references/runtimes/podman.md
+++ b/plugins/open-forge/skills/open-forge/references/runtimes/podman.md
@@ -1,0 +1,178 @@
+---
+name: podman-runtime
+description: Cross-cutting runtime module for Podman-based deployments. Loaded whenever the user picks Podman (rootless, Docker-API-compatible) on any infra. Owns Podman install, rootless namespace setup, and Quadlet (systemd-user) integration. Project recipes own their own image / setup script / app-specific env. For OpenClaw specifically, the upstream `scripts/podman/setup.sh` is the source of truth — this module captures the surrounding host concerns.
+---
+
+# Podman runtime
+
+A near drop-in replacement for Docker that runs **rootless** by default and integrates with `systemd --user` via Quadlet. Worth picking when:
+
+- Running Docker as root is unacceptable (multi-tenant host, security-conscious deploy).
+- The host is RHEL / Fedora / CentOS-derived where Podman is preinstalled.
+- You want systemd-managed lifecycle without writing custom unit files.
+
+## When this module is loaded
+
+User answered the **how** question with anything Podman-flavored:
+
+- "BYO VPS + Podman", "Hetzner CX + Podman", "Lightsail Ubuntu + Podman"
+- "localhost + Podman" (Linux host; Podman on macOS uses a `podman machine` VM internally)
+
+Skipped when the runtime is bundled by a vendor blueprint, when the chosen path is plain Docker, or when the project doesn't ship a Podman-aware setup script.
+
+## Host requirements
+
+- **Linux**: kernel ≥ 4.18 (for rootless). systemd is required for Quadlet auto-start (optional but recommended).
+- **macOS** (Linux container support via `podman machine`): runs containers in a Linux VM under the hood. Some bind-mount edge cases differ from Linux-native — project recipes flag these.
+- Disk: ≥ 20 GB free.
+- RAM: ≥ 2 GB free; ≥ 4 GB for image builds that compile sources.
+
+## Install Podman on the host
+
+### Debian / Ubuntu
+
+```bash
+sudo apt-get update
+sudo apt-get install -y podman podman-compose
+```
+
+### RHEL / Fedora / Amazon Linux
+
+```bash
+sudo dnf install -y podman podman-compose
+```
+
+### macOS
+
+```bash
+brew install podman
+podman machine init
+podman machine start
+```
+
+Verify:
+
+```bash
+podman --version
+podman info --format '{{.Host.RootlessNetworkCmd}}'   # should print a non-empty value on Linux rootless
+podman run --rm hello-world
+```
+
+### Rootless namespace setup (Linux, one-time per user)
+
+If `podman info` warns about subuid/subgid, fix the mappings (most distros do this automatically when the package installs):
+
+```bash
+sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$USER"
+podman system migrate    # rebuilds rootless storage with the new mappings
+```
+
+## Rootless container basics
+
+Project recipes specify the image, mounts, ports, and env vars. Generic patterns:
+
+```bash
+# Pull / build
+podman pull <image>
+podman build -t <local-tag> -f Containerfile .
+
+# Run rootless with bind-mounts (note `--userns=keep-id` so host UID maps inside)
+podman run -d --name <name> \
+  --userns=keep-id \
+  -v "$HOME/.<app>:/home/node/.<app>:Z" \   # :Z for SELinux relabeling on Fedora-likes
+  -p 127.0.0.1:<port>:<port> \
+  <image>
+
+# Lifecycle
+podman ps
+podman logs -f <name>
+podman restart <name>
+podman stop <name>
+podman rm -f <name>
+
+# Exec / shell
+podman exec -it <name> sh
+```
+
+`--userns=keep-id` is the critical rootless flag — it maps the host user's UID to the same UID inside the container, so bind-mounted host directories don't end up owned by an unmapped UID after the container writes to them.
+
+## Quadlet (systemd-user integration)
+
+Quadlet lets you write a **`.container`** file (kin to a systemd unit) and have systemd manage the container's lifecycle. No custom shell wrapper needed.
+
+```bash
+mkdir -p ~/.config/containers/systemd
+cat > ~/.config/containers/systemd/<name>.container <<'EOF'
+[Unit]
+Description=<Project> rootless gateway
+
+[Container]
+Image=<image>:latest
+ContainerName=<name>
+PublishPort=127.0.0.1:18789:18789
+Volume=%h/.<app>:/home/node/.<app>:Z
+UserNS=keep-id
+EnvironmentFile=%h/.<app>/.env
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target
+EOF
+
+systemctl --user daemon-reload
+systemctl --user start <name>.service
+systemctl --user status <name>.service
+journalctl --user -u <name>.service -f
+```
+
+For boot persistence on a headless / SSH-only host (so the service survives logout):
+
+```bash
+sudo loginctl enable-linger "$(whoami)"
+```
+
+## docker-compose compatibility
+
+`podman-compose` (a separate package) implements the docker-compose API on top of Podman. Most simple compose files work unchanged. Caveats:
+
+- Compose's `network: host` works on Linux rootful Podman but not always rootless — test before relying.
+- Compose `depends_on: condition: service_healthy` requires `podman-compose` v1.3+.
+- Some older compose v3 features (`deploy:`) are accepted but ignored.
+
+```bash
+podman-compose up -d
+podman-compose logs -f
+podman-compose down
+```
+
+For projects that ship Quadlet files alongside / instead of compose, prefer the Quadlet path — better systemd integration.
+
+## Firewall
+
+Same model as Docker — project recipes specify which ports to expose; open them at the *infra* layer (cloud firewall, `ufw`, etc.). Default: keep app ports bound to `127.0.0.1` and reach via SSH tunnel.
+
+Rootless Podman cannot bind to ports < 1024 by default. Either:
+
+- Bind to a high port (`18789`, `8080`) and reverse-proxy from `:443` via a system-managed Caddy/nginx.
+- Or grant the capability: `sudo sysctl -w net.ipv4.ip_unprivileged_port_start=80` (then write to `/etc/sysctl.d/`).
+
+## Common gotchas
+
+- **`:Z` SELinux label trap.** On Fedora/RHEL/Amazon Linux, bind-mounts without `:Z` (or `:z` for shared) get blocked by SELinux at runtime. Symptom: `Permission denied` reading host files from inside the container even though host perms look correct. Fix: add `:Z` to every bind-mount.
+- **Rootless can't restart on host reboot without linger.** `systemctl --user enable <name>` alone doesn't survive logout. Pair with `sudo loginctl enable-linger "$(whoami)"` once.
+- **`podman` and `docker` produce different image stores.** A `docker pull <image>` won't show up in `podman images` and vice versa. They don't share state. Migrating from Docker → Podman requires re-pulling.
+- **`docker.io` namespace.** Podman doesn't default to Docker Hub. Reference images by full name (`docker.io/library/postgres:16` rather than just `postgres:16`) or set a `registries.conf` short-name alias.
+- **macOS `podman machine` resource limits.** Default VM is 2 CPU / 2 GB RAM, often too small for image builds. Resize: `podman machine stop && podman machine set --cpus 4 --memory 4096 && podman machine start`.
+- **Rootless doesn't see `/var/run/docker.sock`.** Don't try to mount the Docker socket — Podman has its own at `/run/user/$UID/podman/podman.sock` if a project genuinely needs sibling-container access.
+- **`podman-compose` is not Compose v2.** Some niche features differ. If a project's compose file relies on Docker-Compose-specific extensions, fall back to Docker.
+- **`UserNS=keep-id` is mandatory for bind-mount writability.** Without it, container writes go in as a high subuid the host can't read.
+
+## Reference
+
+- Podman docs: <https://docs.podman.io/>
+- Quadlet (systemd integration): <https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html>
+- Rootless setup: <https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md>
+- `podman-compose`: <https://github.com/containers/podman-compose>


### PR DESCRIPTION
## Summary

Three semver bumps on this branch close OpenClaw deployment-method coverage from 4-of-17 (post-v0.5) to 17-of-17 against `docs.openclaw.ai/install/*`. Each commit is independent; the v0.7.0 Kubernetes section was rewritten in v0.8.0 after I realized I'd trusted a search snippet over the upstream docs (more on that below).

### Net delta vs `main`

```
3c06301  v0.8.0 — every official OpenClaw deployment method
5ea8990  v0.7.0 — Kubernetes (superseded by v0.8.0 — see Caveats)
609a624  v0.6.0 — close OpenClaw combo gaps: EC2 + Hetzner + DO + GCP adapters; native runtime
```

20 new files; ~3,900 insertions across recipes, adapters, and cross-cutting docs.

### Coverage map — 17 of 17 upstream install docs

| Upstream `docs/install/*` | open-forge recipe |
|---|---|
| `index.md`, `installer.md` | `runtimes/native.md` (covers `install.sh`, `install-cli.sh`, `install.ps1`) + openclaw.md *Native installer* section |
| `docker.md` + `docker-vm-runtime.md` | `runtimes/docker.md` + openclaw.md *Docker runtime* section |
| `podman.md` | `runtimes/podman.md` + openclaw.md *Podman runtime* section (new in v0.8.0) |
| `kubernetes.md` | `runtimes/kubernetes.md` rewritten Kustomize-first + openclaw.md *Kubernetes* section |
| `clawdock.md` | openclaw.md *ClawDock* section (new) |
| `ansible.md` | openclaw.md *Ansible* section (points to upstream `openclaw-ansible` repo) |
| `nix.md` | openclaw.md *Nix* section (points to upstream `nix-openclaw` repo) |
| `bun.md` | openclaw.md *Bun* section (experimental, dev-only) |
| `azure.md` | `infra/azure/vm.md` (Bastion-hardened, no public IP) |
| `digitalocean.md` | `infra/digitalocean/droplet.md` |
| `gcp.md` | `infra/gcp/compute-engine.md` |
| `hetzner.md` | `infra/hetzner/cloud-cx.md` |
| `oracle.md` | `infra/oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
| `hostinger.md` | `infra/hostinger.md` (Console-only via hPanel) |
| `raspberry-pi.md` | `infra/raspberry-pi.md` (Pi 4/5 64-bit) |
| `macos-vm.md` | `infra/macos-vm.md` (Lume on Apple Silicon for iMessage/BlueBubbles) |
| `fly.md` | `infra/paas/fly.md` (`fly.toml` + persistent volume; public + private modes) |
| `render.mdx` | `infra/paas/render.md` (`render.yaml` Blueprint, one-click) |
| `railway.mdx` | `infra/paas/railway.md` (one-click template) |
| `northflank.mdx` | `infra/paas/northflank.md` (one-click stack) |
| `exe-dev.md` | `infra/paas/exe-dev.md` (Shelley agent or manual nginx) |

### Major correction inside the PR

v0.7.0 added a Kubernetes section claiming OpenClaw shipped an *official Helm chart at `charts.openclaw.ai`*. That was wrong — sourced from a search snippet, not from upstream. Upstream uses **Kustomize** via `scripts/k8s/deploy.sh` and explicitly argues against Helm; community Helm charts exist (Chrisbattarbee, serhanekicii) but are not upstream-blessed. v0.8.0 rewrites both `runtimes/kubernetes.md` and the openclaw.md Kubernetes section to be Kustomize-first.

If you'd like a clean history without the back-and-forth, this is squash-merge friendly — the per-commit messages preserve the story but the squashed result is the cleaner v0.8.0 end state.

### Architecture notes

- New runtime modules (`runtimes/podman.md`) and `runtimes/native.md` extension follow the same pattern as `runtimes/docker.md`: cross-cutting concerns (host setup, lifecycle, gotchas) live in the runtime module; project-specific commands live in `projects/openclaw.md`.
- New `infra/paas/` group is a sibling of `infra/aws/`, `infra/azure/`, etc., reflecting that PaaS providers are a class of "where" with their own provisioning + lifecycle conventions.
- Combo table in `projects/openclaw.md` now enumerates upstream's two parallel axes — Hosting (where) and Containers (how) — matching `docs.openclaw.ai/install/*` organization.
- `CLAUDE.md` refactor checklist marked complete.
- `plugin.json` version `0.5.0 → 0.8.0`.

## Caveats

- **Only the AWS Lightsail blueprint path has been exercised end-to-end.** The other 16 methods are documented from upstream docs only. Each recipe carries a *TODO — verify on subsequent deployments* entry; first real deploy on each will surface gotchas to fold back per `CLAUDE.md` § *First-run discipline*.
- **Hostinger remains fundamentally browser-driven.** open-forge can't automate clicks in hPanel; the recipe reads the user-facing checklist aloud and verifies the result.
- **Cluster provisioning (EKS/GKE/AKS/DOKS) is intentionally out of scope.** open-forge orchestrates an existing cluster; users own create/delete in their cloud's k8s UI.

## Test plan

- [ ] CI passes (no CI configured in this repo today, so this is a no-op)
- [ ] First post-merge deploy: localhost + `install.sh` (cheapest first-run validation; will surface gotchas if I got the daemon lifecycle, pairing flow, or `openclaw doctor` wrong)
- [ ] Subsequent deploys against any new method fold gotchas back into the relevant recipe + bump version

https://claude.ai/code/session_01F85DthcYEpVsj9dWaN6iXF

---
_Generated by [Claude Code](https://claude.ai/code/session_01F85DthcYEpVsj9dWaN6iXF)_