### PR TITLE
v0.19.3 — Tier 1 / Tier 2 routing + "Is software in scope?" criteria

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,39 @@ references/
 
 `localhost.md` is a first-class infra — for many projects (especially OpenClaw), running locally is the default upstream path. Same conversational UX as a cloud deploy; differences are: no SSH (Claude runs commands directly), no provisioning, public reach via tunnel (`references/modules/tunnels.md`).
 
+## Is this software in scope?
+
+open-forge is for **deployable self-hosted services**. Use these criteria when deciding whether a piece of software belongs as a Tier 1 recipe (see *Two-tier coverage model* below).
+
+### Inclusion criteria — recipe is in scope when ALL are true
+
+1. **Software runs as a deployed service or is served from a host the user owns**: long-running daemon, scheduled job, web service, API, CLI agent, or static asset published to a host.
+2. **Source code or binaries are user-installable on infrastructure they control**: cloud VM, VPS, k3s cluster, or localhost. Paid AMIs / vendor stacks (Bitnami, Dify Premium, etc.) count — closed-source SaaS-only does not.
+3. **At least one upstream-documented install method or canonical install artifact in-repo** exists, so the strict-doc-policy below has something to verify against.
+
+### Exclusion criteria — out of scope
+
+- **Pure libraries / SDKs / packages** that you `import` or call (Unsloth, requests, lodash). No deployment surface.
+- **Desktop / mobile end-user apps** with no self-hosted server side (Slack desktop, VS Code, Discord client).
+- **SaaS / managed-only products** with no self-host distribution (Notion, Linear, Figma).
+- **Dev-only tooling that runs ephemerally on a developer machine** and is never deployed (Storybook *dev* mode, Vite dev server, REPLs).
+
+### Edge cases — borderline classes
+
+| Class | Verdict | Recipe shape |
+|---|---|---|
+| **Static-site generators** (Hugo, Jekyll, Docusaurus, Storybook in production-preview mode) | ✅ in scope | Thin: `<sg> build` → static dir → deploy via a static-host module (nginx / S3+CDN / Pages). The SG-specific bit is build config, theme path, content tree. |
+| **CLI agents** (Aider, OpenClaw, Hermes-Agent) | ✅ in scope | Install on a host, run as daemon or interactive CLI. Standard recipe shape. |
+| **AI inference servers** (vLLM, Ollama, TGI) | ✅ in scope | Deployed services exposing HTTP APIs. Standard recipe shape. |
+| **AI training libraries** (Unsloth, axolotl, transformers) | ❌ out of scope | Libraries called from training scripts, not deployed services. If a "training environments" track ever exists, it's a separate category — not project recipes under `references/projects/`. |
+| **CI runners** (GitHub Actions self-hosted, Buildkite agent) | ✅ in scope | Long-running daemon attached to a control plane. Standard recipe shape. |
+| **Standalone databases** (Postgres, ClickHouse, Redis) | ⚠️ borderline | Useful but usually a dependency of another recipe rather than a deployment goal. Document as a supporting service inside the consuming recipe; only write a standalone recipe when there's clear demand. |
+| **Storage backends** (MinIO, SeaweedFS, Garage) | ✅ in scope | Self-hostable services with HTTP APIs. Standard recipe shape. |
+
+### When in doubt
+
+Ask: *"Would the user need open-forge to walk them through provisioning + DNS + TLS + ongoing lifecycle for this?"* If yes, write a recipe. If no (e.g. they'd just `pip install` it inside their own scripts), it's out of scope — or fall back to Tier 2 (below) for one-off requests.
+
 ## Operating principles
 
 1. **Do more, ask less. Non-tech-friendly.** Default to autonomous execution. Only prompt the user for things only they can decide or provide: credentials, opinionated choices, things that touch their accounts at other companies. Hide everything Claude can figure out from the recipe.
@@ -112,6 +145,43 @@ When this policy is added (or strengthened), every existing recipe must be re-ve
 ### When in doubt
 
 Ask the user whether to pause for verification or accept the README's enumeration. Don't silently downgrade thoroughness.
+
+---
+
+## Two-tier coverage model
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for everything else (Tier 2). Both tiers obey the strict-doc-policy above; the difference is *when* the verification happens.
+
+### Tier 1 — verified recipes (the catalogue)
+
+The current set under `references/projects/`. Authored ahead of time, audited against upstream docs, kept current via the first-run discipline + version bumps. **Quality bar:**
+
+- Every install method has a `> **Source:** <upstream URL>` line at the top of its section.
+- Community-maintained methods open with the required ⚠️ blockquote per *Community-maintained methods — flagging requirements*.
+- Gotchas captured from real deploys; TODOs track unresolved verifications.
+- Plugin version bumped on each user-visible change.
+
+### Tier 2 — derived live from upstream docs
+
+When a user asks for software that has no Tier 1 recipe, the skill **falls back** instead of refusing:
+
+1. **Announce the fallback in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Apply the strict-doc-policy on the fly** — same rules as Tier 1:
+   - Read upstream README via `WebFetch`. If 403/404, fall back to `raw.githubusercontent.com` paths and/or `git clone` the docs repo locally.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate methods from upstream — **do not invent**. If fetches fail, stop and tell the user; never speculate to fill a gap.
+   - Read canonical install artifacts (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`).
+3. **Reuse runtime + infra + cross-cutting modules** under `references/runtimes/`, `references/infra/`, `references/modules/` for all the reusable parts (Docker install, k8s prereqs, VM provisioning, DNS, TLS, SMTP). Tier 2 is mostly *software-specific* on top of those — same shape as Tier 1, just authored at request time.
+4. **Cite every upstream URL** the same way Tier 1 does.
+5. **Offer to capture the result** as a new Tier 1 recipe when the deploy succeeds — that's how the catalogue grows. The captured recipe must still go through first-run discipline before claiming Tier 1 status.
+
+### Routing
+
+The skill checks Tier 1 first by name match against `references/projects/*.md`. If no match, fall back to Tier 2 with the announcement above. **Never silently mix tiers** — the user should always know which tier they're in, since the verification depth differs.
+
+### Quality boundary
+
+Tier 2 output is **best-effort, not authoritative.** It will hallucinate at the edges of upstream docs we couldn't fetch; it skips the iterative refinement that Tier 1 recipes get from real deploys. Tell the user this. They're trading verification depth for coverage breadth.
 
 ---
 

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-forge",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, helm, podman, docker, lume, tailscale, terraform, cdk, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw, Hermes-Agent, Ollama, Open WebUI, Stable Diffusion WebUI (Automatic1111), ComfyUI, Dify, LibreChat, AnythingLLM, Aider, vLLM, Langfuse. AI stack focus: Ollama (single-user LLM inference) + vLLM (production-grade LLM inference) + Open WebUI / LibreChat (multi-user chat UIs) + Stable Diffusion WebUI / ComfyUI (image generation) + AnythingLLM (RAG-focused workspace) + Aider (terminal pair-programming CLI) + Langfuse (LLM observability + evals) compose into a complete local-AI stack; OpenClaw + Hermes-Agent are agent projects; Dify is the LLMOps platform layer. Every recipe is verified against upstream's docs index per the strict-doc policy in CLAUDE.md (community-maintained methods are explicitly flagged when upstream ships no first-party version).",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -86,6 +86,34 @@ The **how** question is *dynamically generated* from (software, where) — each 
 
 Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
 
+## Tier 1 vs Tier 2 routing
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for the long tail (Tier 2). When the user names a piece of software, decide which tier you're in **before** loading anything.
+
+### Tier 1 — verified recipe exists
+
+If `references/projects/<name>.md` matches the user's software, you're in Tier 1. Load it, follow it, and stay in the standard workflow below.
+
+### Tier 2 — no recipe; derive from upstream live
+
+If no recipe matches, **don't refuse — fall back to Tier 2**:
+
+1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Fetch upstream the same way Tier 1 does**:
+   - `WebFetch` the upstream README first. If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
+   - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
+3. **Reuse the existing modules**: drive the Docker install via `runtimes/docker.md`, Kubernetes via `runtimes/kubernetes.md`, VM provisioning via `infra/<cloud>/*.md`, DNS / TLS / SMTP via `references/modules/`. The Tier 2 work is only the software-specific bits on top.
+4. **Cite every upstream URL** in chat the same way Tier 1 sections do (`> Source: <url>`).
+5. **Offer to capture the result** as a new Tier 1 recipe once the deploy succeeds — that's how the catalogue grows. Captured recipes must go through first-run discipline before promotion.
+
+**Quality boundary:** Tier 2 output is best-effort, not authoritative. It will hallucinate at the edges of upstream docs we couldn't fetch and skips the real-deploy refinement Tier 1 recipes get. Always tell the user which tier you're in; never silently mix.
+
+### Out-of-scope software
+
+Some user requests are not deployable services at all (libraries like Unsloth or `requests`, desktop apps like Slack, SaaS like Notion). When you detect this, say so clearly and offer the closest in-scope alternative if there is one. See CLAUDE.md § *Is this software in scope?* for criteria.
+
 ## Phased workflow
 
 Each phase is verifiable and resumable. Do NOT batch phases — complete, verify, and update state before moving on.


### PR DESCRIPTION
## Summary

Codifies two architectural decisions discussed in the audit-fix thread:

1. **What counts as "in scope" for an open-forge recipe** — explicit inclusion + exclusion criteria, and an edge-case table for borderline classes (static-site generators, CLI agents, AI inference vs training libraries, databases, storage backends).
2. **Tier 1 vs Tier 2 coverage model** — the verified recipe catalogue (Tier 1) plus a documented fallback to LLM-derived live-from-upstream-docs for software not in the catalogue (Tier 2). Both tiers obey the strict-doc-policy; the difference is *when* the verification happens.

Bumps plugin to **v0.19.3** since this is a user-visible behavior change (Claude will now fall back to Tier 2 instead of refusing when a recipe doesn't match).

## What changed

### `CLAUDE.md` — two new sections (~70 lines)

- **§ Is this software in scope?** Inclusion criteria, exclusion criteria, edge-case table, decision rule (*"would the user need open-forge to walk them through provisioning + DNS + TLS + ongoing lifecycle?"*).
- **§ Two-tier coverage model** Defines Tier 1 vs Tier 2, the Tier 2 workflow (announce → fetch upstream → reuse modules → cite URLs → offer to capture), routing rule (Tier 1 first, never silently mix), and the explicit quality boundary (Tier 2 is best-effort, not authoritative).

### `SKILL.md` — one new section (~28 lines)

- **§ Tier 1 vs Tier 2 routing** Tells Claude how to detect tier, the fallback steps, the requirement to announce tier to the user, and how to handle out-of-scope software (libraries / desktop / SaaS-only) by saying so explicitly.

### `plugin.json`

- Version bump 0.19.2 → 0.19.3.

## Why two-tier instead of "more recipes"

Catalogue scaling: there are 1,000+ self-hostable apps. Writing strict-doc-policy-grade recipes for all of them is months of work. Tier 2 lets the skill cover the long tail today (best-effort) while we iteratively promote demand-driven items to Tier 1 (authoritative) via first-run discipline.

## Test plan

- [ ] CLAUDE.md renders with two new sections in correct order (after Architecture; after Strict doc-verification policy).
- [ ] SKILL.md routing section renders between *Selection* and *Phased workflow*.
- [ ] Live test: ask Claude (with the skill loaded) to "self-host Vaultwarden" (not in catalogue) — confirm it announces Tier 2 fallback and starts fetching upstream docs rather than refusing.
- [ ] Live test: ask Claude to "self-host Unsloth" — confirm it identifies as out-of-scope per the new criteria and explains why.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_