### PR TITLE
README — DeepWiki coverage link + OpenClaw as hero example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,16 @@
 > A self-improving recipe catalog that gets better every time anyone deploys.
 
 ```
-> "Self-host Ghost on a Hetzner CX22 with a Resend SMTP relay."
+> "Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired."
 
-  [open-forge] Loading verified recipe ghost.md (v0.20.0).
-  [open-forge] Combo: Hetzner Cloud CX × Docker.
-  [open-forge] I have everything I need except your domain and Resend API key.
+  [open-forge] Loading verified recipe openclaw.md (v0.20.1).
+  [open-forge] Combo: AWS Lightsail OpenClaw blueprint (vendor-bundled, Bedrock IAM included).
+  [open-forge] I'll need your AWS profile and the domain you want.
 
-  Domain you want to host Ghost on?
+  AWS profile name?
 ```
+
+> *(OpenClaw — the self-hosted personal AI agent at [openclaw.ai](https://openclaw.ai) — is the project's signature use case; works the same way for any of the [~180 verified recipes](#coverage).)*
 
 ## Install
 
@@ -37,9 +39,11 @@ In Claude Code:
 
 Then say what you want to deploy:
 
-> *"Self-host Vaultwarden on my Raspberry Pi."*
+> *"Set up OpenClaw on my Raspberry Pi with the local Ollama provider."*
 >
-> *"Run Open WebUI + Ollama on my laptop, expose via Cloudflare Tunnel."*
+> *"Run OpenClaw on a Hetzner CX22 + Docker, paired with Open WebUI."*
+>
+> *"Self-host Vaultwarden on my laptop, expose via Cloudflare Tunnel."*
 >
 > *"Deploy Mastodon on a Hetzner VPS — I'll bring my own SMTP."*
 
@@ -62,7 +66,7 @@ Raw Claude Code starts from zero every session. `open-forge` *accumulates* — e
 4. **An AI agent processes the issue** — re-fetches upstream docs, applies the [strict doc-verification policy](CLAUDE.md), patches the recipe, opens a PR, bumps the version.
 5. **The next user gets the improved recipe.**
 
-That's why captured tribal knowledge already includes things like *"Bitnami's `bncert-tool` won't accept `--unattended`"*, *"MySQL on Ubuntu 22+ rejects socket-auth that Ghost needs"*, and *"Ghost-CLI's sudo username can't be `ghost`"* — none of which are in any upstream README.
+That's why captured tribal knowledge already includes things like *"OpenClaw's three installers (`install.sh`, `install-cli.sh`, `install.ps1`) don't share state — pick one and stick with it"*, *"the Lightsail OpenClaw blueprint runs the gateway as a systemd USER unit with `loginctl enable-linger` so it survives no-login sessions"*, *"on Windows, OpenClaw's `iwr | iex` failures are non-fatal to the shell — silent partial installs are common, always check the explicit success line"*, and *"Bitnami's `bncert-tool` won't accept `--unattended`"* — none of which are in any upstream README.
 
 ## Other reasons it's better than raw Claude Code
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 <h1 align="center">open-forge</h1>
 
 <p align="center">
-  <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/plugin-v0.20.0-F97316?style=flat-square&labelColor=0F172A" alt="Plugin version" /></a>
+  <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/plugin-v0.20.1-F97316?style=flat-square&labelColor=0F172A" alt="Plugin version" /></a>
+  <a href="https://deepwiki.com/zhangqi444/open-forge"><img src="https://img.shields.io/badge/docs-DeepWiki-22D3EE?style=flat-square&labelColor=0F172A" alt="DeepWiki" /></a>
   <a href="https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects"><img src="https://img.shields.io/badge/verified%20recipes-180+-EA580C?style=flat-square&labelColor=0F172A" alt="Verified recipes" /></a>
   <a href="#install"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-D77756?style=flat-square&labelColor=0F172A" alt="Built for Claude Code" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=22D3EE" alt="MIT License" /></a>
@@ -69,36 +70,15 @@ That's why captured tribal knowledge already includes things like *"Bitnami's `b
 - **Consistent across clouds** — "install Docker on Ubuntu" is written once and reused for Hetzner / DO / Lightsail / localhost. Swap clouds without re-deriving.
 - **Source-attributed** — every install method cites the upstream URL it derives from. When upstream drifts, the link is the recovery path.
 
-## What you can deploy
+## Coverage
 
-**~180 verified recipes** with captured gotchas + ongoing maintenance. A taste:
+- **Software**: ~180 verified recipes for popular self-hostable apps — AI stack (Ollama · vLLM · Open WebUI · …), publishing (Ghost · WordPress · …), productivity (Nextcloud · Joplin · …), photos & media (Immich · Jellyfin · …), monitoring, security, networking, communication, automation. Plus **live-derived fallback** for anything else with public docs (best-effort; you'll see a banner before it starts).
+- **Where**: any cloud VM (AWS · Azure · GCP · Hetzner · DigitalOcean · Oracle Always-Free ARM · Hostinger), your own machine, Raspberry Pi, macOS VM (Lume), any Kubernetes cluster (EKS · GKE · AKS · DOKS · k3s · kind), or PaaS (Fly.io · Render · Railway · Northflank · exe.dev).
+- **How**: Docker · Podman · Native · Kubernetes (Kustomize-first; Helm where upstream ships one).
 
-| Category | Examples |
-|---|---|
-| **AI stack** | Ollama · vLLM · Open WebUI · LibreChat · AnythingLLM · Aider · Dify · Langfuse · ComfyUI · A1111 |
-| **Publishing** | Ghost · WordPress · Docusaurus · Outline · BookStack · Wiki.js |
-| **Productivity** | Nextcloud · Joplin · Logseq · Trilium · Plane · Twenty CRM |
-| **Photos & media** | Immich · PhotoPrism · Jellyfin · Navidrome |
-| **Dev tools** | Gitea · Coolify · Portainer · Code-Server |
-| **Monitoring** | Grafana · Prometheus · Uptime Kuma · Netdata · SigNoz |
-| **Security** | Vaultwarden · Authelia · Authentik · Keycloak |
-| **Networking** | Pi-hole · AdGuard Home · NetBird · Headscale · wg-easy |
-| **Communication** | Mastodon · Mattermost · Rocket.Chat · Jitsi Meet |
-| **Automation** | n8n · Windmill · Activepieces · Node-RED |
+📖 **Browse the catalog**: [deepwiki.com/zhangqi444/open-forge](https://deepwiki.com/zhangqi444/open-forge) — auto-generated wiki view of every recipe, infra adapter, and module. Stays current with the repo.
 
-Full list: [`references/projects/`](plugins/open-forge/skills/open-forge/references/projects/).
-
-**Don't see what you want?** The skill falls back to a **live-derived recipe** — fetches upstream docs at request time and reuses the runtime + infra modules. Best-effort, not authoritative; you'll see a banner before it starts.
-
-## Where you can deploy
-
-**17 infra adapters × 4 runtimes** — write once, reuse everywhere.
-
-- **Cloud VMs**: AWS (Lightsail · EC2) · Azure · Hetzner · DigitalOcean · GCP · Oracle Cloud (Always-Free ARM) · Hostinger
-- **Bare metal / home**: Raspberry Pi · macOS VM (Lume) · any Linux VM you already have · your own machine
-- **Kubernetes**: any cluster (EKS · GKE · AKS · DOKS · k3s · kind · Docker-Desktop)
-- **PaaS**: Fly.io · Render · Railway · Northflank · exe.dev
-- **Runtimes**: Docker · Podman · Native · Kubernetes (Kustomize-first; Helm where upstream ships one)
+Or just ask Claude — *"self-host X on Y"* — and it'll match.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Two README commits — both pure documentation, no code or version bump.

## Commits

| Commit | Change |
|---|---|
| `7757f82` | **Collapse stale-prone catalog tables into DeepWiki link.** Replaces the `What you can deploy` table (10 categories × ~5 names) and `Where you can deploy` (5 detailed bullets) with a 3-bullet `Coverage` section + a [DeepWiki](https://deepwiki.com/zhangqi444/open-forge) link as the catalog browse experience. DeepWiki auto-indexes the repo and stays current — no README maintenance burden. Added DeepWiki badge (cyan, fits palette). 35 lines → 8 lines. |
| `7c026e0` | **Feature OpenClaw as the hero example throughout.** OpenClaw ([openclaw.ai](https://openclaw.ai) — self-hosted personal AI agent) is the project's signature use case and a more distinctive demo than Ghost. Three places updated: sample chat now demos *"Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired"* (vendor-bundled blueprint path); example prompts in Install lead with two OpenClaw deploys; captured-gotcha examples lead with three OpenClaw-flavored gotchas (three-installer state-sharing, Lightsail-blueprint `loginctl enable-linger`, Windows `iwr \| iex` silent partial installs). |

## Test plan

- [ ] DeepWiki link renders + resolves on GitHub.
- [ ] DeepWiki badge renders correctly in the badge row.
- [ ] OpenClaw is the first concrete example a reader hits (sample chat) and is reinforced in Install + self-improving sections without crowding out the "works for any of ~180 recipes" claim.
- [ ] README still under 110 lines (currently 101).

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_