### PR TITLE
v0.20.1 — credential handling: five patterns over chat paste

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,32 @@ Ask: *"Would the user need open-forge to walk them through provisioning + DNS + 
 6. **Reference upstream docs; don't replace them.** Recipes condense and translate upstream documentation into Claude-actionable steps — they aren't the source of truth for the product itself. Always link the upstream pages we summarized (e.g. `docs.openclaw.ai/install/docker`, AWS Lightsail user guide, Bitnami docs). Reasons: (a) users can verify what we condensed, (b) when upstream drifts our recipe goes stale fast and the link is the recovery path, (c) credit where due. **See *Strict doc-verification policy* below — every install method documented by upstream must have its own recipe section, verified against upstream before being written.**
 7. **Don't invent — interface.** open-forge is a chat-friendly interface to existing tools. Claude is the orchestrator; the user's existing software stack (AWS CLI, Docker, openclaw, ssh, gh, registrar UIs) is the substrate. **Do not** build custom DSLs, YAML schemas, CLI tools, deployment managers, or wrappers around upstream tools. **Do not** reimplement what an upstream tool already does (e.g. don't rebuild `openclaw onboard`'s prompts in chat — call the command). The state file is a thin orchestration helper for resume, nothing more. *Caveat:* "don't invent" applies to **fabricating a deployment path the upstream doesn't support** (e.g. authoring a Helm chart for a project that has no chart). It does **not** mean "no tooling." If upstream supports Docker / k8s / Helm / Terraform, lean on every skill and MCP that helps you orchestrate those paths well — see *Companion skills & MCPs* below.
 
+## Credential handling (expanded from Operating Principle #3)
+
+Pasting raw credentials into Claude Code is risky — secrets enter session history, may be relayed via MCP servers, and could appear in shared transcripts. The skill must offer safer alternatives **first** and only fall back to direct paste with explicit risk acknowledgement.
+
+### The five patterns (priority order)
+
+| # | Pattern | When to suggest |
+|---|---|---|
+| 1 | **Local file path** — user gives skill a path; skill `cat`s it | Personal-use API keys; user already has a `.env` or `.secrets` file |
+| 2 | **Env var name** — user pre-exports the secret; skill reads `$<NAME>` | Shell users with secrets in `.envrc` / `.bashrc` |
+| 3 | **Cloud-CLI session** — user runs `<provider> login` ahead of time; skill uses the resulting profile / session | Default for AWS, GCP, Azure, GitHub, DigitalOcean, Hetzner, Cloudflare |
+| 4 | **Secrets-manager reference** — user gives skill a `op://` / `bw://` / `vault://` reference; skill calls the matching CLI just-in-time | Users with proper secret management (1Password, Bitwarden, Vault, AWS Secrets Manager, GCP Secret Manager, `pass`) |
+| 5 | **Direct chat paste** — last resort, requires risk acknowledgement | When patterns 1-4 don't apply; user explicitly opts in |
+
+### Hard rules
+
+- **Always offer the five patterns** when asking for any sensitive input. Don't silently accept a paste; don't assume Claude Code is a vault.
+- **Surface the risk** before accepting a direct paste: *"the key will live in this session's history; rotate after deploy completes."*
+- **Never accept SSH key contents.** Always ask for the key file *path* (skill uses `ssh -i <path>`); never the key material itself in chat.
+- **Validate before proceeding**: `test -r <path>` for file paths; `test -n "$<VAR>"` for env vars; smoke-command for cloud-CLI sessions and secrets-manager refs.
+- **Refuse files with permissions wider than 600**; offer to `chmod 600` first.
+- **Detect accidental pastes** (regex for `re_*`, `sk-*`, `AKIA*`, etc. in a prompt that expected a path) and stop the user before the secret commits to chat.
+- **End-of-deploy rotation reminder** if the user pasted any secret directly during the deploy: list each pasted credential + the provider's dashboard URL; recommend rotating now that the deploy is done.
+
+The full pattern catalog with skill prompt templates, per-credential-class recommendations, and failure-mode handling lives in [`plugins/open-forge/skills/open-forge/references/modules/credentials.md`](plugins/open-forge/skills/open-forge/references/modules/credentials.md).
+
 ## Strict doc-verification policy (mandatory before writing any recipe)
 
 Recipes are condensations of upstream docs; condensing what we haven't read is speculation. Past failures (the v0.7.0 Helm chart claim sourced from a search snippet, the v0.6.0 OpenClaw "every blessed path" claim that was 4 of 17 because we trusted the README's enumeration) traced back to this. The policy:

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-forge",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, helm, podman, docker, lume, tailscale, terraform, cdk, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw, Hermes-Agent, Ollama, Open WebUI, Stable Diffusion WebUI (Automatic1111), ComfyUI, Dify, LibreChat, AnythingLLM, Aider, vLLM, Langfuse. AI stack focus: Ollama (single-user LLM inference) + vLLM (production-grade LLM inference) + Open WebUI / LibreChat (multi-user chat UIs) + Stable Diffusion WebUI / ComfyUI (image generation) + AnythingLLM (RAG-focused workspace) + Aider (terminal pair-programming CLI) + Langfuse (LLM observability + evals) compose into a complete local-AI stack; OpenClaw + Hermes-Agent are agent projects; Dify is the LLMOps platform layer. Every recipe is verified against upstream's docs index per the strict-doc policy in CLAUDE.md (community-maintained methods are explicitly flagged when upstream ships no first-party version).",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -186,6 +186,33 @@ Inputs split across three layers:
 
 Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use `AskUserQuestion` for structured choices.
 
+## Asking for credentials
+
+Whenever the skill needs sensitive input — API keys, DB passwords, OAuth client secrets, cloud creds, SSH key paths — load `references/modules/credentials.md` and offer the **five patterns** (priority order):
+
+| # | Pattern | What user gives |
+|---|---|---|
+| 1 | Local file path | path to file containing the secret (skill `cat`s it) |
+| 2 | Env var name | name of an env var the user pre-exported (skill reads `$<NAME>`) |
+| 3 | Cloud-CLI session | "I've already run `aws sso login` for profile `<name>`" |
+| 4 | Secrets-manager ref | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` (skill calls matching CLI) |
+| 5 | Direct paste | **last resort** — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |
+
+**Never silently accept a paste.** When the skill detects sensitive input is needed, it should:
+
+1. **Offer the five patterns** with the credential class noted (e.g. *"I need a Resend API key — pick how to provide it: file path, env var, secrets-manager ref, or paste (last resort)"*).
+2. **Validate** before using:
+   - File path → `test -r <path>` + check mode is `≤ 600` (offer `chmod 600` if wider).
+   - Env var → `test -n "$<NAME>"` (refuse if empty; if user `export`ed after Claude Code started, ask them to restart).
+   - Cloud-CLI → smoke-command (e.g. `aws sts get-caller-identity --profile <name>`).
+   - Secrets-manager → smoke-command (`op read --no-newline <ref>`, `vault kv get`, etc.).
+   - Paste → require explicit risk acknowledgement first.
+3. **Detect accidental pastes**: if the user was prompted for a path but pasted a string matching `re_*` / `sk-*` / `AKIA[0-9A-Z]{16}` / etc., stop and ask: *"That looks like the key itself, not a path. Did you mean to paste directly? (see risks)"*.
+4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
+5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
+
+See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
+
 ## Verification after each phase
 
 | Phase | Verify with |

--- a/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+++ b/plugins/open-forge/skills/open-forge/references/modules/credentials.md
@@ -1,0 +1,221 @@
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.


### PR DESCRIPTION
## Summary

Pasting raw credentials into Claude Code is risky — secrets enter session history, may be relayed via MCP servers, may appear in shared transcripts. Until now the skill collected API keys / DB passwords / OAuth secrets via free-text prompts without surfacing the risk or offering safer paths.

This PR ships a five-pattern credential-handling spec that defaults to **safer paths first** and only falls back to direct chat paste with explicit risk acknowledgement. Bumps plugin to **v0.20.1**.

## The five patterns (priority order)

| # | Pattern | What user gives skill |
|---|---|---|
| **1** | **Local file path** | path to file containing the secret (skill `cat`s it; secret never enters chat) |
| **2** | **Env var name** | name of an env var the user pre-exported (skill reads `$<NAME>`) |
| **3** | **Cloud-CLI session** | "I've run `aws sso login` for profile `<name>`" — skill uses the profile |
| **4** | **Secrets-manager ref** | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` — skill calls matching CLI just-in-time |
| **5** | **Direct paste** | last resort — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |

## Hard rules added

- Always offer all five patterns when asking for sensitive input — don't silently accept paste, don't pretend Claude Code is a vault.
- Surface the risk before accepting paste: *"the key will live in this session's history; rotate after deploy completes."*
- **Never accept SSH key contents.** Always ask for the file path; skill uses `ssh -i <path>`.
- Validate before using: `test -r <path>` for files, `test -n` for env vars, smoke-command for CLI sessions and secrets-manager refs.
- Refuse files with mode wider than 600; offer `chmod 600`.
- Detect accidental pastes via key-shape regex (`re_*`, `sk-*`, `AKIA[0-9A-Z]{16}`, etc.) and stop the user before the secret commits to chat.
- End-of-deploy rotation reminder for any secret pasted during the deploy: list each (credential, dashboard URL) pair during the `hardening` phase.

## Files

| File | Change | Size |
|---|---|---|
| `references/modules/credentials.md` (new) | Full pattern catalog + skill prompt template + per-credential-class recommendations + validation rules + failure-mode handling | ~225 lines |
| `CLAUDE.md` | New § *Credential handling* expanding Operating Principle #3 | +26 lines |
| `SKILL.md` | New § *Asking for credentials* between *Inputs* and *Verification after each phase* | +27 lines |
| `plugin.json` | 0.20.0 → 0.20.1 | — |

## Existing recipes unchanged

The new pattern is cross-cutting (enforced from SKILL.md + credentials.md). All ~180 recipes' "Inputs to collect" rows that say *"API key for X — Free-text (sensitive — rotate after)"* will now route through the five-pattern prompt automatically. No per-recipe edits needed.

## Per-credential-class defaults

| Credential | Default pattern | Alternative |
|---|---|---|
| API keys (Resend, OpenAI, etc.) | 1 (file) or 2 (env var) | 4 (secrets manager) |
| Cloud auth (AWS / GCP / Azure / GH) | 3 (CLI session) | 4 |
| **SSH keys** | The file path itself (Pattern 1, but specifically the key file). **Never the contents.** | n/a |
| DB passwords | 1, 2, or 4 | 5 only if it's a one-shot disposable password |
| OAuth client secrets | 4 (long-lived; should be vaulted) | 1 with `chmod 600` |
| Random per-deploy secrets | Generate inline; never echo to user | n/a |

## Test plan

- [ ] Live test: ask Claude to deploy something requiring a Resend API key — confirm the five-pattern prompt appears.
- [ ] Live test: pick pattern 5 (paste) — confirm the risk acknowledgement is required, and the rotation reminder appears at hardening.
- [ ] Live test: paste a string matching `re_*` when prompted for a file path — confirm skill detects + stops.
- [ ] Live test: provide a file path with mode `0644` — confirm skill refuses and offers `chmod 600`.
- [ ] Live test: provide an env var name that's empty — confirm skill refuses with helpful guidance.
- [ ] CLAUDE.md and SKILL.md render correctly with the new sections in the right positions.

## Out of scope

- **Updating per-recipe credential rows.** Cross-cutting layer enforces the pattern; recipe-level "Inputs to collect" tables stay as-is.
- **A vault-backed Claude session** (where Claude itself stores secrets between deploys) — out of scope; the skill is a thin orchestrator and shouldn't custody credentials.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_