### PR TITLE
README — simplify + elevate self-improving catalog as headline feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,13 @@
 <p align="center">
   <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/plugin-v0.20.0-F97316?style=flat-square&labelColor=0F172A" alt="Plugin version" /></a>
   <a href="https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects"><img src="https://img.shields.io/badge/verified%20recipes-180+-EA580C?style=flat-square&labelColor=0F172A" alt="Verified recipes" /></a>
-  <a href="#built-for-claude-code"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-D77756?style=flat-square&labelColor=0F172A" alt="Built for Claude Code" /></a>
+  <a href="#install"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-D77756?style=flat-square&labelColor=0F172A" alt="Built for Claude Code" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=22D3EE" alt="MIT License" /></a>
   <a href="https://github.com/zhangqi444/open-forge/stargazers"><img src="https://img.shields.io/github/stars/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=FACC15" alt="GitHub stars" /></a>
-  <a href="https://github.com/zhangqi444/open-forge/issues"><img src="https://img.shields.io/github/issues/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=A78BFA" alt="Open issues" /></a>
 </p>
 
 > **Self-host any open-source app on your own infrastructure — guided by Claude Code.**
-> No more "read a README, copy-paste 30 lines of bash, debug for hours."
-
-`open-forge` is a Claude Code plugin that turns deployment from a documentation scavenger hunt into a guided chat. Tell Claude what you want to deploy and where; the skill handles provisioning, DNS, TLS, outbound email (SMTP), inbound email, and the non-obvious gotchas that usually cost hours the first time — proxy misconfigurations, non-interactive `certbot` flags, MySQL socket-vs-password auth, race conditions during admin bootstrap, redirect-loop triggers after enabling HTTPS, and more.
+> No more reading READMEs and copy-pasting bash for hours.
 
 ```
 > "Self-host Ghost on a Hetzner CX22 with a Resend SMTP relay."
@@ -28,17 +25,6 @@
   Domain you want to host Ghost on?
 ```
 
-## Why this is better than just asking Claude
-
-Claude already knows how to run `docker compose up`. What `open-forge` adds:
-
-- **Captured tribal knowledge.** ~180 recipes verified against upstream docs include the gotchas that aren't in any README — Bitnami's `bncert-tool` not supporting `--unattended`, Apache reverse-proxy needing `ProxyPreserveHost` after enabling HTTPS, MySQL on Ubuntu 22+ defaulting to socket-auth that Ghost rejects, and so on.
-- **Compounding by design.** Raw Claude Code starts from zero every session. `open-forge` accumulates — every successful (or failed) deploy can feed gotchas back into the catalog. The 1001st deploy is faster and safer than the first because the previous 1000 contributed.
-- **Resumable across sessions.** Every deployment writes a state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow without re-running provisioning.
-- **Consistent across clouds.** The "install Docker on Ubuntu" step is written once and reused for Hetzner / DO / Lightsail Ubuntu / localhost. You can swap clouds without re-deriving the install.
-- **Source-attributed.** Every install method cites the exact upstream URL it derives from. When a recipe goes stale, the link is the recovery path; community-maintained methods are flagged with a warning blockquote.
-- **Self-improving.** The skill drafts a sanitized GitHub issue at the end of every deploy with proposed recipe edits. You review, approve, post — the catalog gets better for the next user.
-
 ## Install
 
 In Claude Code:
@@ -48,156 +34,62 @@ In Claude Code:
 /plugin install open-forge@open-forge
 ```
 
-## Use
+Then say what you want to deploy:
 
-Tell Claude what you want to deploy:
-
-> *"I want to self-host Ghost on AWS Lightsail."*
+> *"Self-host Vaultwarden on my Raspberry Pi."*
 >
-> *"Set up Mastodon on a Hetzner VPS — I'll bring my own SMTP."*
+> *"Run Open WebUI + Ollama on my laptop, expose via Cloudflare Tunnel."*
 >
-> *"Deploy Vaultwarden on my Raspberry Pi."*
->
-> *"Run Open WebUI + Ollama on my laptop, expose it via Cloudflare Tunnel."*
+> *"Deploy Mastodon on a Hetzner VPS — I'll bring my own SMTP."*
 
-The skill takes it from there — collects inputs, runs cloud CLI + SSH commands, walks you through DNS and SMTP, records state so you can resume across sessions.
+## What makes it different from raw Claude Code
 
-## Verified recipes (~180)
+- **Captured gotchas** — recipes include the surprises that aren't in any README. Bitnami's `bncert-tool` won't accept `--unattended`. MySQL on Ubuntu 22+ rejects socket-auth that Ghost needs. Ghost-CLI's sudo username can't actually be `ghost`. The 1001st deploy is faster than the first because the previous 1000 contributed.
+- **Resumable** — phased workflow + state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow.
+- **Self-improving** — every deploy can feed back into the catalog via a sanitized GitHub issue you opt in to. An AI agent re-verifies against upstream and patches the recipe for the next user.
 
-A curated catalog of self-hostable apps. Each recipe cites its upstream sources at authorship; first-deploy verification — confirming the gotchas in the wild — happens via the [feedback loop](#feedback-loop) as users deploy. The catalog grows where it earns its keep — software whose gotchas compound across deploys. We deliberately don't try to catalog every self-hostable app; for everything else, the [live-derived fallback](#dont-see-your-software) handles the long tail. A taste:
+## What you can deploy
+
+**~180 verified recipes** with captured gotchas + ongoing maintenance. A taste:
 
 | Category | Examples |
 |---|---|
-| **AI stack** | Ollama, vLLM, Open WebUI, LibreChat, AnythingLLM, Aider, OpenClaw, Hermes-Agent, Dify, Langfuse, ComfyUI, Stable Diffusion WebUI |
-| **Publishing & docs** | Ghost, WordPress, Docusaurus, Outline, BookStack, Wiki.js, Etherpad |
-| **Productivity** | Nextcloud, AppFlowy, Joplin, Logseq, Trilium, Memos, Plane, Twenty CRM |
-| **Photos & media** | Immich, PhotoPrism, Jellyfin, Navidrome, Koel |
-| **Dev & deploy** | Gitea, Coolify, Dokku, Portainer, Code-Server, Storybook |
-| **Monitoring** | Grafana, Prometheus, Loki, Uptime Kuma, Netdata, SigNoz, Beszel |
-| **Security & auth** | Vaultwarden, Authelia, Authentik, Keycloak, Infisical |
-| **Networking** | Pi-hole, AdGuard Home, NetBird, Headscale, wg-easy |
-| **Communication** | Mastodon, Mattermost, Rocket.Chat, Zulip, Jitsi Meet |
-| **Automation & data** | n8n, Windmill, Activepieces, Huginn, Node-RED, Apache Superset, Metabase |
+| **AI stack** | Ollama · vLLM · Open WebUI · LibreChat · AnythingLLM · Aider · Dify · Langfuse · ComfyUI · A1111 |
+| **Publishing** | Ghost · WordPress · Docusaurus · Outline · BookStack · Wiki.js |
+| **Productivity** | Nextcloud · Joplin · Logseq · Trilium · Plane · Twenty CRM |
+| **Photos & media** | Immich · PhotoPrism · Jellyfin · Navidrome |
+| **Dev tools** | Gitea · Coolify · Portainer · Code-Server |
+| **Monitoring** | Grafana · Prometheus · Uptime Kuma · Netdata · SigNoz |
+| **Security** | Vaultwarden · Authelia · Authentik · Keycloak |
+| **Networking** | Pi-hole · AdGuard Home · NetBird · Headscale · wg-easy |
+| **Communication** | Mastodon · Mattermost · Rocket.Chat · Jitsi Meet |
+| **Automation** | n8n · Windmill · Activepieces · Node-RED |
 
-Full list: [`plugins/open-forge/skills/open-forge/references/projects/`](plugins/open-forge/skills/open-forge/references/projects/).
+Full list: [`references/projects/`](plugins/open-forge/skills/open-forge/references/projects/).
 
-### Don't see your software?
+**Don't see what you want?** The skill falls back to a **live-derived recipe** — fetches upstream docs at request time and reuses the runtime + infra modules. Best-effort, not authoritative; you'll see a banner before it starts.
 
-The skill falls back to a **live-derived recipe** — fetches upstream docs at request time, applies the same strict-doc-verification policy, and reuses the existing infra + runtime modules. Best-effort, not authoritative; you'll see a banner like:
+## Where you can deploy
 
-> *"This software isn't in our verified catalog — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort."*
+**17 infra adapters × 4 runtimes** — write once, reuse everywhere.
 
-If the live deploy goes well, the skill will offer to nominate the software for the verified catalog.
-
-## Where + how
-
-Verified support across **17 infra adapters** and **4 runtime modules** — write once, reuse everywhere.
-
-### Where to host
-
-| Cloud / location | Adapter |
-|---|---|
-| **AWS** | Lightsail (with vendor blueprints for Ghost, OpenClaw, etc.; or plain Ubuntu) · EC2 |
-| **Azure VM** | Bastion-hardened (no public IP) |
-| **Hetzner Cloud** | CX-line VM (`hcloud` CLI) |
-| **DigitalOcean** | Droplet (`doctl` CLI) |
-| **GCP Compute Engine** | VM (`gcloud` CLI) |
-| **Oracle Cloud** | Always-Free A1.Flex ARM (Tailscale reach) |
-| **Hostinger** | Managed (1-Click) or VPS (Docker Manager via hPanel) |
-| **Raspberry Pi** | Pi 4 / Pi 5 (64-bit ARM) |
-| **macOS VM** (Lume on Apple Silicon) | Sandboxed macOS — for iMessage via BlueBubbles |
-| **Any Linux VM you already have** | SSH-only adapter; works for Vultr, Linode, on-prem, etc. |
-| **Your own machine** | macOS / Linux / Windows / WSL2 — Claude runs commands locally |
-| **Any Kubernetes cluster** | EKS / GKE / AKS / DOKS / k3s / kind / Docker-Desktop k8s |
-| **PaaS** | Fly.io · Render · Railway · Northflank · exe.dev — one-click templates from upstream repos |
-
-### How to host (when the infra gives you the choice)
-
-| Runtime | Notes |
-|---|---|
-| **Docker** | The recommended default. Works wherever Docker is supported. |
-| **Podman** | Rootless Docker-compatible alternative; Quadlet (systemd-user) supported. |
-| **Native** | OS package manager / installer scripts. systemd / launchd / Scheduled-Tasks lifecycle. |
-| **Kubernetes** | Kustomize-first (project recipes default to upstream's `scripts/k8s/deploy.sh` shape); Helm where upstream ships a chart. |
-
-The "how" question is **dynamically generated** from your software + cloud choice — different combos expose different runtimes.
-
-## Phased workflow
-
-Each phase is **verifiable and resumable**. Claude completes, verifies, and records state before moving on.
-
-| Phase | What happens |
-|---|---|
-| `preflight` | Check CLI tools, validate accounts, confirm domain ownership; collect just-in-time inputs. |
-| `provision` | Create instance, allocate static IP, retrieve SSH key. |
-| `dns` | Print exact records to add at registrar; poll until resolved. |
-| `tls` | Obtain Let's Encrypt cert, fix reverse-proxy config, switch app URL to https. |
-| `smtp` | Configure outbound email provider; verify a test send. |
-| `inbound` | (Optional) Set up forwarding or mailbox. |
-| `hardening` | Rotate default admin creds; rotate any secrets pasted into chat. |
-| `feedback` | Offer to file a sanitized GitHub issue with deployment notes (you opt in). |
-
-## Feedback loop (the catalog grows from your deploys)
-
-Catalog evolution happens through GitHub issues, not human pull requests. The skill drafts a sanitized issue at the end of every deploy; you review, approve, and post.
-
-Issues are processed by an **AI agent** that reads [`CLAUDE.md`](CLAUDE.md) as its runbook — same policy that governs the existing catalog. For every change the agent re-fetches upstream docs, applies the [strict doc-verification policy](CLAUDE.md#strict-doc-verification-policy-mandatory-before-writing-any-recipe), authors the patch, opens a PR, and bumps the version. No human needs to write code for the catalog to improve; you just deploy + click "share."
-
-Three input channels (all via [GitHub issue templates](.github/ISSUE_TEMPLATE/)):
-
-| Template | When to use |
-|---|---|
-| **Recipe feedback** | You deployed via the skill and want to suggest recipe edits — gotchas you hit, install steps that surprised you, sections that were outdated. The skill drafts these automatically. |
-| **Software nomination** | You want a software added to the verified catalog (after a successful live-derived deploy, the skill offers this). |
-| **Method proposal** | You know an upstream-supported install method that an existing recipe doesn't cover. |
-
-The skill **never auto-posts** — you see the redacted draft, review it, and explicitly approve before submission. Sanitization strips domains, IPs, SSH key paths, API keys, AWS account IDs, and emails before showing the draft.
+- **Cloud VMs**: AWS (Lightsail · EC2) · Azure · Hetzner · DigitalOcean · GCP · Oracle Cloud (Always-Free ARM) · Hostinger
+- **Bare metal / home**: Raspberry Pi · macOS VM (Lume) · any Linux VM you already have · your own machine
+- **Kubernetes**: any cluster (EKS · GKE · AKS · DOKS · k3s · kind · Docker-Desktop)
+- **PaaS**: Fly.io · Render · Railway · Northflank · exe.dev
+- **Runtimes**: Docker · Podman · Native · Kubernetes (Kustomize-first; Helm where upstream ships one)
 
 ## Contributing
 
-**Don't open PRs.** [File an issue](https://github.com/zhangqi444/open-forge/issues/new/choose) instead — the structured templates encode the strict-doc policy, and the AI agent processes the queue and authors patches.
+**File an issue, don't open a PR.** [Issue templates](.github/ISSUE_TEMPLATE/) cover three channels:
 
-**Why issues, not PRs?** The agent re-verifies every change against upstream docs centrally — this keeps the catalog consistent with the [strict-doc policy](CLAUDE.md#strict-doc-verification-policy-mandatory-before-writing-any-recipe), avoids credentials leaking into commit history (the skill sanitizes drafts before posting), and turns "let me submit a PR with my fix" into "let me share what I learned" — much lower bar to contribute, much higher quality bar on what lands. See [CLAUDE.md § Issue-driven contribution model](CLAUDE.md#issue-driven-contribution-model) for the full reasoning.
+- **Recipe feedback** — the skill drafts this for you at end of deploy (sanitized; you opt in)
+- **Software nomination** — request a recipe for an app the catalog doesn't have
+- **Method proposal** — an upstream install method an existing recipe doesn't cover
 
-If you're a maintainer working on the plugin itself, see [`CLAUDE.md`](CLAUDE.md) for the development conventions and architectural model.
+An AI agent reads [`CLAUDE.md`](CLAUDE.md) as its runbook, re-verifies every change against upstream docs, and patches the catalog. Why issues, not PRs? Central verification keeps the catalog consistent, and the skill sanitizes drafts before posting so credentials don't leak into commit history.
 
-## How it works (for the curious)
-
-`open-forge` is built on a **3-layer model** asked in 3 questions:
-
-| # | Question | Layer | Lives in |
-|---|---|---|---|
-| 1 | **What** to host? | software | `references/projects/<sw>.md` |
-| 2 | **Where** to host? | infra | `references/infra/<cloud>/*.md` |
-| 3 | **How** to host? | runtime | `references/runtimes/<runtime>.md` |
-
-Reusability is the test: "install Docker on Ubuntu" is the same on Hetzner / DO / Lightsail / localhost — written once in the runtime layer. Project recipes are 80% software-specific concerns + a one-line link to the runtime.
-
-Cross-cutting modules (`references/modules/`) cover preflight, DNS, TLS via Let's Encrypt, SMTP providers (Resend / SendGrid / Mailgun), inbound forwarders (ImprovMX), tunnels (Cloudflare / Tailscale / ngrok), and the post-deploy feedback flow.
-
-For the full architectural treatment + the strict-doc-verification policy + the issue-driven contribution model, see [`CLAUDE.md`](CLAUDE.md).
-
-## Repo layout
-
-```
-open-forge/
-├── CLAUDE.md                                 # development policy + architecture
-├── README.md                                 # you are here
-├── .github/ISSUE_TEMPLATE/                   # the three input channels
-│   ├── recipe-feedback.yml
-│   ├── software-nomination.yml
-│   └── method-proposal.yml
-├── .claude-plugin/marketplace.json           # marketplace manifest
-└── plugins/open-forge/                       # the plugin
-    ├── .claude-plugin/plugin.json            # version
-    └── skills/open-forge/
-        ├── SKILL.md                          # end-user-Claude entrypoint
-        └── references/
-            ├── projects/                     # ~180 verified recipes
-            ├── infra/                        # 17 cloud / VPS / localhost adapters
-            ├── runtimes/                     # docker / podman / native / kubernetes
-            └── modules/                      # preflight / dns / tls / smtp / inbound / tunnels / feedback
-```
+For the architectural details (3-axis model, strict-doc-verification policy, two-tier coverage, sanitization rules), see [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 > **Self-host any open-source app on your own infrastructure — guided by Claude Code.**
-> No more reading READMEs and copy-pasting bash for hours.
+> A self-improving recipe catalog that gets better every time anyone deploys.
 
 ```
 > "Self-host Ghost on a Hetzner CX22 with a Resend SMTP relay."
@@ -42,11 +42,32 @@ Then say what you want to deploy:
 >
 > *"Deploy Mastodon on a Hetzner VPS — I'll bring my own SMTP."*
 
-## What makes it different from raw Claude Code
+## A self-improving catalog (the key idea)
 
-- **Captured gotchas** — recipes include the surprises that aren't in any README. Bitnami's `bncert-tool` won't accept `--unattended`. MySQL on Ubuntu 22+ rejects socket-auth that Ghost needs. Ghost-CLI's sudo username can't actually be `ghost`. The 1001st deploy is faster than the first because the previous 1000 contributed.
-- **Resumable** — phased workflow + state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow.
-- **Self-improving** — every deploy can feed back into the catalog via a sanitized GitHub issue you opt in to. An AI agent re-verifies against upstream and patches the recipe for the next user.
+Raw Claude Code starts from zero every session. `open-forge` *accumulates* — every deploy can feed gotchas back into the catalog so the next user starts further ahead.
+
+```
+   you deploy ─► skill captures gotchas ─► you review + opt in to share
+        ▲                                         │
+        │                                         ▼
+        └─ improved recipe ◄─ AI agent patches ◄─ sanitized issue
+```
+
+**The loop:**
+
+1. **You deploy.** Skill walks you through provisioning, DNS, TLS, SMTP, hardening — recording state for resume.
+2. **Skill drafts a sanitized issue** at the end with the gotchas it observed and proposed recipe edits. Domains, IPs, API keys, AWS account IDs are stripped before you see the draft.
+3. **You review and opt in** (or don't — never auto-posted). One click; takes seconds.
+4. **An AI agent processes the issue** — re-fetches upstream docs, applies the [strict doc-verification policy](CLAUDE.md), patches the recipe, opens a PR, bumps the version.
+5. **The next user gets the improved recipe.**
+
+That's why captured tribal knowledge already includes things like *"Bitnami's `bncert-tool` won't accept `--unattended`"*, *"MySQL on Ubuntu 22+ rejects socket-auth that Ghost needs"*, and *"Ghost-CLI's sudo username can't be `ghost`"* — none of which are in any upstream README.
+
+## Other reasons it's better than raw Claude Code
+
+- **Resumable across sessions** — phased workflow + state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow.
+- **Consistent across clouds** — "install Docker on Ubuntu" is written once and reused for Hetzner / DO / Lightsail / localhost. Swap clouds without re-deriving.
+- **Source-attributed** — every install method cites the upstream URL it derives from. When upstream drifts, the link is the recovery path.
 
 ## What you can deploy
 


### PR DESCRIPTION
## Summary

Two follow-up README polish commits after PR #29 (merged) — both pure documentation, no code or version change.

## Commits

| Commit | Change |
|---|---|
| `bebf9b9` | **Simplify for first-impression read** (205 → 96 lines, -53%). Cut: 6 value bullets → 3, 8-row phased-workflow table, "How it works (for the curious)" section, repo-layout diagram, 4 example prompts → 3. Sample chat moved up to be the second beat after the tagline. Install moved above-the-fold. Most architectural depth now lives only in CLAUDE.md. |
| `936fc2c` | **Elevate self-improving catalog as the headline feature** (96 → 117 lines, +22%). The feedback-loop-driven catalog is the project's architectural moat — anyone can build "Claude does deploys", but a recipe library that gets better every time anyone deploys is hard to copy. Previous draft buried this as the 3rd bullet behind static features. Now: tagline picks it up explicitly, dedicated section "A self-improving catalog (the key idea)" with a small ASCII diagram of the loop appears right after Install. Captured-gotcha examples (`bncert-tool`, MySQL socket-auth, Ghost-CLI username) reframed as outputs of this loop, not static features. |

Net effect: README is now 117 lines (was 205 before PR #29 + this PR), reads in ~30 seconds, and leads with the right architectural claim.

## Test plan

- [ ] README renders correctly on github.com (ASCII diagram, tables, code blocks, links).
- [ ] Smoke read: a new visitor can answer "what does this do, why is it special, how do I install it" in 30 seconds.
- [ ] The "self-improving catalog" section reads above-the-fold on a typical laptop screen.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_