### PR TITLE
修改了localhost.md

### DIFF
--- a/plugins/open-forge/skills/open-forge/references/infra/localhost.md
+++ b/plugins/open-forge/skills/open-forge/references/infra/localhost.md
@@ -1,6 +1,6 @@
 ---
 name: localhost-infra
-description: Run on the user's own machine — laptop, desktop, home server. Claude executes commands directly via Bash (no SSH). Default upstream path for many self-hosted projects (OpenClaw's `curl | bash` installer is designed for local; a hobby Ghost can run on a Mac). For public reach, pair with `modules/tunnels.md`.
+description: Run on the user's own machine — laptop, desktop, home server, or NAS. Claude executes commands directly via the local shell (no SSH required). Ideal for self-hosted projects (OpenClaw, Ollama, Plex, Home Assistant, Ghost). For public reach, pair with `modules/tunnels.md`.
 ---
 
 # Localhost — run on the user's own machine
@@ -22,9 +22,9 @@ No SSH, no IP, no SSH key. Localhost is the simplest infra by far.
 
 ## What this adapter does NOT do
 
-- **Does not provision anything.** The user's machine already exists.
-- **Does not install Docker / Docker Desktop.** Too disruptive to push silently. If the chosen runtime is Docker and Docker is missing, Claude offers to open the Docker Desktop / colima / OrbStack download page and waits for the user to install + restart their shell.
-- **Does not modify firewall rules autonomously.** macOS / Windows firewalls block inbound by default; if a tunnel is needed, that's the path (see *Public reach*), not opening firewall ports.
+- **Does not provision infrastructure.** The user's machine already exists — no cloud VMs or remote servers are created.
+- **Does not silently install Docker / Docker Desktop.** This is too disruptive. If Docker is required but missing, Claude offers to open the download page (Docker Desktop for macOS/Windows, Colima/OrbStack for macOS, or native Linux packages) and waits for installation to complete.
+- **Does not modify firewall rules autonomously.** macOS / Windows / Linux firewalls block inbound connections by default. For public access, use tunneling (see *Public reach*) instead of opening firewall ports.
 
 ## OS-specific package managers
 
@@ -36,8 +36,8 @@ Claude uses these for any prereq install (jq, curl, etc.):
 | Linux (Debian/Ubuntu) | apt | `sudo apt-get install -y <pkg>` |
 | Linux (Fedora/RHEL) | dnf | `sudo dnf install -y <pkg>` |
 | Linux (Arch) | pacman | `sudo pacman -S --noconfirm <pkg>` |
-| Windows (WSL) | apt inside WSL | same as Debian/Ubuntu |
-| Windows (native) | winget / scoop | `winget install <pkg>` or `scoop install <pkg>` |
+| Windows (WSL) | apt inside WSL | `sudo apt-get install -y <pkg>` |
+| Windows (native) | winget (preferred) / scoop | `winget install <pkg>` or `scoop install <pkg>` |
 
 Always `command -v <tool>` first; install only if missing AND the user confirms.
 
@@ -59,11 +59,15 @@ Common rule: **only set up a tunnel if the user actually needs public reach.** A
 
 ## Resource constraints
 
-Different from cloud: the user is also using their machine. Be considerate:
+Unlike cloud: the user shares their machine with other work. Be considerate:
 
-- Don't run `pnpm install` / Docker builds when the user mentioned battery / heat / "I'm in a meeting".
-- If the project keeps a daemon running (OpenClaw gateway, Plex), tell the user it'll consume RAM/CPU continuously and ask whether to launch on login.
-- Project config dirs survive reboots; running daemons don't. For "always running" set up the OS's native autostart (launchd on macOS, systemd user units on Linux, Task Scheduler on Windows). Project recipe owns the unit/plist file shape.
+- **Avoid heavy operations during busy times.** Don't run `pnpm install`, Docker builds, or large downloads if the user mentioned battery concerns, heat issues, or that they're in a meeting.
+- **Warn about background daemons.** If the project keeps a daemon running (e.g., OpenClaw gateway, Plex, Home Assistant), inform the user it'll consume RAM/CPU continuously and ask whether to launch it on login.
+- **Remember state persistence differences.** Project config directories survive reboots; running daemons do not. For "always running" services, configure the OS's native autostart mechanism:
+  - macOS: `launchd` (plist files in `~/Library/LaunchAgents/`)
+  - Linux: `systemd` user units (`systemctl --user`)
+  - Windows: Task Scheduler or Startup folder
+  The project recipe defines the unit/plist file format.
 
 ## Verification before marking `provision` done
 
@@ -83,16 +87,29 @@ Different from cloud: the user is also using their machine. Be considerate:
 | Cost | Monthly VPS bill | Electricity + the user's own hardware |
 | Always-on | Yes | Only when the machine is on |
 
-## Hand-off lines for the user
+## Hand-off summary for the user
 
-When set-up completes, give the user a clear "what's running, where, how to access it" summary:
+When setup completes, provide a clear summary of what's running, where, and how to access it:
 
 ```
-✅ <Project> is running on your <OS>.
-- Access: http://localhost:<port>
-- Config: <path>
-- To stop: <command>
-- To start again after reboot: <command>  [or — autostart configured]
+✅ <Project> is now running on your <OS> (<machine name>).
+
+📍 Access:
+   - Local:  http://localhost:<port>
+   - Remote: <tunnel URL if configured>
+
+⚙️  Configuration:
+   - Config: <path>
+   - Data:   <data directory path>
+
+🔧  Management:
+   - To stop:       <command>
+   - To start:     <command>
+   - After reboot: <command>  [or — autostart configured ✓]
+
+📊  Resource usage:
+   - Memory: <approx. RAM usage>
+   - URL:    <status page if available>
 ```
 
-Match the project recipe's outputs to this template.
+Replace placeholders with values from the project recipe.


### PR DESCRIPTION
**Update Summary for localhost.md(Optimization)**

This update enhances the accuracy, completeness, and user experience of the localhost.mdadapter documentation. Key improvements are as follows:

Core Description (description):

Added "NAS" to the list of example devices to better reflect common user scenarios.

Changed "via Bash" to "via the local shell" for accuracy across operating systems (e.g., Windows PowerShell).

Expanded the list of example self-hosted projects to include "Ollama, Plex, Home Assistant" for better recognizability.

Clarified Scope ("What this adapter does NOT do"):

Refined "provision anything" to the more precise "provision infrastructure".

Explicitly mentioned "Colima/OrbStack" as lightweight Docker alternatives for macOS users.

Clarified the installer waiting behavior.

Noted that firewall rules apply to Linux as well and emphasized tunneling over port opening.

Enhanced OS Package Manager Table:

Marked wingetas the preferred package manager for native Windows.

Added a complete example command (sudo apt-get install -y <pkg>) for the WSL (Windows Subsystem for Linux) row.

Improved "Resource constraints" Section:

Restructured with bold headings for better readability.

Added "large downloads" as an example of heavy operations to avoid.

Included "Home Assistant" as an example of a background daemon.

Crucially added the specific autostart configuration paths for each OS:

macOS: launchd(plist files in ~/Library/LaunchAgents/)

Linux: systemduser units (systemctl --user)

Windows: Task Scheduler or Startup folder

Redesigned "Hand-off" Template (now "Hand-off summary"):

Restructured and Enriched Information:

Added a "Remote:" field for public access via tunnels.

Split storage into "Config:" and "Data:" directories.

Added a "Resource usage:" section to manage user expectations (e.g., approximate RAM).

Visual & Usability Improvements:

Used emojis (✅📍⚙️🔧📊) to create visual sections for quick scanning.

Grouped management commands (Stop, Start, After reboot) under a "Management" header.