### PR TITLE
README — rewrite for marketing + reflect v0.20.0 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 Claude already knows how to run `docker compose up`. What `open-forge` adds:
 
 - **Captured tribal knowledge.** ~180 recipes verified against upstream docs include the gotchas that aren't in any README — Bitnami's `bncert-tool` not supporting `--unattended`, Apache reverse-proxy needing `ProxyPreserveHost` after enabling HTTPS, MySQL on Ubuntu 22+ defaulting to socket-auth that Ghost rejects, and so on.
+- **Compounding by design.** Raw Claude Code starts from zero every session. `open-forge` accumulates — every successful (or failed) deploy can feed gotchas back into the catalog. The 1001st deploy is faster and safer than the first because the previous 1000 contributed.
 - **Resumable across sessions.** Every deployment writes a state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow without re-running provisioning.
 - **Consistent across clouds.** The "install Docker on Ubuntu" step is written once and reused for Hetzner / DO / Lightsail Ubuntu / localhost. You can swap clouds without re-deriving the install.
 - **Source-attributed.** Every install method cites the exact upstream URL it derives from. When a recipe goes stale, the link is the recovery path; community-maintained methods are flagged with a warning blockquote.
@@ -50,7 +51,7 @@ The skill takes it from there — collects inputs, runs cloud CLI + SSH commands
 
 ## Verified recipes (~180)
 
-A curated catalog of self-hostable apps with verified install paths, captured gotchas, and ongoing maintenance via the [feedback loop](#feedback-loop-the-catalog-grows-from-your-deploys). A taste:
+A curated catalog of self-hostable apps. Each recipe cites its upstream sources at authorship; first-deploy verification — confirming the gotchas in the wild — happens via the [feedback loop](#feedback-loop) as users deploy. The catalog grows where it earns its keep — software whose gotchas compound across deploys. We deliberately don't try to catalog every self-hostable app; for everything else, the [live-derived fallback](#dont-see-your-software) handles the long tail. A taste:
 
 | Category | Examples |
 |---|---|
@@ -83,7 +84,7 @@ Verified support across **17 infra adapters** and **4 runtime modules** — writ
 
 | Cloud / location | Adapter |
 |---|---|
-| **AWS** | Lightsail (Ghost-Bitnami + OpenClaw blueprints + Ubuntu) · EC2 |
+| **AWS** | Lightsail (with vendor blueprints for Ghost, OpenClaw, etc.; or plain Ubuntu) · EC2 |
 | **Azure VM** | Bastion-hardened (no public IP) |
 | **Hetzner Cloud** | CX-line VM (`hcloud` CLI) |
 | **DigitalOcean** | Droplet (`doctl` CLI) |
@@ -112,15 +113,22 @@ The "how" question is **dynamically generated** from your software + cloud choic
 
 Each phase is **verifiable and resumable**. Claude completes, verifies, and records state before moving on.
 
-```
-preflight  →  provision  →  dns  →  tls  →  smtp  →  inbound  →  hardening  →  feedback
-```
-
-After `hardening`, the skill offers to file a sanitized GitHub issue with the deployment notes — see below.
+| Phase | What happens |
+|---|---|
+| `preflight` | Check CLI tools, validate accounts, confirm domain ownership; collect just-in-time inputs. |
+| `provision` | Create instance, allocate static IP, retrieve SSH key. |
+| `dns` | Print exact records to add at registrar; poll until resolved. |
+| `tls` | Obtain Let's Encrypt cert, fix reverse-proxy config, switch app URL to https. |
+| `smtp` | Configure outbound email provider; verify a test send. |
+| `inbound` | (Optional) Set up forwarding or mailbox. |
+| `hardening` | Rotate default admin creds; rotate any secrets pasted into chat. |
+| `feedback` | Offer to file a sanitized GitHub issue with deployment notes (you opt in). |
 
 ## Feedback loop (the catalog grows from your deploys)
 
-Catalog evolution happens through GitHub issues, not human pull requests. The skill drafts a sanitized issue at the end of every deploy; you review, approve, and post; AI sessions process the issues into recipe patches per the [strict doc-verification policy](CLAUDE.md#strict-doc-verification-policy-mandatory-before-writing-any-recipe).
+Catalog evolution happens through GitHub issues, not human pull requests. The skill drafts a sanitized issue at the end of every deploy; you review, approve, and post.
+
+Issues are processed by an **AI agent** that reads [`CLAUDE.md`](CLAUDE.md) as its runbook — same policy that governs the existing catalog. For every change the agent re-fetches upstream docs, applies the [strict doc-verification policy](CLAUDE.md#strict-doc-verification-policy-mandatory-before-writing-any-recipe), authors the patch, opens a PR, and bumps the version. No human needs to write code for the catalog to improve; you just deploy + click "share."
 
 Three input channels (all via [GitHub issue templates](.github/ISSUE_TEMPLATE/)):
 
@@ -134,9 +142,11 @@ The skill **never auto-posts** — you see the redacted draft, review it, and ex
 
 ## Contributing
 
-**Don't open PRs.** [File an issue](https://github.com/zhangqi444/open-forge/issues/new/choose) instead. The structured templates encode the strict-doc policy; AI sessions process the queue and author patches.
+**Don't open PRs.** [File an issue](https://github.com/zhangqi444/open-forge/issues/new/choose) instead — the structured templates encode the strict-doc policy, and the AI agent processes the queue and authors patches.
 
-If you're a maintainer working on the plugin itself, see [`CLAUDE.md`](CLAUDE.md) for the development conventions, the strict-doc-verification policy, the issue-processing workflow, and the architectural model.
+**Why issues, not PRs?** The agent re-verifies every change against upstream docs centrally — this keeps the catalog consistent with the [strict-doc policy](CLAUDE.md#strict-doc-verification-policy-mandatory-before-writing-any-recipe), avoids credentials leaking into commit history (the skill sanitizes drafts before posting), and turns "let me submit a PR with my fix" into "let me share what I learned" — much lower bar to contribute, much higher quality bar on what lands. See [CLAUDE.md § Issue-driven contribution model](CLAUDE.md#issue-driven-contribution-model) for the full reasoning.
+
+If you're a maintainer working on the plugin itself, see [`CLAUDE.md`](CLAUDE.md) for the development conventions and architectural model.
 
 ## How it works (for the curious)
 

--- a/README.md
+++ b/README.md
@@ -1,49 +1,29 @@
 # open-forge
 
-Self-host open-source apps on your own cloud, guided by Claude Code.
+> **Self-host any open-source app on your own infrastructure — guided by Claude Code.**
+> No more "read a README, copy-paste 30 lines of bash, debug for hours."
 
-Given a project and a cloud provider, open-forge walks you through provisioning, DNS, TLS, outbound email (SMTP), and inbound email. It captures the non-obvious gotchas that usually cost hours the first time: proxy misconfigurations, non-interactive certbot flags, mail config quirks, DNS propagation, etc.
+`open-forge` is a Claude Code plugin that turns deployment from a documentation scavenger hunt into a guided chat. Tell Claude what you want to deploy and where; the skill handles provisioning, DNS, TLS, outbound email (SMTP), inbound email, and the non-obvious gotchas that usually cost hours the first time — proxy misconfigurations, non-interactive `certbot` flags, MySQL socket-vs-password auth, race conditions during admin bootstrap, redirect-loop triggers after enabling HTTPS, and more.
 
-## Supported today
+```
+> "Self-host Ghost on a Hetzner CX22 with a Resend SMTP relay."
 
-Supported software:
+  [open-forge] Loading verified recipe ghost.md (v0.20.0).
+  [open-forge] Combo: Hetzner Cloud CX × Docker.
+  [open-forge] I have everything I need except your domain and Resend API key.
 
-| Software | What it is |
-|---|---|
-| Ghost | Self-hosted blogging platform |
-| OpenClaw | Self-hosted personal AI agent (openclaw.ai) |
-| Hermes-Agent | Self-improving personal AI agent from Nous Research |
-| Ollama | Local-LLM inference server (foundation layer for self-hosted AI) |
-| Open WebUI | Feature-rich web UI for any OpenAI-compatible LLM (pairs with Ollama) |
-| Stable Diffusion WebUI (A1111) | Most-popular open-source AI image generator (text-to-image, ControlNet, LoRA) |
-| ComfyUI | Node-based AI image / video generation (workflow graphs; power-user alternative to A1111) |
-| Dify | Open-source LLMOps + AI app builder (visual workflows, RAG, multi-tenant) |
-| LibreChat | Multi-provider chat UI for teams (multi-user, social logins, per-user balance, MCP, RAG) |
-| AnythingLLM | RAG-focused workspace + agent platform (drop-in PDFs / URLs, built-in LanceDB, Desktop App + 8 cloud one-clicks) |
-| Aider | AI pair-programming CLI (terminal-based; edits files via diffs, auto-commits; pairs with any LLM) |
-| vLLM | Production-grade LLM inference server (high-throughput multi-tenant; tensor parallelism; prefix caching) |
-| Langfuse | Open-source LLM engineering platform (observability, evals, prompt management, datasets, scoring) |
+  Domain you want to host Ghost on?
+```
 
-Supported **where**:
+## Why this is better than just asking Claude
 
-| Where | How |
-|---|---|
-| **AWS Lightsail** | OpenClaw blueprint (Bedrock pre-wired) · Ubuntu + Docker · Ubuntu + native · Ghost Bitnami blueprint |
-| **AWS EC2** | Ubuntu / Amazon Linux + Docker · + native |
-| **Azure VM** (Bastion-hardened, no public IP) | Ubuntu + Docker · + native |
-| **Hetzner Cloud** | CX-line VM + Docker · + native |
-| **DigitalOcean** | Droplet + Docker · + native |
-| **GCP Compute Engine** | VM + Docker · + native |
-| **Oracle Cloud** | Always-Free A1.Flex ARM + native (via Tailscale) |
-| **Hostinger** | Managed (1-Click) or VPS (Docker Manager via hPanel) |
-| **Raspberry Pi** | Pi 4 / Pi 5 (64-bit) + native |
-| **macOS VM** (Lume on Apple Silicon) | Sandboxed macOS + native (for iMessage via BlueBubbles) |
-| Any Linux VM you already have (other providers, bare metal) | Docker · Podman · native |
-| **Any Kubernetes cluster** (EKS / GKE / AKS / DOKS / k3s / kind / Docker Desktop) | Kustomize manifests (or community Helm charts for projects that ship them) |
-| **Fly.io** · **Render** · **Railway** · **Northflank** · **exe.dev** | PaaS one-click templates from the upstream repos |
-| **Your own machine** (macOS / Linux / Windows / WSL2) | Docker Desktop · Podman · native (`install.sh` / `install-cli.sh` / `install.ps1`) |
+Claude already knows how to run `docker compose up`. What `open-forge` adds:
 
-Three-question flow: what to host, where to host, how to host. Claude asks only what's genuinely ambiguous — if your prompt already names a clear cloud, the first question is skipped.
+- **Captured tribal knowledge.** ~180 recipes verified against upstream docs include the gotchas that aren't in any README — Bitnami's `bncert-tool` not supporting `--unattended`, Apache reverse-proxy needing `ProxyPreserveHost` after enabling HTTPS, MySQL on Ubuntu 22+ defaulting to socket-auth that Ghost rejects, and so on.
+- **Resumable across sessions.** Every deployment writes a state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow without re-running provisioning.
+- **Consistent across clouds.** The "install Docker on Ubuntu" step is written once and reused for Hetzner / DO / Lightsail Ubuntu / localhost. You can swap clouds without re-deriving the install.
+- **Source-attributed.** Every install method cites the exact upstream URL it derives from. When a recipe goes stale, the link is the recovery path; community-maintained methods are flagged with a warning blockquote.
+- **Self-improving.** The skill drafts a sanitized GitHub issue at the end of every deploy with proposed recipe edits. You review, approve, post — the catalog gets better for the next user.
 
 ## Install
 
@@ -58,41 +38,144 @@ In Claude Code:
 
 Tell Claude what you want to deploy:
 
-> "I want to self-host Ghost on AWS Lightsail."
+> *"I want to self-host Ghost on AWS Lightsail."*
+>
+> *"Set up Mastodon on a Hetzner VPS — I'll bring my own SMTP."*
+>
+> *"Deploy Vaultwarden on my Raspberry Pi."*
+>
+> *"Run Open WebUI + Ollama on my laptop, expose it via Cloudflare Tunnel."*
 
-The `open-forge` skill will take it from there — collecting inputs, running AWS CLI + SSH commands, guiding you through DNS and SMTP setup, and recording state so you can resume across sessions.
+The skill takes it from there — collects inputs, runs cloud CLI + SSH commands, walks you through DNS and SMTP, records state so you can resume across sessions.
 
-## How it works
+## Verified recipes (~180)
 
-- **Phased workflow**: preflight → provision → DNS → TLS → outbound email → inbound email → hardening. Each phase is verifiable and resumable.
-- **State file**: `~/.open-forge/deployments/<name>.yaml` records inputs, outputs, and completed phases.
-- **Progressive disclosure**: the skill loads only the references it needs for your chosen project + infra combo.
-- **Autonomous with `--dry-run`**: runs AWS CLI / SSH directly by default; pass `--dry-run` to print commands without executing.
+A curated catalog of self-hostable apps with verified install paths, captured gotchas, and ongoing maintenance via the [feedback loop](#feedback-loop-the-catalog-grows-from-your-deploys). A taste:
+
+| Category | Examples |
+|---|---|
+| **AI stack** | Ollama, vLLM, Open WebUI, LibreChat, AnythingLLM, Aider, OpenClaw, Hermes-Agent, Dify, Langfuse, ComfyUI, Stable Diffusion WebUI |
+| **Publishing & docs** | Ghost, WordPress, Docusaurus, Outline, BookStack, Wiki.js, Etherpad |
+| **Productivity** | Nextcloud, AppFlowy, Joplin, Logseq, Trilium, Memos, Plane, Twenty CRM |
+| **Photos & media** | Immich, PhotoPrism, Jellyfin, Navidrome, Koel |
+| **Dev & deploy** | Gitea, Coolify, Dokku, Portainer, Code-Server, Storybook |
+| **Monitoring** | Grafana, Prometheus, Loki, Uptime Kuma, Netdata, SigNoz, Beszel |
+| **Security & auth** | Vaultwarden, Authelia, Authentik, Keycloak, Infisical |
+| **Networking** | Pi-hole, AdGuard Home, NetBird, Headscale, wg-easy |
+| **Communication** | Mastodon, Mattermost, Rocket.Chat, Zulip, Jitsi Meet |
+| **Automation & data** | n8n, Windmill, Activepieces, Huginn, Node-RED, Apache Superset, Metabase |
+
+Full list: [`plugins/open-forge/skills/open-forge/references/projects/`](plugins/open-forge/skills/open-forge/references/projects/).
+
+### Don't see your software?
+
+The skill falls back to a **live-derived recipe** — fetches upstream docs at request time, applies the same strict-doc-verification policy, and reuses the existing infra + runtime modules. Best-effort, not authoritative; you'll see a banner like:
+
+> *"This software isn't in our verified catalog — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort."*
+
+If the live deploy goes well, the skill will offer to nominate the software for the verified catalog.
+
+## Where + how
+
+Verified support across **17 infra adapters** and **4 runtime modules** — write once, reuse everywhere.
+
+### Where to host
+
+| Cloud / location | Adapter |
+|---|---|
+| **AWS** | Lightsail (Ghost-Bitnami + OpenClaw blueprints + Ubuntu) · EC2 |
+| **Azure VM** | Bastion-hardened (no public IP) |
+| **Hetzner Cloud** | CX-line VM (`hcloud` CLI) |
+| **DigitalOcean** | Droplet (`doctl` CLI) |
+| **GCP Compute Engine** | VM (`gcloud` CLI) |
+| **Oracle Cloud** | Always-Free A1.Flex ARM (Tailscale reach) |
+| **Hostinger** | Managed (1-Click) or VPS (Docker Manager via hPanel) |
+| **Raspberry Pi** | Pi 4 / Pi 5 (64-bit ARM) |
+| **macOS VM** (Lume on Apple Silicon) | Sandboxed macOS — for iMessage via BlueBubbles |
+| **Any Linux VM you already have** | SSH-only adapter; works for Vultr, Linode, on-prem, etc. |
+| **Your own machine** | macOS / Linux / Windows / WSL2 — Claude runs commands locally |
+| **Any Kubernetes cluster** | EKS / GKE / AKS / DOKS / k3s / kind / Docker-Desktop k8s |
+| **PaaS** | Fly.io · Render · Railway · Northflank · exe.dev — one-click templates from upstream repos |
+
+### How to host (when the infra gives you the choice)
+
+| Runtime | Notes |
+|---|---|
+| **Docker** | The recommended default. Works wherever Docker is supported. |
+| **Podman** | Rootless Docker-compatible alternative; Quadlet (systemd-user) supported. |
+| **Native** | OS package manager / installer scripts. systemd / launchd / Scheduled-Tasks lifecycle. |
+| **Kubernetes** | Kustomize-first (project recipes default to upstream's `scripts/k8s/deploy.sh` shape); Helm where upstream ships a chart. |
+
+The "how" question is **dynamically generated** from your software + cloud choice — different combos expose different runtimes.
+
+## Phased workflow
+
+Each phase is **verifiable and resumable**. Claude completes, verifies, and records state before moving on.
+
+```
+preflight  →  provision  →  dns  →  tls  →  smtp  →  inbound  →  hardening  →  feedback
+```
+
+After `hardening`, the skill offers to file a sanitized GitHub issue with the deployment notes — see below.
+
+## Feedback loop (the catalog grows from your deploys)
+
+Catalog evolution happens through GitHub issues, not human pull requests. The skill drafts a sanitized issue at the end of every deploy; you review, approve, and post; AI sessions process the issues into recipe patches per the [strict doc-verification policy](CLAUDE.md#strict-doc-verification-policy-mandatory-before-writing-any-recipe).
+
+Three input channels (all via [GitHub issue templates](.github/ISSUE_TEMPLATE/)):
+
+| Template | When to use |
+|---|---|
+| **Recipe feedback** | You deployed via the skill and want to suggest recipe edits — gotchas you hit, install steps that surprised you, sections that were outdated. The skill drafts these automatically. |
+| **Software nomination** | You want a software added to the verified catalog (after a successful live-derived deploy, the skill offers this). |
+| **Method proposal** | You know an upstream-supported install method that an existing recipe doesn't cover. |
+
+The skill **never auto-posts** — you see the redacted draft, review it, and explicitly approve before submission. Sanitization strips domains, IPs, SSH key paths, API keys, AWS account IDs, and emails before showing the draft.
+
+## Contributing
+
+**Don't open PRs.** [File an issue](https://github.com/zhangqi444/open-forge/issues/new/choose) instead. The structured templates encode the strict-doc policy; AI sessions process the queue and author patches.
+
+If you're a maintainer working on the plugin itself, see [`CLAUDE.md`](CLAUDE.md) for the development conventions, the strict-doc-verification policy, the issue-processing workflow, and the architectural model.
+
+## How it works (for the curious)
+
+`open-forge` is built on a **3-layer model** asked in 3 questions:
+
+| # | Question | Layer | Lives in |
+|---|---|---|---|
+| 1 | **What** to host? | software | `references/projects/<sw>.md` |
+| 2 | **Where** to host? | infra | `references/infra/<cloud>/*.md` |
+| 3 | **How** to host? | runtime | `references/runtimes/<runtime>.md` |
+
+Reusability is the test: "install Docker on Ubuntu" is the same on Hetzner / DO / Lightsail / localhost — written once in the runtime layer. Project recipes are 80% software-specific concerns + a one-line link to the runtime.
+
+Cross-cutting modules (`references/modules/`) cover preflight, DNS, TLS via Let's Encrypt, SMTP providers (Resend / SendGrid / Mailgun), inbound forwarders (ImprovMX), tunnels (Cloudflare / Tailscale / ngrok), and the post-deploy feedback flow.
+
+For the full architectural treatment + the strict-doc-verification policy + the issue-driven contribution model, see [`CLAUDE.md`](CLAUDE.md).
 
 ## Repo layout
 
 ```
 open-forge/
-├── .claude-plugin/marketplace.json     # marketplace manifest
-└── plugins/
-    └── open-forge/                     # the plugin
-        ├── .claude-plugin/plugin.json
-        └── skills/open-forge/
-            ├── SKILL.md
-            ├── references/
-            │   ├── projects/           # per-project recipes (ghost.md, openclaw.md, ...)
-            │   ├── infra/              # per-infra adapters (aws/, hetzner/, digitalocean/, gcp/, byo-vps.md, localhost.md)
-            │   ├── runtimes/           # docker.md, podman.md, native.md, kubernetes.md
-            │   └── modules/            # cross-cutting (preflight, dns, tls, smtp, inbound, tunnels)
-            └── scripts/
+├── CLAUDE.md                                 # development policy + architecture
+├── README.md                                 # you are here
+├── .github/ISSUE_TEMPLATE/                   # the three input channels
+│   ├── recipe-feedback.yml
+│   ├── software-nomination.yml
+│   └── method-proposal.yml
+├── .claude-plugin/marketplace.json           # marketplace manifest
+└── plugins/open-forge/                       # the plugin
+    ├── .claude-plugin/plugin.json            # version
+    └── skills/open-forge/
+        ├── SKILL.md                          # end-user-Claude entrypoint
+        └── references/
+            ├── projects/                     # ~180 verified recipes
+            ├── infra/                        # 17 cloud / VPS / localhost adapters
+            ├── runtimes/                     # docker / podman / native / kubernetes
+            └── modules/                      # preflight / dns / tls / smtp / inbound / tunnels / feedback
 ```
-
-## Contributing
-
-To add a new project: drop a `references/projects/<name>.md` recipe.
-To add a new infra: drop a `references/infra/<name>.md` adapter.
-See existing files for the expected shape.
 
 ## License
 
-MIT
+[MIT](LICENSE) — fork freely, attribution appreciated.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
-# open-forge
+<p align="center">
+  <img src="assets/icon.svg" width="120" height="120" alt="open-forge" />
+</p>
+
+<h1 align="center">open-forge</h1>
+
+<p align="center">
+  <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/plugin-v0.20.0-F97316?style=flat-square&labelColor=0F172A" alt="Plugin version" /></a>
+  <a href="https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects"><img src="https://img.shields.io/badge/verified%20recipes-180+-EA580C?style=flat-square&labelColor=0F172A" alt="Verified recipes" /></a>
+  <a href="#built-for-claude-code"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-D77756?style=flat-square&labelColor=0F172A" alt="Built for Claude Code" /></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=22D3EE" alt="MIT License" /></a>
+  <a href="https://github.com/zhangqi444/open-forge/stargazers"><img src="https://img.shields.io/github/stars/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=FACC15" alt="GitHub stars" /></a>
+  <a href="https://github.com/zhangqi444/open-forge/issues"><img src="https://img.shields.io/github/issues/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=A78BFA" alt="Open issues" /></a>
+</p>
 
 > **Self-host any open-source app on your own infrastructure — guided by Claude Code.**
 > No more "read a README, copy-paste 30 lines of bash, debug for hours."

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" role="img" aria-label="open-forge">
+  <!-- rounded-square background -->
+  <rect width="64" height="64" rx="14" fill="#0F172A"/>
+
+  <!-- spark / flame above the anvil -->
+  <path d="M32 12 L28.5 22 L31 21 L30 26 L34 19 L32 20 Z" fill="#FACC15" stroke="#F59E0B" stroke-width="0.6" stroke-linejoin="round"/>
+
+  <!-- anvil top plate -->
+  <rect x="14" y="34" width="36" height="4.5" rx="1.5" fill="#F97316"/>
+
+  <!-- anvil horn (left) -->
+  <path d="M14 34 Q9 34 9 30 Q9 27 12 27 L14 27 Z" fill="#F97316"/>
+
+  <!-- anvil shoulder (right step) -->
+  <path d="M50 34 L52 34 L52 32 L50 32 Z" fill="#F97316"/>
+
+  <!-- anvil body / waist -->
+  <path d="M19 38.5 L45 38.5 L42 47 L22 47 Z" fill="#EA580C"/>
+
+  <!-- anvil base -->
+  <rect x="18" y="47" width="28" height="5" rx="1" fill="#C2410C"/>
+</svg>

--- a/assets/social-preview.svg
+++ b/assets/social-preview.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1280 640" fill="none" role="img" aria-label="open-forge — self-host any open-source app, guided by Claude Code">
+  <!-- background -->
+  <rect width="1280" height="640" fill="#0F172A"/>
+
+  <!-- subtle grid pattern -->
+  <defs>
+    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+      <path d="M40 0 L0 0 0 40" fill="none" stroke="#1E293B" stroke-width="1"/>
+    </pattern>
+  </defs>
+  <rect width="1280" height="640" fill="url(#grid)"/>
+
+  <!-- accent ring on the right -->
+  <circle cx="1080" cy="320" r="260" fill="#1E293B" opacity="0.6"/>
+
+  <!-- icon (anvil) at right -->
+  <g transform="translate(960, 200) scale(4)">
+    <!-- spark -->
+    <path d="M32 12 L28.5 22 L31 21 L30 26 L34 19 L32 20 Z" fill="#FACC15" stroke="#F59E0B" stroke-width="0.6" stroke-linejoin="round"/>
+    <!-- anvil top plate -->
+    <rect x="14" y="34" width="36" height="4.5" rx="1.5" fill="#F97316"/>
+    <!-- horn -->
+    <path d="M14 34 Q9 34 9 30 Q9 27 12 27 L14 27 Z" fill="#F97316"/>
+    <!-- shoulder -->
+    <path d="M50 34 L52 34 L52 32 L50 32 Z" fill="#F97316"/>
+    <!-- body -->
+    <path d="M19 38.5 L45 38.5 L42 47 L22 47 Z" fill="#EA580C"/>
+    <!-- base -->
+    <rect x="18" y="47" width="28" height="5" rx="1" fill="#C2410C"/>
+  </g>
+
+  <!-- title -->
+  <text x="100" y="290" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="92" font-weight="800" fill="#F8FAFC" letter-spacing="-2">open-forge</text>
+
+  <!-- tagline line 1 -->
+  <text x="100" y="358" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="34" font-weight="500" fill="#CBD5E1">Self-host any open-source app on your own infra.</text>
+
+  <!-- tagline line 2 -->
+  <text x="100" y="404" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="34" font-weight="500" fill="#CBD5E1">Guided by Claude Code.</text>
+
+  <!-- accent stats line -->
+  <g transform="translate(100, 480)">
+    <rect x="0" y="0" width="14" height="14" rx="3" fill="#F97316"/>
+    <text x="26" y="13" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="22" font-weight="600" fill="#F8FAFC">~180 verified recipes</text>
+
+    <rect x="280" y="0" width="14" height="14" rx="3" fill="#22D3EE"/>
+    <text x="306" y="13" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="22" font-weight="600" fill="#F8FAFC">17 infra adapters</text>
+
+    <rect x="510" y="0" width="14" height="14" rx="3" fill="#A78BFA"/>
+    <text x="536" y="13" font-family="system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="22" font-weight="600" fill="#F8FAFC">resumable + self-improving</text>
+  </g>
+
+  <!-- repo URL footer -->
+  <text x="100" y="580" font-family="ui-monospace, 'SF Mono', Menlo, monospace" font-size="20" fill="#64748B">github.com/zhangqi444/open-forge</text>
+</svg>


### PR DESCRIPTION
## Summary

Old README was stale and predated the v0.20.0 architecture. Rewrote for marketing + accuracy:

- Listed 13 software when main now has **~180 verified recipes**
- No mention of the **live-derived (Tier 2) fallback** for software outside the catalog
- "Contributing" said "drop a PR" but the new model is **issues-only**
- No mention of the **post-deploy feedback loop** (the catalog-evolution mechanism)
- Marketing was thin — didn't lead with the value prop or show what a chat exchange feels like

This is **documentation only** — no code/skill behavior change, plugin version unchanged at 0.20.0.

## What changed

- **Stronger tagline + value prop** up front ("self-host any open-source app on your own infra — guided by Claude Code"), with concrete pain ("30 lines of bash, debug for hours") and an inline sample chat so users see the experience before scrolling.
- **"Why this is better than just asking Claude" section** — 5 explicit value bullets (captured tribal knowledge, resumable state, consistent across clouds, source-attributed, self-improving via the feedback loop).
- **Verified-recipe section** restructured around 11 categories with ~50 named examples instead of trying to enumerate all 180; points at `references/projects/` for the full list.
- **Friendly Tier 1/2 naming**: "verified recipe" / "live-derived recipe" replace internal Tier 1/2 labels in user-facing prose. Internal CLAUDE.md still uses Tier 1/2 (it's tool-internal terminology).
- **"Don't see your software?" section** — frames the live-derived fallback as a feature with a sample announcement banner.
- **"Feedback loop" section** — explains how the catalog grows from user deploys via the three GitHub issue templates, with the no-auto-post + sanitization safety guarantees called out.
- **"Contributing" flipped** — "Don't open PRs — file an issue" per CLAUDE.md § Issue-driven contribution model. Pointer to CLAUDE.md for plugin maintainers.
- **Architecture summary** preserved but moved below operational content + simplified to the 3-axis table; full details in CLAUDE.md.
- **Repo layout** updated to include `.github/ISSUE_TEMPLATE/` and the `references/modules/feedback.md` added in v0.20.0.

## Test plan

- [ ] README renders correctly on github.com (tables, code blocks, links).
- [ ] Quick smoke read: a new user landing on the repo can answer "what does this do, why is it better, how do I install it" in under 60 seconds.
- [ ] All inline links resolve (CLAUDE.md, references/projects/, .github/ISSUE_TEMPLATE/, LICENSE).

## Out of scope

- Adding all 180 recipes to a separate `CATALOG.md` — the `references/projects/` directory listing on GitHub is already a good index; a duplicated catalog would just go stale.
- Marketplace / npm / Hacker News announcement copy — that's a separate marketing task.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_