### PR TITLE
v0.20.0 — issue-driven contribution model + post-deploy feedback flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Use the open-forge skill
+    url: https://github.com/zhangqi444/open-forge#install
+    about: For deployment help, install the open-forge plugin and run the skill — it walks you through provisioning, DNS, TLS, and lifecycle in a guided chat. Issues are for catalogue feedback / nominations / method proposals (see templates above), not for deployment support.
+  - name: Read CLAUDE.md
+    url: https://github.com/zhangqi444/open-forge/blob/main/CLAUDE.md
+    about: How the project decides what's in scope, the strict-doc-verification policy, the issue-driven contribution model, and Tier 1 vs Tier 2.

--- a/.github/ISSUE_TEMPLATE/method-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/method-proposal.yml
@@ -1,0 +1,81 @@
+name: Method proposal (missing install method)
+description: Propose adding an upstream-supported install method that an existing recipe doesn't cover.
+title: "[method-proposal] <recipe>: add <method>"
+labels: ["method-proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Strict-doc-policy applies.** The proposed method must be documented by upstream — either in the README, the project's docs site, the repo's `docs/install/` tree, or the wiki. Community-maintained methods are also acceptable but will be flagged with a community-maintained blockquote per CLAUDE.md.
+
+  - type: input
+    id: recipe
+    attributes:
+      label: Recipe to extend
+      description: Filename under `references/projects/`.
+      placeholder: ollama.md
+    validations:
+      required: true
+
+  - type: input
+    id: method_name
+    attributes:
+      label: Method name
+      description: Short name for the install method (e.g. "Helm chart", "Snap package", "Docker Desktop extension").
+      placeholder: Snap package
+    validations:
+      required: true
+
+  - type: input
+    id: upstream_url
+    attributes:
+      label: Upstream URL documenting this method
+      description: Direct link to the upstream doc / install file / README section that covers this method.
+      placeholder: https://github.com/ollama/ollama/blob/main/docs/snap.md
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source_type
+    attributes:
+      label: Source type
+      options:
+        - First-party — published by upstream
+        - Community-maintained (will require ⚠️ blockquote per policy)
+    validations:
+      required: true
+
+  - type: textarea
+    id: canonical_commands
+    attributes:
+      label: Canonical install command(s)
+      description: |
+        Quote the upstream install instructions verbatim. The AI session that processes this issue will re-fetch the upstream URL and verify, but starting from your quote saves a round-trip.
+      placeholder: |
+        ```bash
+        sudo snap install ollama
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why this method matters
+      description: When would a user pick this method over the existing options in the recipe?
+      placeholder: |
+        Snap packages are the default on Ubuntu Server installs and auto-update.
+        For users who already use snap for everything, having ollama via snap
+        avoids juggling two package managers.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have verified the upstream URL above shows this install method on the current upstream version.
+          required: true
+        - label: I have not included any credentials, IP addresses, or other identifiers in this issue.
+          required: true

--- a/.github/ISSUE_TEMPLATE/recipe-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/recipe-feedback.yml
@@ -1,0 +1,88 @@
+name: Recipe feedback (deployment notes)
+description: Share what you learned deploying via the open-forge skill — gotchas, install steps that surprised you, sections that were wrong/outdated.
+title: "[recipe-feedback] <recipe>: <one-line summary>"
+labels: ["recipe-feedback"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Sanitization reminder.** This issue will be public and permanent on GitHub. Strip every domain, IP, SSH key path, API key, AWS account ID, and email before submitting. The open-forge skill drafts these issues with redaction applied automatically — if you're filing manually, double-check.
+        >
+        > **License + liability.** By submitting, you grant a non-revocable license to use this content in the open-forge recipe; the project bears no liability for your decision to share.
+
+  - type: input
+    id: recipe
+    attributes:
+      label: Recipe
+      description: Filename under `references/projects/` (e.g. `ghost.md`, `openclaw.md`).
+      placeholder: ghost.md
+    validations:
+      required: true
+
+  - type: input
+    id: combo
+    attributes:
+      label: Combo (infra × runtime)
+      description: Which infra adapter and runtime did you use?
+      placeholder: DigitalOcean droplet / Ghost-CLI on Ubuntu
+    validations:
+      required: true
+
+  - type: input
+    id: plugin_version
+    attributes:
+      label: Plugin version
+      description: From `plugins/open-forge/.claude-plugin/plugin.json`. Helps us know whether your feedback applies to current state.
+      placeholder: "0.20.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Outcome
+      options:
+        - Deploy succeeded (with notes)
+        - Deploy succeeded after retries
+        - Deploy failed; recovered manually
+        - Deploy failed; abandoned
+        - Recipe was outdated / contradicted upstream
+    validations:
+      required: true
+
+  - type: textarea
+    id: what_recipe_missed
+    attributes:
+      label: What the recipe missed
+      description: Concrete description of what surprised you, what failed, what required manual intervention. Sanitized.
+      placeholder: |
+        In the `tls` phase, `ghost install` errored because DNS hadn't propagated yet.
+        The recipe says "DNS must propagate first" but doesn't tell Claude to actually
+        `dig` and wait before running `ghost install`.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggested_edit
+    attributes:
+      label: Suggested edit (optional — diff format preferred)
+      description: If you have a specific change in mind, paste it here as a diff or as a "before / after". The AI session that processes this issue will re-verify against upstream before applying.
+      placeholder: |
+        ```diff
+        @@ Method — Ghost-CLI on Ubuntu @@
+        -DNS A-record must already point to the server's IP.
+        +DNS A-record must already point to the server's IP. Verify with
+        +`dig +short ${CANONICAL_HOST}` and block until it returns the IP
+        +— Ghost-CLI runs Let's Encrypt inline.
+        ```
+
+  - type: checkboxes
+    id: sanitization
+    attributes:
+      label: Sanitization confirmation
+      description: Confirm you reviewed every line for identifiers before submitting.
+      options:
+        - label: I have stripped all domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses from this issue body.
+          required: true
+        - label: I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+          required: true

--- a/.github/ISSUE_TEMPLATE/software-nomination.yml
+++ b/.github/ISSUE_TEMPLATE/software-nomination.yml
@@ -1,0 +1,84 @@
+name: Software nomination (add to Tier 1 catalogue)
+description: Nominate a self-hostable open-source app to be added to the Tier 1 catalogue under `references/projects/`.
+title: "[software-nomination] <project name>"
+labels: ["software-nomination"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Before nominating**, check the current catalogue at <https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects> and the *Is this software in scope?* section in CLAUDE.md.
+        >
+        > **Tier 2 already covers anything not in the catalogue.** A nomination requests *Tier 1* treatment (verified recipe with first-run discipline). Per the demand-driven graduation criteria, nominations need a real reason — repeat deploys, painful gotchas, or a maintainer pickup — to land.
+
+  - type: input
+    id: software_name
+    attributes:
+      label: Software name
+      placeholder: Vaultwarden
+    validations:
+      required: true
+
+  - type: input
+    id: upstream_repo
+    attributes:
+      label: Upstream repo URL
+      placeholder: https://github.com/dani-garcia/vaultwarden
+    validations:
+      required: true
+
+  - type: input
+    id: upstream_docs
+    attributes:
+      label: Upstream install-method index URL
+      description: Where do install methods live? Docs site, repo `docs/install/` tree, or wiki.
+      placeholder: https://github.com/dani-garcia/vaultwarden/wiki
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why Tier 1?
+      description: |
+        What's painful about this software's install that compounds across deploys? Per the graduation criteria, a Tier 1 recipe earns its keep when the captured tribal knowledge saves the next user real pain. If this is "I just want a recipe", a Tier 2 deploy may already be enough.
+      placeholder: |
+        I've deployed Vaultwarden 4 times — each time I forget that the
+        admin token has to be set via env var BEFORE first run, and the
+        SMTP config requires `secure: starttls` not `secure: true`. The
+        Wiki has these but it's spread across 6 pages.
+    validations:
+      required: true
+
+  - type: input
+    id: intended_combo
+    attributes:
+      label: Intended deploy combo (infra × runtime)
+      description: Which infra adapter and runtime would you use? Helps us know which combos to prioritize.
+      placeholder: Hetzner Cloud CX / Docker
+    validations:
+      required: true
+
+  - type: dropdown
+    id: in_scope_check
+    attributes:
+      label: In-scope check
+      description: Per CLAUDE.md § *Is this software in scope?*, this software is —
+      options:
+        - A deployable service (web app / API / daemon / CLI agent)
+        - A static-site generator (build → deploy static dir)
+        - An AI inference server (HTTP API)
+        - A CI runner (long-running daemon attached to a control plane)
+        - A storage backend (HTTP-API self-hostable)
+        - I'm not sure — please advise
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+          required: true
+        - label: This software has at least one upstream-documented install method or canonical install artifact in-repo.
+          required: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,140 @@ The skill checks Tier 1 first by name match against `references/projects/*.md`. 
 
 Tier 2 output is **best-effort, not authoritative.** It will hallucinate at the edges of upstream docs we couldn't fetch; it skips the iterative refinement that Tier 1 recipes get from real deploys. Tell the user this. They're trading verification depth for coverage breadth.
 
+### Tier 2 → Tier 1 graduation criteria
+
+The catalogue grows demand-driven, not by guess. Promote a Tier 2 deploy to a Tier 1 recipe when ANY of:
+
+1. **3+ feedback issues** for the same software (demand signal — see *Issue-driven contribution model*).
+2. **Same user has deployed it 3+ times** and asks for first-run discipline applied.
+3. **A Tier 2 deploy surfaced a non-obvious gotcha** that's likely to bite the next person — capture the gotcha as a recipe even if demand is small (one-shot promotion is allowed when the value is in the captured knowledge).
+4. **A maintainer chooses to deploy the software themselves** (sunk cost is acceptable).
+
+Don't author Tier 1 recipes speculatively from a "popular self-host" list — without a real demand signal, the compounding effect can't kick in and the upfront cost goes to waste.
+
+---
+
+## Issue-driven contribution model
+
+The catalogue evolves through GitHub issues, not direct human PRs. AI coding sessions (whether triggered by a maintainer running this skill, by a scheduled job, or by a webhook) read incoming issues, verify them against upstream docs per *Strict doc-verification policy*, and author patches.
+
+### Three input channels
+
+GitHub issue templates under `.github/ISSUE_TEMPLATE/` define the structured input:
+
+| Template | When to use | Filed by |
+|---|---|---|
+| `recipe-feedback.yml` | A user deployed via the skill and wants to suggest recipe edits (gotchas captured, install steps that surprised them, sections that were wrong/outdated). The skill drafts these automatically at the end of a deploy. | End user (skill-assisted) |
+| `software-nomination.yml` | A user wants software added to the Tier 1 catalogue. Must include rationale + upstream URL + the user's intended deploy combo. | End user |
+| `method-proposal.yml` | A user knows an upstream-supported install method that an existing recipe doesn't cover. Must include the upstream URL where the method is documented. | End user |
+
+A blank-issue / off-template issue is treated as a request for routing — close politely with a pointer to the templates.
+
+### Why issues, not PRs
+
+- **Sanitization happens at submission time.** The skill (or a careful manual filer) redacts identifiers before posting; the issue templates encode the structure. PRs from random users could include credentials in commit history that can't be cleanly removed.
+- **Verification happens centrally.** Every change is re-verified against upstream by the AI session that processes the issue, not trusted because someone filed a PR.
+- **Demand signal lives in the issue stream.** Issues with the most thumbs-up / cross-linking / repeat filings are the demand signal that drives Tier 2 → Tier 1 graduation.
+
+### Direct human PRs
+
+Discouraged. If a maintainer writes a PR by hand, it's still subject to the strict-doc-policy and recipe-structure rules — the issue model is the documented contribution path.
+
+---
+
+## Sanitization principles
+
+User-shared content (deployment logs, gotchas, error output) routinely contains identifiers that **must not** end up in the public repo. Both the skill (when drafting issue content) and any session reviewing user-supplied content (when accepting a PR sourced from an issue) must apply these rules.
+
+### Always strip
+
+| Class | Replace with |
+|---|---|
+| Domain names (apex / canonical / admin) | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| IP addresses (public + private + IPv6) | `${PUBLIC_IP}` / `${PRIVATE_IP}` |
+| SSH key paths and contents | `${KEY_PATH}` / `<REDACTED-SSH-KEY>` |
+| API keys and bearer tokens (regex: `re_[A-Za-z0-9_]+`, `SG\.[A-Za-z0-9._-]+`, `sk-[A-Za-z0-9]+`, `xox[bp]-[A-Za-z0-9-]+`, `ghp_[A-Za-z0-9]+`, AWS access keys `AKIA[0-9A-Z]{16}` + secret `[A-Za-z0-9/+=]{40}`, GCP service-account JSON, generic `Bearer [A-Za-z0-9._-]{20,}`) | `<REDACTED>` |
+| AWS account IDs (12 consecutive digits in AWS context) | `${AWS_ACCOUNT}` |
+| AWS profile names | `${AWS_PROFILE}` |
+| Email addresses (LE email, SMTP from-address, user identity) | `${EMAIL}` |
+| State-file contents from `~/.open-forge/deployments/<name>.yaml` | Reference the file by name only, never paste contents |
+| Hostnames embedded in URLs that include the user's domain | `https://${CANONICAL_HOST}/path` |
+| Anything from the user's clipboard / env vars they pasted into chat | `<REDACTED>` |
+
+### Multi-step consent (no auto-post, ever)
+
+The skill flow when posting feedback to GitHub:
+
+1. **Opt-in prompt** — *"Want to share what you learned?"* User must explicitly opt in.
+2. **Show the redacted draft in chat** — full text, before any submission attempt.
+3. **Confirm post?** — explicit "yes" required.
+4. **If user edits the draft**, re-show + re-confirm before submitting.
+5. **Standing reminder text** in the prompt: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; edit if anything looks identifiable."*
+6. **Liability notice in the issue body**: *"Submitter grants a non-revocable license to use this content in the open-forge recipe; the project bears no liability for the submitter's choice to share."*
+
+### When reviewing PRs sourced from issues
+
+Issue-processing sessions must re-scan PR diffs against the same strip-list before merging. If any identifier slipped through, redact in the PR before merge — never merge content with live identifiers.
+
+---
+
+## Processing incoming issues
+
+When an AI coding session is asked to process incoming issues (whether by a maintainer prompt, a scheduled job, or a webhook), apply this workflow:
+
+### 1. Triage
+
+For each open issue without an `applied` / `out-of-scope` / `needs-info` label:
+
+- Identify the template type from the issue body's structured fields. If the issue doesn't follow a template, comment with a pointer to the templates and label `needs-info`.
+- Validate that the issue is in scope per *Is this software in scope?*. Out-of-scope → comment + `out-of-scope` label + close.
+- Otherwise, label `triaged` and proceed to validation.
+
+### 2. Validate against upstream
+
+Apply *Strict doc-verification policy* to every change:
+
+- For `recipe-feedback`: re-fetch the recipe's cited upstream URLs; verify the user's proposed change is consistent with current upstream content. If upstream has drifted in a way that conflicts with the user's report, prefer upstream and explain the discrepancy in the PR.
+- For `software-nomination`: confirm the software passes inclusion criteria; locate upstream's install-method index; do **not** start authoring a recipe until the index is reachable.
+- For `method-proposal`: confirm the cited upstream URL documents the method; if it's community-maintained, it must be flagged per *Community-maintained methods — flagging requirements*.
+
+If validation fails (upstream URL 404s, software is out of scope, methodology is unverifiable), comment on the issue explaining + label `needs-info` or `out-of-scope` as appropriate. Do not author a patch.
+
+### 3. Author the patch
+
+- Apply the change per *Recipe structure (must-have sections)*.
+- Cite the upstream URL at the top of every section per *Strict doc-verification policy*.
+- Flag community-maintained methods with the required ⚠️ blockquote.
+- Re-scan against the *Sanitization principles* strip-list — if any identifier slipped through user-supplied content, redact before drafting.
+- Bump `plugin.json` `version` per *Versioning + publish flow*.
+- If multiple feedback issues for the same recipe are pending, batch them into a single PR.
+
+### 4. Open the PR
+
+- **Branch naming**: `bot/issue-<N>-<short-slug>` (where `<N>` is the originating issue number).
+- **Commit author**: `Qi Zhang <zhangqi444@gmail.com>` per *Author convention*.
+- **PR body** must cite (a) the originating issue number(s), (b) every upstream URL re-verified, (c) the version bump rationale.
+- After opening, label the issue `in-progress`. After merge, relabel `applied`.
+
+### 5. State-machine via labels
+
+| Label | Meaning |
+|---|---|
+| (none) | New issue, not yet triaged |
+| `triaged` | Identified template type + scope-checked; ready to validate |
+| `in-progress` | A PR is open against this issue |
+| `applied` | PR merged; issue resolved |
+| `needs-info` | Author needs to provide more before processing can continue |
+| `out-of-scope` | Software / request doesn't meet inclusion criteria; closed |
+
+Optionally also: `recipe:<name>`, `tier:1`, `tier:2`, `infra:<cloud>`, `runtime:<runtime>` for filtering.
+
+### 6. Conflicts and ambiguity
+
+- **Contradicting suggestions across issues**: prefer upstream-doc-verified content; cite the upstream URL in the PR explaining which suggestion was chosen and why.
+- **Ambiguous suggestion**: if the issue is unclear about what should change, comment asking for clarification with a deadline (e.g. *"reply within 14 days or this issue will be auto-closed"*) and label `needs-info`.
+- **Idempotency**: never re-process an issue already labeled `applied`. If the same recipe issue resurfaces under a new issue number, treat it as a fresh demand signal (counts toward Tier 2 → Tier 1 graduation per *Two-tier coverage model*).
+
 ---
 
 ## Companion skills & MCPs
@@ -239,6 +373,8 @@ When a recipe is exercised end-to-end against a real deployment for the first ti
 
 This is how the recipe stops being a guess and becomes a known-working deployment template. Don't skip it.
 
+The dominant path for first-run discipline is now **user-submitted feedback issues** processed per *Processing incoming issues* — the skill drafts a sanitized issue at the end of each deploy and the user opts in to share. Maintainer-driven deploys (where the maintainer is also the recipe author) still apply for new recipes. Either way, the same five-step capture applies.
+
 ## File layout
 
 ```
@@ -268,11 +404,13 @@ open-forge/
 - **Bump on**: skill description change, new project/runtime/infra, major recipe rewrite, anything that changes user-visible behavior.
 - **Don't bump on**: typo fixes, internal comment cleanups, lint-only changes.
 
-Publish flow:
+Publish flow (typical path: AI session processing an issue per *Issue-driven contribution model*):
 
-1. Local commit (with version bump if applicable).
-2. `git push` to `github.com/zhangqi444/open-forge`.
-3. End user runs `/plugin marketplace update zhangqi444/open-forge` then re-installs.
+1. Commit the change with version bump if applicable. Author per *Author convention*.
+2. Push to `github.com/zhangqi444/open-forge` — typically as a PR opened against `main` (branch name per *Processing incoming issues*).
+3. After merge, end users run `/plugin marketplace update zhangqi444/open-forge` then re-install.
+
+Maintainer manual edits follow the same flow but skip the issue-tracking labels.
 
 ## Author convention
 

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-forge",
-  "version": "0.19.3",
+  "version": "0.20.0",
   "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, helm, podman, docker, lume, tailscale, terraform, cdk, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw, Hermes-Agent, Ollama, Open WebUI, Stable Diffusion WebUI (Automatic1111), ComfyUI, Dify, LibreChat, AnythingLLM, Aider, vLLM, Langfuse. AI stack focus: Ollama (single-user LLM inference) + vLLM (production-grade LLM inference) + Open WebUI / LibreChat (multi-user chat UIs) + Stable Diffusion WebUI / ComfyUI (image generation) + AnythingLLM (RAG-focused workspace) + Aider (terminal pair-programming CLI) + Langfuse (LLM observability + evals) compose into a complete local-AI stack; OpenClaw + Hermes-Agent are agent projects; Dify is the LLMOps platform layer. Every recipe is verified against upstream's docs index per the strict-doc policy in CLAUDE.md (community-maintained methods are explicitly flagged when upstream ships no first-party version).",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -198,6 +198,52 @@ Each recipe and adapter has its own **"Inputs to collect"** section listing exac
 
 Never mark a phase `done` without verification.
 
+## Post-deploy feedback (closes the catalogue evolution loop)
+
+After `hardening` (or after the user explicitly says "we're done", or after they abort mid-phase and want to share what they learned), offer to file a GitHub issue with the deployment notes. Per CLAUDE.md § *Issue-driven contribution model*, this is how the catalogue evolves — the bot or a future Claude session reads these issues and patches the recipes.
+
+Three flows the user can trigger from this prompt:
+
+1. **Recipe feedback** (default at end of deploy) — submit gotchas, suggested edits, or "the recipe was outdated". Claude self-summarizes from the session; the user reviews + opts in.
+2. **Software nomination** — when the user asked to deploy something not in the catalogue and Tier 2 worked, offer to nominate it for Tier 1.
+3. **Method proposal** — when the user discovered an upstream-supported install method the recipe doesn't cover.
+
+### The flow (multi-step consent — never auto-post)
+
+Load `references/modules/feedback.md` for the full sanitization rules + draft templates + submission paths. Summary:
+
+1. **Opt-in prompt**:
+   - Recipe feedback: *"Want to share what you learned with the open-forge project? I can draft a sanitized GitHub issue with the gotchas + suggested edits — you review, then post."*
+   - Software nomination (Tier 2 deploy): *"This software isn't in the Tier 1 catalogue yet. Want to nominate it? I'll draft an issue with the rationale + upstream URLs."*
+   - User must explicitly opt in (no auto-post).
+2. **Self-summarize the session**:
+   - Which recipe + combo was used, plugin version.
+   - Which phases ran, which retried, which failed.
+   - Where the user got prompted unexpectedly (gaps in the recipe).
+   - Any gotchas Claude observed (commands that failed, error messages, deviations from the documented path).
+3. **Draft the issue** in the format from `references/modules/feedback.md`:
+   - Specific recipe-edit suggestions (preferred: as a diff), not free-prose.
+   - All identifiers redacted per CLAUDE.md § *Sanitization principles*.
+4. **Show the redacted draft in chat — full text — before any submission attempt.**
+5. **Standing reminder**: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; if anything looks identifiable to you, edit before posting. By submitting, you grant a non-revocable license to use this content in the recipe; the project bears no liability for your decision to share."*
+6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
+7. **Submit via the first available path**:
+   - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
+   - GitHub MCP `mcp__github__issue_write` if available.
+   - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
+
+### Sanitization is mandatory
+
+Per CLAUDE.md § *Sanitization principles* — strip every domain, IP, SSH key path, API key, AWS account ID, email address, state-file content, and anything from the user's clipboard / env vars before showing the draft. Use the patterns + replacements documented in `references/modules/feedback.md`.
+
+If you find something in the draft that you can't confidently classify as safe, **redact it** rather than ship it. The user's review pass is a safety net, not the only line of defense.
+
+### When to skip
+
+- User says "no thanks" or doesn't reply → drop it, don't pester.
+- Deploy aborted very early (before any state was created) → no useful feedback to capture; skip.
+- Tier 2 deploy that obviously wasn't in scope (e.g. user tried to "self-host" a library) → don't nominate; politely explain it's out of scope per CLAUDE.md § *Is this software in scope?*.
+
 ## Common pitfalls across infras/projects
 
 - **Stale DNS**: browsers cache 301 responses with long max-age. After any HTTP↔HTTPS or apex↔www redirect change, suggest hard reload or incognito.

--- a/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+++ b/plugins/open-forge/skills/open-forge/references/modules/feedback.md
@@ -1,0 +1,240 @@
+---
+name: feedback
+description: Post-deploy feedback module — sanitization rules + draft templates + submission paths for the three GitHub-issue input channels (recipe-feedback / software-nomination / method-proposal). Loaded by SKILL.md § Post-deploy feedback.
+---
+
+# Feedback module — drafting + submitting GitHub issues
+
+This module is loaded after a deploy completes (or is abandoned) when the user opts in to share what they learned. Implements the multi-step consent flow described in CLAUDE.md § *Sanitization principles* and SKILL.md § *Post-deploy feedback*.
+
+**Hard rule:** never post without showing the redacted draft + getting explicit "yes" from the user. The skill is the user's submitter; consent gates everything.
+
+---
+
+## Sanitization checklist
+
+Apply BEFORE drafting. Scan the deployment session — including chat transcript, any tool outputs Claude has in context, any state-file references — and replace identifiers per the table.
+
+### Strip-list (regex patterns + replacements)
+
+| Class | Detection | Replacement |
+|---|---|---|
+| **Domains** (apex, www, admin) | Anything matching the user's `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` collected during inputs, plus generic FQDNs in URL paths the user typed | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| **Public IPv4** | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (excluding RFC-1918 ranges if you want to allow them as `${PRIVATE_IP}`) | `${PUBLIC_IP}` |
+| **Private IPv4** | `\b(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)[0-9.]+\b` | `${PRIVATE_IP}` (or strip if it leaks network topology) |
+| **IPv6** | Standard IPv6 patterns | `${PUBLIC_IPV6}` / `${PRIVATE_IPV6}` |
+| **SSH key paths** | Anything matching `~/.ssh/[^ ]+`, `/home/[^/]+/\.ssh/[^ ]+`, `*.pem`, `*.priv`, `id_(rsa|ed25519|ecdsa)` | `${KEY_PATH}` |
+| **SSH key contents** | `-----BEGIN [A-Z ]+ KEY-----` blocks | `<REDACTED-SSH-KEY>` |
+| **Resend API key** | `re_[A-Za-z0-9_]+` | `<REDACTED-RESEND-KEY>` |
+| **SendGrid API key** | `SG\.[A-Za-z0-9._-]+` | `<REDACTED-SENDGRID-KEY>` |
+| **OpenAI API key** | `sk-[A-Za-z0-9]{20,}` | `<REDACTED-OPENAI-KEY>` |
+| **Anthropic API key** | `sk-ant-[A-Za-z0-9_-]{20,}` | `<REDACTED-ANTHROPIC-KEY>` |
+| **Slack tokens** | `xox[bp]-[A-Za-z0-9-]+` | `<REDACTED-SLACK-TOKEN>` |
+| **GitHub PAT** | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]+` | `<REDACTED-GH-PAT>` |
+| **AWS access key ID** | `AKIA[0-9A-Z]{16}` | `<REDACTED-AWS-KEY>` |
+| **AWS secret key** | After `aws_secret_access_key`, 40-char base64 | `<REDACTED-AWS-SECRET>` |
+| **AWS account ID** | 12 consecutive digits in AWS context (ARN, account-id field) | `${AWS_ACCOUNT}` |
+| **AWS profile name** | Whatever the user collected as `aws_profile` during inputs | `${AWS_PROFILE}` |
+| **GCP service-account JSON** | `"type": "service_account"` blocks | `<REDACTED-GCP-SA>` |
+| **Generic Bearer token** | `Bearer [A-Za-z0-9._~+/=-]{20,}` | `<REDACTED-BEARER>` |
+| **Email addresses** | RFC-822 pattern; especially the LE email + SMTP from-address + any user identity email | `${EMAIL}` |
+| **State-file contents** | Anything from `~/.open-forge/deployments/<name>.yaml` raw | Reference by deployment name only, never paste contents |
+| **MySQL/Postgres password** | After `password=` / `--password ` / `IDENTIFIED BY ` | `<REDACTED-DB-PASSWORD>` |
+| **OAuth client secrets** | After `client_secret` / `CLIENT_SECRET` | `<REDACTED-CLIENT-SECRET>` |
+| **Random bytes from `openssl rand -hex N`** that the user generated as a secret | Long hex strings used as secrets | `<REDACTED-RANDOM-SECRET>` |
+
+### Manual review pass (after regex)
+
+After regex-based sanitization, do a final read-through looking for:
+
+- **Hostnames in URL paths** that contain the user's domain (sed/regex may have missed embedded URLs).
+- **Username conventions** that are personally identifiable (e.g. `qi-experiment` as an AWS profile).
+- **Stack-trace lines** containing absolute filesystem paths (`/home/<user>/...`).
+- **Anything pasted from the user's clipboard or env vars** that wasn't covered by the strip-list.
+
+If you can't confidently classify something as safe, **redact it** — the user's final review is a safety net, not the only line of defense.
+
+### What you may keep
+
+| Class | OK to keep | Why |
+|---|---|---|
+| Recipe filenames (`ghost.md`, `openclaw.md`) | ✅ | Public; needed for context |
+| Plugin version (`0.20.0`) | ✅ | Public; needed for triage |
+| Combo names (`Ghost-CLI on Ubuntu`, `DigitalOcean droplet`) | ✅ | Public; needed for context |
+| Generic error messages quoted from upstream tools | ⚠️ | OK if no identifiers; redact paths and IPs from stack traces |
+| `${VAR}` placeholders | ✅ | These are the redactions; they're fine |
+| Public repo URLs (upstream docs you're proposing to add) | ✅ | Public |
+
+---
+
+## Draft templates
+
+Each template renders into the matching `.github/ISSUE_TEMPLATE/*.yml` form. The structure mirrors the form fields so the user pastes the body and the form auto-validates the sanitization checkboxes.
+
+### Channel 1 — recipe feedback (default at end of deploy)
+
+```markdown
+**Recipe**: <recipe-filename>
+**Combo**: <infra adapter> / <runtime>
+**Plugin version**: <version-from-plugin.json>
+**Outcome**: <one-of: Deploy succeeded with notes / Deploy succeeded after retries / Deploy failed; recovered manually / Deploy failed; abandoned / Recipe was outdated>
+
+## What the recipe missed
+
+<Concrete description: what surprised you, what failed, what required manual intervention. Sanitized.>
+
+## Suggested edit (optional — diff format preferred)
+
+```diff
+@@ <section header from the recipe> @@
+- <line that was wrong / missing>
++ <line that should be there>
+```
+
+## Sanitization confirmation
+- [x] All domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses stripped from this issue body.
+- [x] I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+```
+
+### Channel 2 — software nomination (Tier 2 → Tier 1)
+
+```markdown
+**Software name**: <project>
+**Upstream repo**: <github URL>
+**Upstream install-method index**: <docs / repo path / wiki URL>
+**Intended deploy combo**: <infra> / <runtime>
+
+## Why Tier 1?
+
+<What's painful about this software's install that compounds across deploys?
+Per the demand-driven graduation criteria in CLAUDE.md, a Tier 1 recipe earns
+its keep when the captured tribal knowledge saves the next user real pain.>
+
+## In-scope check (per CLAUDE.md § Is this software in scope?)
+
+This software is: <one-of: deployable service / static-site generator / AI inference server / CI runner / storage backend / not sure>
+
+## Confirmation
+- [x] I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+- [x] This software has at least one upstream-documented install method or canonical install artifact in-repo.
+```
+
+### Channel 3 — method proposal
+
+```markdown
+**Recipe to extend**: <recipe-filename>
+**Method name**: <e.g. "Snap package", "Helm chart">
+**Upstream URL documenting this method**: <URL>
+**Source type**: <First-party — published by upstream / Community-maintained>
+
+## Canonical install command(s)
+
+```bash
+<paste verbatim from upstream>
+```
+
+## Why this method matters
+
+<When would a user pick this method over the existing options in the recipe?>
+
+## Confirmation
+- [x] I have verified the upstream URL above shows this install method on the current upstream version.
+- [x] No credentials, IPs, or other identifiers in this issue.
+```
+
+---
+
+## Submission paths (try in order)
+
+The skill never opens a browser silently or POSTs without explicit user confirmation. Three submission paths in priority order:
+
+### 1. `gh` CLI (preferred when available)
+
+```bash
+# Check if gh is authenticated for the right account
+gh auth status
+
+# If yes, submit
+gh issue create \
+  --repo zhangqi444/open-forge \
+  --title "<title from template>" \
+  --body-file /tmp/feedback-draft.md \
+  --label recipe-feedback,recipe:<name>
+```
+
+Strengths: works headlessly in chat; respects user's existing GitHub auth.
+
+Caveats: user must have `gh` installed + authenticated. If `gh auth status` errors, fall through to path 2.
+
+### 2. GitHub MCP server (if available)
+
+If `mcp__github__issue_write` is available in the tool list, use it:
+
+```
+mcp__github__issue_write({
+  method: "create",
+  owner: "zhangqi444",
+  repo: "open-forge",
+  title: "<title>",
+  body: "<full body>",
+  labels: ["recipe-feedback", "recipe:<name>"]
+})
+```
+
+Strengths: no `gh` install needed; uses the MCP server's auth.
+
+Caveats: only works if the MCP server is configured with appropriate scopes.
+
+### 3. Prefilled URL (always-available fallback)
+
+When neither `gh` nor the GitHub MCP works, generate a URL the user opens in a browser:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=<URL-encoded-title>&body=<URL-encoded-body>
+```
+
+Print the URL in chat with the instruction:
+
+> *"I can't post for you in this environment. Open this URL in a browser, review one more time, and click Submit:*
+>
+> *<URL>*
+>
+> *The form has the same sanitization checkboxes from the template — they'll be checked based on what you've already confirmed in chat."*
+
+URL-encode the title + body. GitHub URL length limit is ~8 KB total; if the body is longer, truncate the body and put the rest in a `<details>` block (or warn the user to paste it manually).
+
+---
+
+## Liability + license boilerplate (paste at end of every issue body)
+
+Append this exact block as the final paragraph of every issue body before submission:
+
+```markdown
+---
+
+> By submitting this issue, I grant a non-revocable license to the open-forge project to use this content in recipes and documentation. The open-forge project bears no liability for my choice to share. I have reviewed the issue body for credentials and personal information per CLAUDE.md § *Sanitization principles*.
+```
+
+This is in addition to the checkboxes in the issue-template form — it's an extra paper trail in the issue body itself.
+
+---
+
+## When the deploy aborted before completion
+
+If the user wants to file feedback about a deploy that failed mid-phase (e.g. preflight passed, provisioning failed at the security-group step), the `Outcome` field should be *"Deploy failed; abandoned"* and the body should include:
+
+- Which phase failed.
+- What the error was (sanitized — strip stack traces of paths/IPs).
+- What workaround the user attempted (if any).
+- Whether the user wants the recipe edited to handle this case, or whether they think it was an upstream / cloud-account issue (out of recipe scope).
+
+These are often the highest-value feedback issues — they catch recipes that succeed in the maintainer's environment but fail in others.
+
+---
+
+## Failure modes to watch for
+
+- **User says "post it" too quickly.** Respect their consent, but flag any line you weren't 100% sure about: *"Posting now. One last thing — line 14 mentions a username `qi-experiment` that might be your AWS profile name. Was that intentional?"*
+- **Drafts that quote upstream error messages with embedded user data.** Common with Bitnami's `bncert-tool` output, AWS CLI errors quoting account IDs in ARNs.
+- **State-file leaks.** If the user asks Claude to read `~/.open-forge/deployments/<name>.yaml` while drafting, do **not** paste contents — reference by deployment name only.
+- **Multiple rapid yes-clicks.** If the user says "yes, yes, yes, post" to skip the review, slow down: re-show the draft once, get confirmation, then submit. Speed is not a user safety feature.


### PR DESCRIPTION
## Summary

Closes the catalogue-evolution loop: the skill drafts sanitized feedback issues at end of deploy, the user reviews + opts in, and AI coding sessions process those issues into recipe patches per the strict-doc-policy. **No human PRs needed** — issues are the universal contribution channel.

Bumps plugin to **v0.20.0** (architecture-significant user-visible behavior change).

## What changed

### Architecture (CLAUDE.md, +142 lines)

Four new sections:

- **§ Tier 2 → Tier 1 graduation criteria** (added inside existing Two-tier coverage model). Demand-driven promotion: 3+ feedback issues, repeat user, captured non-obvious gotcha, or maintainer pickup. Don't author Tier 1 speculatively.
- **§ Issue-driven contribution model**. Three input channels via `.github/ISSUE_TEMPLATE/`. Direct human PRs discouraged.
- **§ Sanitization principles**. Universal strip-list with regex patterns. Multi-step consent (no auto-post, ever). Standing reminders + liability text.
- **§ Processing incoming issues**. Six-step workflow for any AI session that processes issues: triage → validate → author → open PR → label state machine → conflict/ambiguity handling.

Two updates:
- **§ First-run discipline** — note user-submitted feedback is now the dominant path.
- **§ Versioning + publish flow** — reframed as agent-shape-agnostic; typical actor is the AI session processing the issue.

### Input channels (4 new YAML files under `.github/ISSUE_TEMPLATE/`)

- **`recipe-feedback.yml`** — for users who deployed via the skill and want to suggest recipe edits. Hard sanitization-confirmation checkboxes.
- **`software-nomination.yml`** — for users who want a software added to Tier 1. Asks for upstream URL + intended combo + in-scope check.
- **`method-proposal.yml`** — for users who know an upstream-supported install method an existing recipe doesn't cover.
- **`config.yml`** — disables blank issues; routes "I need deployment help" back to the skill itself.

### Skill (SKILL.md +46 lines, new `references/modules/feedback.md` ~190 lines)

- **SKILL.md § Post-deploy feedback** — new section between *Verification after each phase* and *Common pitfalls*. Documents the three flows + multi-step consent + sanitize-then-show-draft rule.
- **`references/modules/feedback.md`** — operational module the skill loads:
  - Sanitization checklist (regex patterns for domains, IPs, SSH keys, API keys for Resend/SendGrid/OpenAI/Anthropic/Slack/GitHub PAT/AWS, AWS account IDs, GCP service-account JSON, emails, MySQL/Postgres passwords, OAuth client secrets, etc.)
  - Manual review pass for things regex misses
  - Draft templates for all three issue channels
  - Three submission paths (gh CLI → GitHub MCP → prefilled URL fallback)
  - Liability + license boilerplate
  - Special handling for aborted-deploy feedback
  - Failure modes (user says "post" too quickly, state-file leaks, etc.)

### Version

`plugin.json`: 0.19.3 → **0.20.0**.

## Three commits

| Commit | Scope |
|---|---|
| `7f25fae` | CLAUDE.md — architecture (issue-driven contribution model, sanitization principles, processing workflow, graduation criteria) |
| `c262674` | `.github/ISSUE_TEMPLATE/` — four template files (recipe-feedback, software-nomination, method-proposal, config) |
| `bcab175` | SKILL.md + references/modules/feedback.md + plugin.json bump — skill-side enforcement |

## What's NOT in this PR

- **The scheduling layer** (cron / GitHub Action / webhook that triggers issue-processing). That's operational config outside CLAUDE.md's tool-agnostic scope. The processing workflow is documented; how often you trigger it is up to you.
- **Auto-merge policy** for bot-opened PRs — same reason; operational, not architectural.

## Test plan

- [ ] Filing a blank issue at the repo redirects to the templates (config.yml).
- [ ] Each of the three templates renders with required-field validation enforced.
- [ ] Live test: ask Claude to "deploy Vaultwarden" (Tier 2), let it complete, confirm it offers to (a) file recipe-feedback for the deploy and (b) nominate Vaultwarden for Tier 1.
- [ ] Live test: ask Claude to draft a feedback issue with a deploy that included a public IP / domain — confirm the redaction is applied before showing the draft.
- [ ] Confirm `gh issue create` is the first attempted submission path; falls through to GitHub MCP if `gh auth status` errors; falls through to prefilled URL if neither works.
- [ ] CLAUDE.md renders correctly: graduation criteria appears as a sub-section of Two-tier coverage model; new top-level sections appear after Two-tier and before Companion skills.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_