### PR TITLE
v0.21.0 — multi-platform support (Codex / Cursor / Aider / Continue / generic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,20 @@
 
 ## Install
 
-In Claude Code:
+In **Claude Code**:
 
 ```
 /plugin marketplace add zhangqi444/open-forge
 /plugin install open-forge@open-forge
 ```
+
+**Other AI coding tools** — Codex (ChatGPT / CLI), Cursor, Aider, Continue.dev, or any tools-using LLM — see [`docs/platforms/`](docs/platforms/):
+
+- [Codex](docs/platforms/codex.md) — system-prompt embedding or workspace files
+- [Cursor](docs/platforms/cursor.md) — `.cursor/rules/` bundle
+- [Aider](docs/platforms/aider.md) — `--read` files + `CONVENTIONS.md`
+- [Continue.dev](docs/platforms/continue.md) — context provider + slash command
+- [Generic agents](docs/platforms/generic.md) — any LLM that can read files + run shell commands
 
 Then say what you want to deploy:
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,26 @@
+# dist/ — platform-specific distribution bundles
+
+Auto-generated bundles for AI coding tools other than Claude Code. Each subdirectory packages the open-forge skill in the format that platform expects.
+
+| Subdirectory | What's in it | Used by |
+|---|---|---|
+| `codex/` | `system-prompt.md` (full) + `system-prompt-slim.md` (lightweight) | Codex (ChatGPT custom instructions; Codex CLI workspace files) |
+| `cursor/` | `.mdc` rule files with Cursor frontmatter | Cursor's `.cursor/rules/` |
+| `aider/` | `CONVENTIONS.md` + `read-files.txt` + `.aider.conf.yml` | Aider |
+| `continue/` | `config.snippet.yaml` | Continue.dev's `~/.continue/config.yaml` |
+| `generic/` | `open-forge-bundle.md` (single-file concatenation) | Any LLM agent with tool use |
+
+## Regenerate after upstream changes
+
+The bundles are concatenations of the canonical content (`CLAUDE.md`, `plugins/open-forge/skills/open-forge/SKILL.md`, `references/modules/credentials.md`, `references/modules/feedback.md`). When those change, regenerate via:
+
+```bash
+./scripts/build-dist.sh all       # all five platforms
+./scripts/build-dist.sh codex     # just one
+```
+
+Run from the repo root.
+
+## Per-platform usage
+
+See [`docs/platforms/`](../docs/platforms/) — one guide per platform with install instructions, tool translations, limitations, and example sessions.

--- a/dist/aider/.aider.conf.yml
+++ b/dist/aider/.aider.conf.yml
@@ -1,0 +1,10 @@
+# Drop this file into your project root (or merge with existing config) to load
+# open-forge as default context for every Aider session in the project.
+
+read:
+  - /home/user/open-forge/CLAUDE.md
+  - /home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md
+  - /home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+  - /home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+
+auto-commits: false   # open-forge state files at ~/.open-forge/ shouldn't be auto-committed

--- a/dist/aider/CONVENTIONS.md
+++ b/dist/aider/CONVENTIONS.md
@@ -1,0 +1,527 @@
+# Aider conventions — open-forge skill
+
+When the user asks to self-host a service, follow the open-forge phased workflow + recipe content below.
+
+Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specific — use Aider equivalents:
+- Structured choice → ask in chat with bulleted options; user replies in terminal
+- WebFetch → /run curl <url> via Aider's shell capability, or user pastes upstream content
+- GitHub issue posting → /run gh issue create (preferred), or prefilled URL fallback
+
+State file at ~/.open-forge/deployments/<name>.yaml — Aider operates on it via filesystem ops.
+
+---
+
+---
+name: open-forge
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / Kubernetes / Fly.io / Render / Railway / Northflank / exe.dev", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game) or **Hermes-Agent** (Nous Research's self-improving AI agent at github.com/NousResearch/hermes-agent), wants to run **Ollama** (local-LLM inference server at ollama.com — pairs with every AI agent / chat UI as an OpenAI-compatible provider), wants to run **Open WebUI** (feature-rich self-hosted ChatGPT-like UI at github.com/open-webui/open-webui — pairs natively with Ollama and any OpenAI-compatible backend; adds RAG, web search, image gen, voice, multi-user), wants to run **Stable Diffusion WebUI** / **Automatic1111** / **A1111** (the most-popular open-source AI image generator at github.com/AUTOMATIC1111/stable-diffusion-webui — text-to-image, img2img, inpainting, ControlNet, LoRA; pairs with Open WebUI as an image-gen backend), wants to run **ComfyUI** (node-based AI image / video generation at github.com/comfyanonymous/ComfyUI — power-user alternative to A1111 with workflow graphs; same models, different UX; pairs with Open WebUI as image-gen backend), wants to deploy **Dify** (open-source LLMOps + AI app builder at github.com/langgenius/dify — visual workflow builder, RAG, multi-tenant; the "build a SaaS-grade AI app" platform, different category from chat UIs), wants to deploy **LibreChat** (multi-provider chat UI with deep enterprise plumbing at github.com/danny-avila/LibreChat — alternative to Open WebUI for teams; multi-user with social logins, per-user balance + transactions, agents + MCP, dedicated rag_api), wants to deploy **AnythingLLM** (RAG-focused workspace + agent platform at github.com/Mintplex-Labs/anything-llm — drop-in PDFs + URLs + GitHub repos, ask questions over them; built-in LanceDB; Desktop App + Docker + 8 cloud one-clicks), wants to install **Aider** (AI pair-programming CLI at github.com/Aider-AI/aider — runs in the terminal next to a git repo, edits files via diffs, auto-commits; pairs with any LLM provider including Ollama for local), wants to deploy **vLLM** (production-grade LLM inference server at github.com/vllm-project/vllm — high-throughput multi-tenant serving with PagedAttention + tensor parallelism + prefix caching; NVIDIA / AMD / Intel / CPU; Docker / Kubernetes / Helm / PaaS), wants to deploy **Langfuse** (open-source LLM engineering platform at github.com/langfuse/langfuse — observability, evals, prompt management, datasets, scoring; v3 six-service architecture with Postgres + ClickHouse + Redis + S3; Docker Compose, Kubernetes Helm chart, first-party Terraform modules for AWS / GCP / Azure, Railway one-click), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path documented at docs.openclaw.ai/install/* — AWS Lightsail blueprint, Docker Compose, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / macOS-VM (Lume) / BYO Linux server / localhost / Fly.io / Render / Railway / Northflank / exe.dev. More projects and infras added under `references/projects/` and `references/infra/`.
+---
+
+# open-forge
+
+## Overview
+
+Walk a user from "I have a cloud account and a domain" to "working app at `https://my.domain` with TLS and mail." Load the appropriate project recipe and infra adapter based on the user's stated intent; run phases sequentially; record state so the user can resume later.
+
+> **Platform note:** this skill is designed for Claude Code but the content is platform-agnostic. Tool names like `AskUserQuestion`, `WebFetch`, and `mcp__github__*` are Claude Code-specific — read them as *capabilities* (structured-choice prompt, URL fetch, GitHub API) and use whichever equivalent your platform exposes. See [`docs/platforms/`](../../../../docs/platforms/) in the repo for per-platform integration guides (Codex / Cursor / Aider / Continue / generic).
+
+## Operating principle
+
+**Claude does the work; the user makes the choices.** open-forge replaces the traditional "read a README, copy-paste 30 lines of bash, debug for hours" experience with a guided chat where Claude executes everything via the user's local CLI tools (aws, ssh, jq, curl) and only stops to ask when input is genuinely required.
+
+What this means in practice:
+
+- **Run, don't print.** When a recipe contains a bash block, *Claude executes it*. Announce it in one sentence first ("Opening port 22 in the Lightsail firewall now."), then run. Don't paste the block into chat for the user to run.
+- **Ask for choices and credentials only.** Things only the user can decide or provide: AWS profile name, domain choice, canonical www-vs-apex, SMTP API key, model provider preference. Everything else (which jq command to run, which sed pattern to apply, which IAM script URL to fetch) Claude figures out from the recipe.
+- **One question at a time when possible.** Use a structured-choice prompt for multiple-choice / single-select (Claude Code: `AskUserQuestion`; on other platforms, ask in prose with options listed). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
+- **Auto-install with confirmation, not silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run it. Never `sudo apt-get install` without asking.
+- **The recipe files in `references/projects/` and `references/infra/` are guidance for Claude, not pages for the user to read.** Keep that lens when extending or refactoring.
+
+## What's supported
+
+Check `references/projects/` and `references/infra/` for available recipes/adapters. As of this writing:
+
+Supported **software**:
+
+| Software | What it is |
+|---|---|
+| Ghost | Self-hosted blogging platform |
+| OpenClaw | Self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game) |
+| Hermes-Agent | Self-improving personal AI agent from Nous Research (github.com/NousResearch/hermes-agent). Native (`scripts/install.sh`), Docker, Nix, manual-dev, Termux (Android), Homebrew. Includes `hermes claw migrate` for OpenClaw users. |
+| Ollama | Local-LLM inference server (ollama.com). Foundation layer — pairs with OpenClaw / Hermes / Open WebUI / LibreChat / Aider / etc. as an OpenAI-compatible provider. Native (`install.sh` / `install.ps1` / `.dmg` / `.exe`), Docker (CPU + NVIDIA + AMD ROCm + Vulkan), Kubernetes (community Helm chart), Homebrew, Nix, Pacman. |
+| Open WebUI | Feature-rich web UI for any OpenAI-compatible LLM backend (github.com/open-webui/open-webui). Multi-user, RAG, web search, image gen, voice, MCP. Pairs naturally with Ollama. Docker (`:main` / `:cuda` / `:ollama` / `:dev` tags), docker-compose (with bundled or external Ollama), pip (Python 3.11), Kubernetes (community Helm). |
+| Stable Diffusion WebUI (A1111) | The most-popular open-source AI image generator (github.com/AUTOMATIC1111/stable-diffusion-webui). Pairs with Open WebUI as an image-gen backend. Native (`webui.sh` Linux/macOS, `webui-user.bat` Windows, `sd.webui.zip` one-click), GPU paths for NVIDIA CUDA / AMD ROCm Linux / AMD DirectML Windows fork / Apple Silicon MPS, plus community-maintained Docker images (AbdBarho recommended). |
+| ComfyUI | Node-based AI image / video generation (github.com/comfyanonymous/ComfyUI). Power-user alternative to A1111; same models, workflow-graph UX. Pairs with Open WebUI as image-gen backend. Desktop App (Windows/macOS), Windows portable 7z (NVIDIA / AMD / Intel variants), `comfy-cli`, manual install, plus broad GPU support (NVIDIA CUDA, AMD ROCm Linux + Windows nightly, Intel Arc XPU, Apple Silicon MPS) and community Docker (AbdBarho `comfy` profile, yanwk/comfyui-boot). |
+| Dify | Open-source LLMOps + AI app builder platform (github.com/langgenius/dify). Visual workflow builder, RAG with many vector-DB backends (Weaviate / Qdrant / Milvus / pgvector / Elasticsearch / OpenSearch / Couchbase / Chroma / +more), multi-tenant, plugin marketplace. Different category from chat UIs — Dify is the platform for *building* AI products. Docker Compose (canonical, ~12 services), Kubernetes via community Helm, source code, aaPanel one-click, plus cloud templates (Azure / GCP Terraform, AWS CDK for EKS/ECS, Alibaba Computing Nest). |
+| LibreChat | Multi-provider chat UI with deep enterprise plumbing (github.com/danny-avila/LibreChat). Multi-user with social logins (GitHub / Google / Discord / OIDC / SAML / Apple / Facebook), per-user balance + transactions, agents + assistants + MCP, RAG via pgvector + dedicated rag_api, web search, TTS/STT. Alternative to Open WebUI for teams. Docker Compose dev (`docker-compose.yml`), Docker Compose prod (`deploy-compose.yml` + Nginx), npm / source, **first-party Helm chart** (`helm/librechat/` v2.0.2), plus one-click deploys for Railway / Zeabur / Sealos. |
+| AnythingLLM | Open-source RAG-focused workspace + AI agent platform (github.com/Mintplex-Labs/anything-llm). Workspace-style "drop a folder of PDFs, ask questions over them" UX with built-in LanceDB vector store (or external Pinecone / Weaviate / Qdrant / Chroma / Milvus / Astra / pgvector), built-in agents, MCP support, multi-user, embeddable chat widget. Docker (canonical, `docker/HOW_TO_USE_DOCKER.md`), Desktop App (Mac / Windows / Linux installers), bare-metal source install (per `BARE_METAL.md`, "not supported by core team" — flagged), plus upstream-published one-click cloud deploys for AWS CloudFormation / GCP Cloud Run / DigitalOcean Terraform / Render / Railway / RepoCloud / Elestio / Northflank. |
+| Aider | AI pair-programming CLI (github.com/Aider-AI/aider). Different category — runs in the developer's terminal alongside their git repo, edits files via diffs, auto-commits per change. Pairs with any LLM provider (Anthropic / OpenAI / DeepSeek / Gemini / OpenRouter / Ollama / vLLM / OpenAI-compatible). `aider-install` (recommended, isolated Python 3.12 env), uv-based one-liner script (Mac / Linux / Windows), uv direct, pipx, plain pip, plus Docker (`paulgauthier/aider` + `paulgauthier/aider-full`), GitHub Codespaces, and Replit. |
+| vLLM | Production-grade LLM inference server (github.com/vllm-project/vllm). Different niche from Ollama (single-user / hobby) — vLLM is for high-throughput multi-tenant serving with PagedAttention, tensor parallelism, prefix caching. NVIDIA CUDA (canonical) + AMD ROCm + Intel XPU/Gaudi + CPU variants (x86 / ARM / Apple Silicon / s390x), Docker (`vllm/vllm-openai`), Kubernetes (raw manifests + first-party Helm chart + LeaderWorkerSet for distributed inference), plus upstream PaaS cookbooks (SkyPilot / RunPod / Modal / Cerebrium / dstack / Anyscale / Triton). |
+| Langfuse | Open-source LLM engineering platform (github.com/langfuse/langfuse). LLM observability + evaluation + prompt management + datasets + scoring; cross-cutting layer that pairs with vLLM / Ollama (inference) and Open WebUI / LibreChat / AnythingLLM / Dify / Aider (apps). v3 architecture is six services (web, worker, Postgres, ClickHouse, Redis, MinIO/S3). Docker Compose (local + single-VM), Kubernetes Helm chart (`langfuse/langfuse-k8s`, recommended for prod), first-party Terraform modules for AWS (EKS + Aurora + ElastiCache + S3 + ALB), GCP (GKE + Cloud SQL + Memorystore + GCS + LB), Azure (AKS + PG-Flex + Redis + Storage + App Gateway), plus upstream-published Railway one-click. |
+
+Supported **infras** (under `references/infra/`):
+
+| Cloud / where | Adapter |
+|---|---|
+| AWS | `aws/lightsail.md` (Ghost Bitnami + OpenClaw blueprints), `aws/ec2.md` (general-purpose VM) |
+| Azure | `azure/vm.md` (Bastion-hardened, no public IP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` (CX-line VPS via `hcloud`) |
+| DigitalOcean | `digitalocean/droplet.md` (Droplet via `doctl`) |
+| GCP Compute Engine | `gcp/compute-engine.md` (VM via `gcloud`) |
+| Oracle Cloud | `oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
+| Hostinger | `hostinger.md` (managed via hPanel — no CLI) |
+| Raspberry Pi | `raspberry-pi.md` (Pi 4/5 64-bit, ARM64) |
+| macOS VM (Apple Silicon) | `macos-vm.md` (Lume; for iMessage via BlueBubbles) |
+| Any Linux VM (other providers, on-prem) | `byo-vps.md` (SSH-only, no cloud APIs) |
+| Your own machine | `localhost.md` (Claude runs commands directly) |
+| Fly.io | `paas/fly.md` (`fly.toml` + persistent volume; public or private mode) |
+| Render | `paas/render.md` (`render.yaml` Blueprint, one-click) |
+| Railway | `paas/railway.md` (one-click template) |
+| Northflank | `paas/northflank.md` (one-click stack) |
+| exe.dev | `paas/exe-dev.md` (Shelley agent or manual nginx) |
+
+Supported **runtimes** (under `references/runtimes/`):
+
+| Runtime | Notes |
+|---|---|
+| Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
+| Podman | `podman.md` — rootless Docker-compatible alternative; Quadlet (systemd-user) supported. Reusable across every Linux/macOS infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd / Scheduled-Tasks lifecycle, reverse-proxy guidance. Covers `install.sh` (macOS / Linux / WSL2), `install-cli.sh` (local-prefix, no root), and `install.ps1` (native Windows). |
+| Kubernetes | `kubernetes.md` — kubectl + Kustomize (preferred, what openclaw upstream uses) and Helm orchestration. open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
+| Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
+
+## Selection — ask three questions
+
+Before provisioning, establish three things by asking (or inferring from the user's prompt):
+
+1. **What** to host? → loads `references/projects/<software>.md`
+2. **Where** to host? → loads `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`
+3. **How** to host? → loads the matching `references/runtimes/<runtime>.md` (skipped if the infra bundles the runtime, e.g. vendor blueprints)
+
+The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Ask a structured-choice question only when genuinely ambiguous.
+
+Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
+
+## Tier 1 vs Tier 2 routing
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for the long tail (Tier 2). When the user names a piece of software, decide which tier you're in **before** loading anything.
+
+### Tier 1 — verified recipe exists
+
+If `references/projects/<name>.md` matches the user's software, you're in Tier 1. Load it, follow it, and stay in the standard workflow below.
+
+### Tier 2 — no recipe; derive from upstream live
+
+If no recipe matches, **don't refuse — fall back to Tier 2**:
+
+1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Fetch upstream the same way Tier 1 does**:
+   - Fetch the upstream README first via the platform's URL-fetch capability (Claude Code: `WebFetch`; Cursor: `@Web`; Aider/generic: `curl` via shell). If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
+   - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
+3. **Reuse the existing modules**: drive the Docker install via `runtimes/docker.md`, Kubernetes via `runtimes/kubernetes.md`, VM provisioning via `infra/<cloud>/*.md`, DNS / TLS / SMTP via `references/modules/`. The Tier 2 work is only the software-specific bits on top.
+4. **Cite every upstream URL** in chat the same way Tier 1 sections do (`> Source: <url>`).
+5. **Offer to capture the result** as a new Tier 1 recipe once the deploy succeeds — that's how the catalogue grows. Captured recipes must go through first-run discipline before promotion.
+
+**Quality boundary:** Tier 2 output is best-effort, not authoritative. It will hallucinate at the edges of upstream docs we couldn't fetch and skips the real-deploy refinement Tier 1 recipes get. Always tell the user which tier you're in; never silently mix.
+
+### Out-of-scope software
+
+Some user requests are not deployable services at all (libraries like Unsloth or `requests`, desktop apps like Slack, SaaS like Notion). When you detect this, say so clearly and offer the closest in-scope alternative if there is one. See CLAUDE.md § *Is this software in scope?* for criteria.
+
+## Phased workflow
+
+Each phase is verifiable and resumable. Do NOT batch phases — complete, verify, and update state before moving on.
+
+```
+1. preflight     → check prerequisites (CLI tools, profiles, domain ownership); collect inputs
+2. provision     → create instance, allocate + attach static IP, retrieve SSH key
+3. dns           → print exact DNS records for user to add at registrar; poll until resolved
+4. tls           → obtain Let's Encrypt cert, fix reverse proxy, switch app URL to https
+5. smtp          → configure outbound email provider; verify a test send
+6. inbound       → (optional) set up forwarding or mailbox
+7. hardening     → rotate default admin creds, rotate any secrets pasted into chat
+```
+
+Infra adapter defines *how* to do each phase (what CLI commands to run). Project recipe defines *what's specific* about that app (config file paths, gotchas, mail block shape). Cross-cutting steps — DNS guidance, Let's Encrypt, SMTP providers, inbound forwarders — live in `references/modules/` and are loaded as needed.
+
+## State file
+
+Every deployment has a YAML state file at:
+
+```
+~/.open-forge/deployments/<name>.yaml
+```
+
+Shape:
+
+```yaml
+name: my-blog
+project: ghost
+infra: lightsail
+inputs:
+  aws_profile: qi-experiment
+  aws_region: us-east-1
+  domain: ariazhang.org
+  canonical: www  # or "apex"
+  letsencrypt_email: user@example.com
+outputs:
+  instance_name: my-blog
+  static_ip_name: my-blog-ip
+  public_ip: 54.156.69.42
+  ssh_key_path: ~/.ssh/lightsail-default.pem
+  admin_url: https://www.ariazhang.org/ghost
+phases:
+  preflight:   { status: done,  at: "2026-04-22T19:00Z" }
+  provision:   { status: done,  at: "2026-04-22T19:10Z" }
+  dns:         { status: done,  at: "2026-04-22T19:25Z" }
+  tls:         { status: done,  at: "2026-04-22T19:30Z" }
+  smtp:        { status: done,  at: "2026-04-22T20:05Z" }
+  inbound:     { status: skipped }
+  hardening:   { status: pending }
+```
+
+At the start of each session: if a state file exists for the named deployment, read it and resume from the first non-done phase. If the user says "start over", confirm destructively before unlinking.
+
+## Execution mode
+
+Default: **autonomous** — run AWS CLI, SSH, and file edits directly. Announce each external command in one sentence before running. Never fabricate outputs.
+
+Flag: **`--dry-run`** — print what would be done, do not execute. Useful for review.
+
+Commands that cross trust boundaries (paste secrets into config files, send real emails, spend money) should be announced and, when ambiguous, confirmed.
+
+## Inputs
+
+Inputs split across three layers:
+
+- **Cross-cutting (all deployments)** — handled by `references/modules/preflight.md`: AWS profile, region, deployment name, tool install confirmations.
+- **Infra-specific** — handled by the loaded infra adapter (e.g. `references/infra/lightsail.md`): bundle/blueprint choice, SSH key path defaults.
+- **Project-specific** — handled by the loaded project recipe (e.g. `references/projects/ghost.md`): domain, canonical preference, Let's Encrypt email, SMTP provider + API key, model provider, etc.
+
+Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use a structured-choice prompt where the platform supports one (Claude Code: `AskUserQuestion`; otherwise prose with options listed).
+
+## Asking for credentials
+
+Whenever the skill needs sensitive input — API keys, DB passwords, OAuth client secrets, cloud creds, SSH key paths — load `references/modules/credentials.md` and offer the **five patterns** (priority order):
+
+| # | Pattern | What user gives |
+|---|---|---|
+| 1 | Local file path | path to file containing the secret (skill `cat`s it) |
+| 2 | Env var name | name of an env var the user pre-exported (skill reads `$<NAME>`) |
+| 3 | Cloud-CLI session | "I've already run `aws sso login` for profile `<name>`" |
+| 4 | Secrets-manager ref | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` (skill calls matching CLI) |
+| 5 | Direct paste | **last resort** — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |
+
+**Never silently accept a paste.** When the skill detects sensitive input is needed, it should:
+
+1. **Offer the five patterns** with the credential class noted (e.g. *"I need a Resend API key — pick how to provide it: file path, env var, secrets-manager ref, or paste (last resort)"*).
+2. **Validate** before using:
+   - File path → `test -r <path>` + check mode is `≤ 600` (offer `chmod 600` if wider).
+   - Env var → `test -n "$<NAME>"` (refuse if empty; if user `export`ed after Claude Code started, ask them to restart).
+   - Cloud-CLI → smoke-command (e.g. `aws sts get-caller-identity --profile <name>`).
+   - Secrets-manager → smoke-command (`op read --no-newline <ref>`, `vault kv get`, etc.).
+   - Paste → require explicit risk acknowledgement first.
+3. **Detect accidental pastes**: if the user was prompted for a path but pasted a string matching `re_*` / `sk-*` / `AKIA[0-9A-Z]{16}` / etc., stop and ask: *"That looks like the key itself, not a path. Did you mean to paste directly? (see risks)"*.
+4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
+5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
+
+See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
+
+## Verification after each phase
+
+| Phase | Verify with |
+|---|---|
+| provision | `aws lightsail get-instance ... --query 'instance.state'` is `running`; SSH to `<user>@<ip>` succeeds |
+| dns | `dig +short <domain> @1.1.1.1` returns the static IP for apex AND the canonical host |
+| tls | `curl -sI https://<domain>/` returns 2xx/3xx with a valid cert; browser loads without warnings |
+| smtp | Send a test email from the app's admin UI; confirm arrival in the recipient inbox and in the provider's log |
+| inbound | Send a test email to the configured alias; confirm it lands in the destination inbox |
+
+Never mark a phase `done` without verification.
+
+## Post-deploy feedback (closes the catalogue evolution loop)
+
+After `hardening` (or after the user explicitly says "we're done", or after they abort mid-phase and want to share what they learned), offer to file a GitHub issue with the deployment notes. Per CLAUDE.md § *Issue-driven contribution model*, this is how the catalogue evolves — the bot or a future Claude session reads these issues and patches the recipes.
+
+Three flows the user can trigger from this prompt:
+
+1. **Recipe feedback** (default at end of deploy) — submit gotchas, suggested edits, or "the recipe was outdated". Claude self-summarizes from the session; the user reviews + opts in.
+2. **Software nomination** — when the user asked to deploy something not in the catalogue and Tier 2 worked, offer to nominate it for Tier 1.
+3. **Method proposal** — when the user discovered an upstream-supported install method the recipe doesn't cover.
+
+### The flow (multi-step consent — never auto-post)
+
+Load `references/modules/feedback.md` for the full sanitization rules + draft templates + submission paths. Summary:
+
+1. **Opt-in prompt**:
+   - Recipe feedback: *"Want to share what you learned with the open-forge project? I can draft a sanitized GitHub issue with the gotchas + suggested edits — you review, then post."*
+   - Software nomination (Tier 2 deploy): *"This software isn't in the Tier 1 catalogue yet. Want to nominate it? I'll draft an issue with the rationale + upstream URLs."*
+   - User must explicitly opt in (no auto-post).
+2. **Self-summarize the session**:
+   - Which recipe + combo was used, plugin version.
+   - Which phases ran, which retried, which failed.
+   - Where the user got prompted unexpectedly (gaps in the recipe).
+   - Any gotchas Claude observed (commands that failed, error messages, deviations from the documented path).
+3. **Draft the issue** in the format from `references/modules/feedback.md`:
+   - Specific recipe-edit suggestions (preferred: as a diff), not free-prose.
+   - All identifiers redacted per CLAUDE.md § *Sanitization principles*.
+4. **Show the redacted draft in chat — full text — before any submission attempt.**
+5. **Standing reminder**: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; if anything looks identifiable to you, edit before posting. By submitting, you grant a non-revocable license to use this content in the recipe; the project bears no liability for your decision to share."*
+6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
+7. **Submit via the first available path**:
+   - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
+   - Platform-native GitHub integration if available (Claude Code: `mcp__github__issue_write`; Cursor / generic: GitHub MCP server if installed).
+   - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
+
+### Sanitization is mandatory
+
+Per CLAUDE.md § *Sanitization principles* — strip every domain, IP, SSH key path, API key, AWS account ID, email address, state-file content, and anything from the user's clipboard / env vars before showing the draft. Use the patterns + replacements documented in `references/modules/feedback.md`.
+
+If you find something in the draft that you can't confidently classify as safe, **redact it** rather than ship it. The user's review pass is a safety net, not the only line of defense.
+
+### When to skip
+
+- User says "no thanks" or doesn't reply → drop it, don't pester.
+- Deploy aborted very early (before any state was created) → no useful feedback to capture; skip.
+- Tier 2 deploy that obviously wasn't in scope (e.g. user tried to "self-host" a library) → don't nominate; politely explain it's out of scope per CLAUDE.md § *Is this software in scope?*.
+
+## Common pitfalls across infras/projects
+
+- **Stale DNS**: browsers cache 301 responses with long max-age. After any HTTP↔HTTPS or apex↔www redirect change, suggest hard reload or incognito.
+- **Host key mismatch on new static IP**: the first SSH to a freshly-allocated IP needs `-o StrictHostKeyChecking=accept-new`; don't blindly blow away `~/.ssh/known_hosts` entries.
+- **Non-interactive cert tools**: some have quirky option-file or flag requirements. See the project recipe — do not assume `--unattended` works.
+- **Reverse-proxy misconfig after switching to https URL**: apps that enforce HTTPS redirects from the `url` config need `X-Forwarded-Proto` and `Host` preserved. See `references/modules/tls-letsencrypt.md`.
+
+## Adding a new project or infra
+
+A new project: add `references/projects/<name>.md` covering required services, config file paths, mail config shape, and any install/upgrade quirks. Follow the structure of the existing ghost.md.
+
+A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
+
+Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.
+
+
+---
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.

--- a/dist/aider/read-files.txt
+++ b/dist/aider/read-files.txt
@@ -1,0 +1,5 @@
+/home/user/open-forge/CLAUDE.md
+/home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md
+/home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+/home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+/home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/preflight.md

--- a/dist/codex/system-prompt-slim.md
+++ b/dist/codex/system-prompt-slim.md
@@ -1,0 +1,523 @@
+# open-forge skill (slim Codex system prompt)
+
+When the user asks to self-host a service, look up the matching recipe at:
+  https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects/<software>.md
+
+Follow the phased workflow + credential-handling patterns below. Tool names are Claude Code's; use Codex equivalents.
+
+---
+
+---
+name: open-forge
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / Kubernetes / Fly.io / Render / Railway / Northflank / exe.dev", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game) or **Hermes-Agent** (Nous Research's self-improving AI agent at github.com/NousResearch/hermes-agent), wants to run **Ollama** (local-LLM inference server at ollama.com — pairs with every AI agent / chat UI as an OpenAI-compatible provider), wants to run **Open WebUI** (feature-rich self-hosted ChatGPT-like UI at github.com/open-webui/open-webui — pairs natively with Ollama and any OpenAI-compatible backend; adds RAG, web search, image gen, voice, multi-user), wants to run **Stable Diffusion WebUI** / **Automatic1111** / **A1111** (the most-popular open-source AI image generator at github.com/AUTOMATIC1111/stable-diffusion-webui — text-to-image, img2img, inpainting, ControlNet, LoRA; pairs with Open WebUI as an image-gen backend), wants to run **ComfyUI** (node-based AI image / video generation at github.com/comfyanonymous/ComfyUI — power-user alternative to A1111 with workflow graphs; same models, different UX; pairs with Open WebUI as image-gen backend), wants to deploy **Dify** (open-source LLMOps + AI app builder at github.com/langgenius/dify — visual workflow builder, RAG, multi-tenant; the "build a SaaS-grade AI app" platform, different category from chat UIs), wants to deploy **LibreChat** (multi-provider chat UI with deep enterprise plumbing at github.com/danny-avila/LibreChat — alternative to Open WebUI for teams; multi-user with social logins, per-user balance + transactions, agents + MCP, dedicated rag_api), wants to deploy **AnythingLLM** (RAG-focused workspace + agent platform at github.com/Mintplex-Labs/anything-llm — drop-in PDFs + URLs + GitHub repos, ask questions over them; built-in LanceDB; Desktop App + Docker + 8 cloud one-clicks), wants to install **Aider** (AI pair-programming CLI at github.com/Aider-AI/aider — runs in the terminal next to a git repo, edits files via diffs, auto-commits; pairs with any LLM provider including Ollama for local), wants to deploy **vLLM** (production-grade LLM inference server at github.com/vllm-project/vllm — high-throughput multi-tenant serving with PagedAttention + tensor parallelism + prefix caching; NVIDIA / AMD / Intel / CPU; Docker / Kubernetes / Helm / PaaS), wants to deploy **Langfuse** (open-source LLM engineering platform at github.com/langfuse/langfuse — observability, evals, prompt management, datasets, scoring; v3 six-service architecture with Postgres + ClickHouse + Redis + S3; Docker Compose, Kubernetes Helm chart, first-party Terraform modules for AWS / GCP / Azure, Railway one-click), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path documented at docs.openclaw.ai/install/* — AWS Lightsail blueprint, Docker Compose, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / macOS-VM (Lume) / BYO Linux server / localhost / Fly.io / Render / Railway / Northflank / exe.dev. More projects and infras added under `references/projects/` and `references/infra/`.
+---
+
+# open-forge
+
+## Overview
+
+Walk a user from "I have a cloud account and a domain" to "working app at `https://my.domain` with TLS and mail." Load the appropriate project recipe and infra adapter based on the user's stated intent; run phases sequentially; record state so the user can resume later.
+
+> **Platform note:** this skill is designed for Claude Code but the content is platform-agnostic. Tool names like `AskUserQuestion`, `WebFetch`, and `mcp__github__*` are Claude Code-specific — read them as *capabilities* (structured-choice prompt, URL fetch, GitHub API) and use whichever equivalent your platform exposes. See [`docs/platforms/`](../../../../docs/platforms/) in the repo for per-platform integration guides (Codex / Cursor / Aider / Continue / generic).
+
+## Operating principle
+
+**Claude does the work; the user makes the choices.** open-forge replaces the traditional "read a README, copy-paste 30 lines of bash, debug for hours" experience with a guided chat where Claude executes everything via the user's local CLI tools (aws, ssh, jq, curl) and only stops to ask when input is genuinely required.
+
+What this means in practice:
+
+- **Run, don't print.** When a recipe contains a bash block, *Claude executes it*. Announce it in one sentence first ("Opening port 22 in the Lightsail firewall now."), then run. Don't paste the block into chat for the user to run.
+- **Ask for choices and credentials only.** Things only the user can decide or provide: AWS profile name, domain choice, canonical www-vs-apex, SMTP API key, model provider preference. Everything else (which jq command to run, which sed pattern to apply, which IAM script URL to fetch) Claude figures out from the recipe.
+- **One question at a time when possible.** Use a structured-choice prompt for multiple-choice / single-select (Claude Code: `AskUserQuestion`; on other platforms, ask in prose with options listed). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
+- **Auto-install with confirmation, not silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run it. Never `sudo apt-get install` without asking.
+- **The recipe files in `references/projects/` and `references/infra/` are guidance for Claude, not pages for the user to read.** Keep that lens when extending or refactoring.
+
+## What's supported
+
+Check `references/projects/` and `references/infra/` for available recipes/adapters. As of this writing:
+
+Supported **software**:
+
+| Software | What it is |
+|---|---|
+| Ghost | Self-hosted blogging platform |
+| OpenClaw | Self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game) |
+| Hermes-Agent | Self-improving personal AI agent from Nous Research (github.com/NousResearch/hermes-agent). Native (`scripts/install.sh`), Docker, Nix, manual-dev, Termux (Android), Homebrew. Includes `hermes claw migrate` for OpenClaw users. |
+| Ollama | Local-LLM inference server (ollama.com). Foundation layer — pairs with OpenClaw / Hermes / Open WebUI / LibreChat / Aider / etc. as an OpenAI-compatible provider. Native (`install.sh` / `install.ps1` / `.dmg` / `.exe`), Docker (CPU + NVIDIA + AMD ROCm + Vulkan), Kubernetes (community Helm chart), Homebrew, Nix, Pacman. |
+| Open WebUI | Feature-rich web UI for any OpenAI-compatible LLM backend (github.com/open-webui/open-webui). Multi-user, RAG, web search, image gen, voice, MCP. Pairs naturally with Ollama. Docker (`:main` / `:cuda` / `:ollama` / `:dev` tags), docker-compose (with bundled or external Ollama), pip (Python 3.11), Kubernetes (community Helm). |
+| Stable Diffusion WebUI (A1111) | The most-popular open-source AI image generator (github.com/AUTOMATIC1111/stable-diffusion-webui). Pairs with Open WebUI as an image-gen backend. Native (`webui.sh` Linux/macOS, `webui-user.bat` Windows, `sd.webui.zip` one-click), GPU paths for NVIDIA CUDA / AMD ROCm Linux / AMD DirectML Windows fork / Apple Silicon MPS, plus community-maintained Docker images (AbdBarho recommended). |
+| ComfyUI | Node-based AI image / video generation (github.com/comfyanonymous/ComfyUI). Power-user alternative to A1111; same models, workflow-graph UX. Pairs with Open WebUI as image-gen backend. Desktop App (Windows/macOS), Windows portable 7z (NVIDIA / AMD / Intel variants), `comfy-cli`, manual install, plus broad GPU support (NVIDIA CUDA, AMD ROCm Linux + Windows nightly, Intel Arc XPU, Apple Silicon MPS) and community Docker (AbdBarho `comfy` profile, yanwk/comfyui-boot). |
+| Dify | Open-source LLMOps + AI app builder platform (github.com/langgenius/dify). Visual workflow builder, RAG with many vector-DB backends (Weaviate / Qdrant / Milvus / pgvector / Elasticsearch / OpenSearch / Couchbase / Chroma / +more), multi-tenant, plugin marketplace. Different category from chat UIs — Dify is the platform for *building* AI products. Docker Compose (canonical, ~12 services), Kubernetes via community Helm, source code, aaPanel one-click, plus cloud templates (Azure / GCP Terraform, AWS CDK for EKS/ECS, Alibaba Computing Nest). |
+| LibreChat | Multi-provider chat UI with deep enterprise plumbing (github.com/danny-avila/LibreChat). Multi-user with social logins (GitHub / Google / Discord / OIDC / SAML / Apple / Facebook), per-user balance + transactions, agents + assistants + MCP, RAG via pgvector + dedicated rag_api, web search, TTS/STT. Alternative to Open WebUI for teams. Docker Compose dev (`docker-compose.yml`), Docker Compose prod (`deploy-compose.yml` + Nginx), npm / source, **first-party Helm chart** (`helm/librechat/` v2.0.2), plus one-click deploys for Railway / Zeabur / Sealos. |
+| AnythingLLM | Open-source RAG-focused workspace + AI agent platform (github.com/Mintplex-Labs/anything-llm). Workspace-style "drop a folder of PDFs, ask questions over them" UX with built-in LanceDB vector store (or external Pinecone / Weaviate / Qdrant / Chroma / Milvus / Astra / pgvector), built-in agents, MCP support, multi-user, embeddable chat widget. Docker (canonical, `docker/HOW_TO_USE_DOCKER.md`), Desktop App (Mac / Windows / Linux installers), bare-metal source install (per `BARE_METAL.md`, "not supported by core team" — flagged), plus upstream-published one-click cloud deploys for AWS CloudFormation / GCP Cloud Run / DigitalOcean Terraform / Render / Railway / RepoCloud / Elestio / Northflank. |
+| Aider | AI pair-programming CLI (github.com/Aider-AI/aider). Different category — runs in the developer's terminal alongside their git repo, edits files via diffs, auto-commits per change. Pairs with any LLM provider (Anthropic / OpenAI / DeepSeek / Gemini / OpenRouter / Ollama / vLLM / OpenAI-compatible). `aider-install` (recommended, isolated Python 3.12 env), uv-based one-liner script (Mac / Linux / Windows), uv direct, pipx, plain pip, plus Docker (`paulgauthier/aider` + `paulgauthier/aider-full`), GitHub Codespaces, and Replit. |
+| vLLM | Production-grade LLM inference server (github.com/vllm-project/vllm). Different niche from Ollama (single-user / hobby) — vLLM is for high-throughput multi-tenant serving with PagedAttention, tensor parallelism, prefix caching. NVIDIA CUDA (canonical) + AMD ROCm + Intel XPU/Gaudi + CPU variants (x86 / ARM / Apple Silicon / s390x), Docker (`vllm/vllm-openai`), Kubernetes (raw manifests + first-party Helm chart + LeaderWorkerSet for distributed inference), plus upstream PaaS cookbooks (SkyPilot / RunPod / Modal / Cerebrium / dstack / Anyscale / Triton). |
+| Langfuse | Open-source LLM engineering platform (github.com/langfuse/langfuse). LLM observability + evaluation + prompt management + datasets + scoring; cross-cutting layer that pairs with vLLM / Ollama (inference) and Open WebUI / LibreChat / AnythingLLM / Dify / Aider (apps). v3 architecture is six services (web, worker, Postgres, ClickHouse, Redis, MinIO/S3). Docker Compose (local + single-VM), Kubernetes Helm chart (`langfuse/langfuse-k8s`, recommended for prod), first-party Terraform modules for AWS (EKS + Aurora + ElastiCache + S3 + ALB), GCP (GKE + Cloud SQL + Memorystore + GCS + LB), Azure (AKS + PG-Flex + Redis + Storage + App Gateway), plus upstream-published Railway one-click. |
+
+Supported **infras** (under `references/infra/`):
+
+| Cloud / where | Adapter |
+|---|---|
+| AWS | `aws/lightsail.md` (Ghost Bitnami + OpenClaw blueprints), `aws/ec2.md` (general-purpose VM) |
+| Azure | `azure/vm.md` (Bastion-hardened, no public IP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` (CX-line VPS via `hcloud`) |
+| DigitalOcean | `digitalocean/droplet.md` (Droplet via `doctl`) |
+| GCP Compute Engine | `gcp/compute-engine.md` (VM via `gcloud`) |
+| Oracle Cloud | `oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
+| Hostinger | `hostinger.md` (managed via hPanel — no CLI) |
+| Raspberry Pi | `raspberry-pi.md` (Pi 4/5 64-bit, ARM64) |
+| macOS VM (Apple Silicon) | `macos-vm.md` (Lume; for iMessage via BlueBubbles) |
+| Any Linux VM (other providers, on-prem) | `byo-vps.md` (SSH-only, no cloud APIs) |
+| Your own machine | `localhost.md` (Claude runs commands directly) |
+| Fly.io | `paas/fly.md` (`fly.toml` + persistent volume; public or private mode) |
+| Render | `paas/render.md` (`render.yaml` Blueprint, one-click) |
+| Railway | `paas/railway.md` (one-click template) |
+| Northflank | `paas/northflank.md` (one-click stack) |
+| exe.dev | `paas/exe-dev.md` (Shelley agent or manual nginx) |
+
+Supported **runtimes** (under `references/runtimes/`):
+
+| Runtime | Notes |
+|---|---|
+| Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
+| Podman | `podman.md` — rootless Docker-compatible alternative; Quadlet (systemd-user) supported. Reusable across every Linux/macOS infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd / Scheduled-Tasks lifecycle, reverse-proxy guidance. Covers `install.sh` (macOS / Linux / WSL2), `install-cli.sh` (local-prefix, no root), and `install.ps1` (native Windows). |
+| Kubernetes | `kubernetes.md` — kubectl + Kustomize (preferred, what openclaw upstream uses) and Helm orchestration. open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
+| Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
+
+## Selection — ask three questions
+
+Before provisioning, establish three things by asking (or inferring from the user's prompt):
+
+1. **What** to host? → loads `references/projects/<software>.md`
+2. **Where** to host? → loads `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`
+3. **How** to host? → loads the matching `references/runtimes/<runtime>.md` (skipped if the infra bundles the runtime, e.g. vendor blueprints)
+
+The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Ask a structured-choice question only when genuinely ambiguous.
+
+Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
+
+## Tier 1 vs Tier 2 routing
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for the long tail (Tier 2). When the user names a piece of software, decide which tier you're in **before** loading anything.
+
+### Tier 1 — verified recipe exists
+
+If `references/projects/<name>.md` matches the user's software, you're in Tier 1. Load it, follow it, and stay in the standard workflow below.
+
+### Tier 2 — no recipe; derive from upstream live
+
+If no recipe matches, **don't refuse — fall back to Tier 2**:
+
+1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Fetch upstream the same way Tier 1 does**:
+   - Fetch the upstream README first via the platform's URL-fetch capability (Claude Code: `WebFetch`; Cursor: `@Web`; Aider/generic: `curl` via shell). If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
+   - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
+3. **Reuse the existing modules**: drive the Docker install via `runtimes/docker.md`, Kubernetes via `runtimes/kubernetes.md`, VM provisioning via `infra/<cloud>/*.md`, DNS / TLS / SMTP via `references/modules/`. The Tier 2 work is only the software-specific bits on top.
+4. **Cite every upstream URL** in chat the same way Tier 1 sections do (`> Source: <url>`).
+5. **Offer to capture the result** as a new Tier 1 recipe once the deploy succeeds — that's how the catalogue grows. Captured recipes must go through first-run discipline before promotion.
+
+**Quality boundary:** Tier 2 output is best-effort, not authoritative. It will hallucinate at the edges of upstream docs we couldn't fetch and skips the real-deploy refinement Tier 1 recipes get. Always tell the user which tier you're in; never silently mix.
+
+### Out-of-scope software
+
+Some user requests are not deployable services at all (libraries like Unsloth or `requests`, desktop apps like Slack, SaaS like Notion). When you detect this, say so clearly and offer the closest in-scope alternative if there is one. See CLAUDE.md § *Is this software in scope?* for criteria.
+
+## Phased workflow
+
+Each phase is verifiable and resumable. Do NOT batch phases — complete, verify, and update state before moving on.
+
+```
+1. preflight     → check prerequisites (CLI tools, profiles, domain ownership); collect inputs
+2. provision     → create instance, allocate + attach static IP, retrieve SSH key
+3. dns           → print exact DNS records for user to add at registrar; poll until resolved
+4. tls           → obtain Let's Encrypt cert, fix reverse proxy, switch app URL to https
+5. smtp          → configure outbound email provider; verify a test send
+6. inbound       → (optional) set up forwarding or mailbox
+7. hardening     → rotate default admin creds, rotate any secrets pasted into chat
+```
+
+Infra adapter defines *how* to do each phase (what CLI commands to run). Project recipe defines *what's specific* about that app (config file paths, gotchas, mail block shape). Cross-cutting steps — DNS guidance, Let's Encrypt, SMTP providers, inbound forwarders — live in `references/modules/` and are loaded as needed.
+
+## State file
+
+Every deployment has a YAML state file at:
+
+```
+~/.open-forge/deployments/<name>.yaml
+```
+
+Shape:
+
+```yaml
+name: my-blog
+project: ghost
+infra: lightsail
+inputs:
+  aws_profile: qi-experiment
+  aws_region: us-east-1
+  domain: ariazhang.org
+  canonical: www  # or "apex"
+  letsencrypt_email: user@example.com
+outputs:
+  instance_name: my-blog
+  static_ip_name: my-blog-ip
+  public_ip: 54.156.69.42
+  ssh_key_path: ~/.ssh/lightsail-default.pem
+  admin_url: https://www.ariazhang.org/ghost
+phases:
+  preflight:   { status: done,  at: "2026-04-22T19:00Z" }
+  provision:   { status: done,  at: "2026-04-22T19:10Z" }
+  dns:         { status: done,  at: "2026-04-22T19:25Z" }
+  tls:         { status: done,  at: "2026-04-22T19:30Z" }
+  smtp:        { status: done,  at: "2026-04-22T20:05Z" }
+  inbound:     { status: skipped }
+  hardening:   { status: pending }
+```
+
+At the start of each session: if a state file exists for the named deployment, read it and resume from the first non-done phase. If the user says "start over", confirm destructively before unlinking.
+
+## Execution mode
+
+Default: **autonomous** — run AWS CLI, SSH, and file edits directly. Announce each external command in one sentence before running. Never fabricate outputs.
+
+Flag: **`--dry-run`** — print what would be done, do not execute. Useful for review.
+
+Commands that cross trust boundaries (paste secrets into config files, send real emails, spend money) should be announced and, when ambiguous, confirmed.
+
+## Inputs
+
+Inputs split across three layers:
+
+- **Cross-cutting (all deployments)** — handled by `references/modules/preflight.md`: AWS profile, region, deployment name, tool install confirmations.
+- **Infra-specific** — handled by the loaded infra adapter (e.g. `references/infra/lightsail.md`): bundle/blueprint choice, SSH key path defaults.
+- **Project-specific** — handled by the loaded project recipe (e.g. `references/projects/ghost.md`): domain, canonical preference, Let's Encrypt email, SMTP provider + API key, model provider, etc.
+
+Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use a structured-choice prompt where the platform supports one (Claude Code: `AskUserQuestion`; otherwise prose with options listed).
+
+## Asking for credentials
+
+Whenever the skill needs sensitive input — API keys, DB passwords, OAuth client secrets, cloud creds, SSH key paths — load `references/modules/credentials.md` and offer the **five patterns** (priority order):
+
+| # | Pattern | What user gives |
+|---|---|---|
+| 1 | Local file path | path to file containing the secret (skill `cat`s it) |
+| 2 | Env var name | name of an env var the user pre-exported (skill reads `$<NAME>`) |
+| 3 | Cloud-CLI session | "I've already run `aws sso login` for profile `<name>`" |
+| 4 | Secrets-manager ref | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` (skill calls matching CLI) |
+| 5 | Direct paste | **last resort** — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |
+
+**Never silently accept a paste.** When the skill detects sensitive input is needed, it should:
+
+1. **Offer the five patterns** with the credential class noted (e.g. *"I need a Resend API key — pick how to provide it: file path, env var, secrets-manager ref, or paste (last resort)"*).
+2. **Validate** before using:
+   - File path → `test -r <path>` + check mode is `≤ 600` (offer `chmod 600` if wider).
+   - Env var → `test -n "$<NAME>"` (refuse if empty; if user `export`ed after Claude Code started, ask them to restart).
+   - Cloud-CLI → smoke-command (e.g. `aws sts get-caller-identity --profile <name>`).
+   - Secrets-manager → smoke-command (`op read --no-newline <ref>`, `vault kv get`, etc.).
+   - Paste → require explicit risk acknowledgement first.
+3. **Detect accidental pastes**: if the user was prompted for a path but pasted a string matching `re_*` / `sk-*` / `AKIA[0-9A-Z]{16}` / etc., stop and ask: *"That looks like the key itself, not a path. Did you mean to paste directly? (see risks)"*.
+4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
+5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
+
+See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
+
+## Verification after each phase
+
+| Phase | Verify with |
+|---|---|
+| provision | `aws lightsail get-instance ... --query 'instance.state'` is `running`; SSH to `<user>@<ip>` succeeds |
+| dns | `dig +short <domain> @1.1.1.1` returns the static IP for apex AND the canonical host |
+| tls | `curl -sI https://<domain>/` returns 2xx/3xx with a valid cert; browser loads without warnings |
+| smtp | Send a test email from the app's admin UI; confirm arrival in the recipient inbox and in the provider's log |
+| inbound | Send a test email to the configured alias; confirm it lands in the destination inbox |
+
+Never mark a phase `done` without verification.
+
+## Post-deploy feedback (closes the catalogue evolution loop)
+
+After `hardening` (or after the user explicitly says "we're done", or after they abort mid-phase and want to share what they learned), offer to file a GitHub issue with the deployment notes. Per CLAUDE.md § *Issue-driven contribution model*, this is how the catalogue evolves — the bot or a future Claude session reads these issues and patches the recipes.
+
+Three flows the user can trigger from this prompt:
+
+1. **Recipe feedback** (default at end of deploy) — submit gotchas, suggested edits, or "the recipe was outdated". Claude self-summarizes from the session; the user reviews + opts in.
+2. **Software nomination** — when the user asked to deploy something not in the catalogue and Tier 2 worked, offer to nominate it for Tier 1.
+3. **Method proposal** — when the user discovered an upstream-supported install method the recipe doesn't cover.
+
+### The flow (multi-step consent — never auto-post)
+
+Load `references/modules/feedback.md` for the full sanitization rules + draft templates + submission paths. Summary:
+
+1. **Opt-in prompt**:
+   - Recipe feedback: *"Want to share what you learned with the open-forge project? I can draft a sanitized GitHub issue with the gotchas + suggested edits — you review, then post."*
+   - Software nomination (Tier 2 deploy): *"This software isn't in the Tier 1 catalogue yet. Want to nominate it? I'll draft an issue with the rationale + upstream URLs."*
+   - User must explicitly opt in (no auto-post).
+2. **Self-summarize the session**:
+   - Which recipe + combo was used, plugin version.
+   - Which phases ran, which retried, which failed.
+   - Where the user got prompted unexpectedly (gaps in the recipe).
+   - Any gotchas Claude observed (commands that failed, error messages, deviations from the documented path).
+3. **Draft the issue** in the format from `references/modules/feedback.md`:
+   - Specific recipe-edit suggestions (preferred: as a diff), not free-prose.
+   - All identifiers redacted per CLAUDE.md § *Sanitization principles*.
+4. **Show the redacted draft in chat — full text — before any submission attempt.**
+5. **Standing reminder**: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; if anything looks identifiable to you, edit before posting. By submitting, you grant a non-revocable license to use this content in the recipe; the project bears no liability for your decision to share."*
+6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
+7. **Submit via the first available path**:
+   - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
+   - Platform-native GitHub integration if available (Claude Code: `mcp__github__issue_write`; Cursor / generic: GitHub MCP server if installed).
+   - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
+
+### Sanitization is mandatory
+
+Per CLAUDE.md § *Sanitization principles* — strip every domain, IP, SSH key path, API key, AWS account ID, email address, state-file content, and anything from the user's clipboard / env vars before showing the draft. Use the patterns + replacements documented in `references/modules/feedback.md`.
+
+If you find something in the draft that you can't confidently classify as safe, **redact it** rather than ship it. The user's review pass is a safety net, not the only line of defense.
+
+### When to skip
+
+- User says "no thanks" or doesn't reply → drop it, don't pester.
+- Deploy aborted very early (before any state was created) → no useful feedback to capture; skip.
+- Tier 2 deploy that obviously wasn't in scope (e.g. user tried to "self-host" a library) → don't nominate; politely explain it's out of scope per CLAUDE.md § *Is this software in scope?*.
+
+## Common pitfalls across infras/projects
+
+- **Stale DNS**: browsers cache 301 responses with long max-age. After any HTTP↔HTTPS or apex↔www redirect change, suggest hard reload or incognito.
+- **Host key mismatch on new static IP**: the first SSH to a freshly-allocated IP needs `-o StrictHostKeyChecking=accept-new`; don't blindly blow away `~/.ssh/known_hosts` entries.
+- **Non-interactive cert tools**: some have quirky option-file or flag requirements. See the project recipe — do not assume `--unattended` works.
+- **Reverse-proxy misconfig after switching to https URL**: apps that enforce HTTPS redirects from the `url` config need `X-Forwarded-Proto` and `Host` preserved. See `references/modules/tls-letsencrypt.md`.
+
+## Adding a new project or infra
+
+A new project: add `references/projects/<name>.md` covering required services, config file paths, mail config shape, and any install/upgrade quirks. Follow the structure of the existing ghost.md.
+
+A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
+
+Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.
+
+
+---
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.

--- a/dist/codex/system-prompt.md
+++ b/dist/codex/system-prompt.md
@@ -1,0 +1,1243 @@
+# open-forge skill (Codex system prompt)
+
+You are an expert at deploying self-hostable open-source apps. You operate as the open-forge skill — see the canonical content below.
+
+When the user asks to self-host a service, follow the phased workflow (preflight → provision → dns → tls → smtp → inbound → hardening → feedback) defined in SKILL.md. Look up the matching recipe in references/projects/<software>.md and the matching infra adapter in references/infra/<cloud>/<service>.md.
+
+If no recipe matches, fall back to Tier 2 (live-derived) per CLAUDE.md § Two-tier coverage model.
+
+Tool names like AskUserQuestion / WebFetch / mcp__github__* are Claude Code-specific — use Codex's equivalents (prose questions with options listed; web_search / fetch_url; gh CLI shell-out).
+
+For credential collection, follow references/modules/credentials.md — five patterns prioritized from "secret never enters chat" to "last-resort paste with risk acknowledgement."
+
+After hardening, offer the post-deploy feedback flow per references/modules/feedback.md.
+
+---
+
+# CLAUDE.md
+
+Instructions for any Claude Code session working *on* the open-forge plugin (not running it). Different audience from `plugins/open-forge/skills/open-forge/SKILL.md`, which is what an end-user's Claude reads to *use* the plugin.
+
+## What is open-forge
+
+A Claude Code plugin/skill that turns "read a README, copy-paste 30 lines of bash, debug for hours" into a guided chat where Claude executes everything via the user's local CLI tools and the user only makes choices.
+
+## Architecture — 3 layers, asked in 3 questions
+
+A deployment is a tuple of three independent axes, asked in this order:
+
+| # | Question | Layer | Examples |
+|---|---|---|---|
+| 1 | **What** to host? | software | OpenClaw, Ghost, Mastodon, Vaultwarden, Nextcloud |
+| 2 | **Where** to host? | infra (cloud or local) | AWS / Hetzner / DigitalOcean / GCP / Azure / bring-your-own-VPS / **localhost** |
+| 3 | **How** to host (within that cloud)? | infra-service + runtime | AWS: Lightsail blueprint, Lightsail Ubuntu + Docker, EC2 + native, EKS, ECS Fargate. Hetzner: Cloud CX + Docker, Cloud CX + native. localhost: Docker Desktop, native. |
+
+The third question is *dynamically generated* from (software, cloud) — different clouds expose different compute services, and some software has vendor-bundled blueprints on specific clouds.
+
+**Some infra services bundle the runtime** — EKS → Kubernetes, Lightsail OpenClaw blueprint → vendor's pre-baked install. In those cases the "runtime" question is not asked separately. **Other services give runtime choice** — EC2, plain VPS, localhost — there we ask Docker vs native vs k3s.
+
+**Reusability is the test.** "Install Docker + run docker-compose" is the same on Lightsail Ubuntu, Hetzner CX-line, a DO droplet, and a localhost — write it once in the runtime layer, reference from every project. "Install k3s" is the same across clouds — write it once. Project recipes should be 80% software-specific concerns and contain *no* per-runtime install commands beyond a one-line link.
+
+### File layout for the 3 layers
+
+```
+references/
+├── projects/<sw>.md                       # software layer (thin)
+├── infra/
+│   ├── aws/
+│   │   ├── lightsail-blueprint.md         # vendor-bundled, software-specific
+│   │   ├── lightsail-ubuntu.md            # Lightsail as a plain VM
+│   │   ├── ec2.md
+│   │   ├── eks.md
+│   │   └── ecs-fargate.md
+│   ├── hetzner/cloud-cx.md
+│   ├── digitalocean/droplet.md
+│   ├── gcp/compute-engine.md
+│   ├── byo-vps.md                         # user provides any Linux VPS, Claude SSH-es in
+│   └── localhost.md                       # user's own machine, Claude runs commands directly
+├── runtimes/
+│   ├── docker.md                          # reusable wherever Docker works
+│   ├── native.md                          # native installer (curl/apt)
+│   └── kubernetes.md                      # reusable across EKS/GKE/AKS/k3s
+└── modules/                               # cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
+```
+
+`localhost.md` is a first-class infra — for many projects (especially OpenClaw), running locally is the default upstream path. Same conversational UX as a cloud deploy; differences are: no SSH (Claude runs commands directly), no provisioning, public reach via tunnel (`references/modules/tunnels.md`).
+
+## Is this software in scope?
+
+open-forge is for **deployable self-hosted services**. Use these criteria when deciding whether a piece of software belongs as a Tier 1 recipe (see *Two-tier coverage model* below).
+
+### Inclusion criteria — recipe is in scope when ALL are true
+
+1. **Software runs as a deployed service or is served from a host the user owns**: long-running daemon, scheduled job, web service, API, CLI agent, or static asset published to a host.
+2. **Source code or binaries are user-installable on infrastructure they control**: cloud VM, VPS, k3s cluster, or localhost. Paid AMIs / vendor stacks (Bitnami, Dify Premium, etc.) count — closed-source SaaS-only does not.
+3. **At least one upstream-documented install method or canonical install artifact in-repo** exists, so the strict-doc-policy below has something to verify against.
+
+### Exclusion criteria — out of scope
+
+- **Pure libraries / SDKs / packages** that you `import` or call (Unsloth, requests, lodash). No deployment surface.
+- **Desktop / mobile end-user apps** with no self-hosted server side (Slack desktop, VS Code, Discord client).
+- **SaaS / managed-only products** with no self-host distribution (Notion, Linear, Figma).
+- **Dev-only tooling that runs ephemerally on a developer machine** and is never deployed (Storybook *dev* mode, Vite dev server, REPLs).
+
+### Edge cases — borderline classes
+
+| Class | Verdict | Recipe shape |
+|---|---|---|
+| **Static-site generators** (Hugo, Jekyll, Docusaurus, Storybook in production-preview mode) | ✅ in scope | Thin: `<sg> build` → static dir → deploy via a static-host module (nginx / S3+CDN / Pages). The SG-specific bit is build config, theme path, content tree. |
+| **CLI agents** (Aider, OpenClaw, Hermes-Agent) | ✅ in scope | Install on a host, run as daemon or interactive CLI. Standard recipe shape. |
+| **AI inference servers** (vLLM, Ollama, TGI) | ✅ in scope | Deployed services exposing HTTP APIs. Standard recipe shape. |
+| **AI training libraries** (Unsloth, axolotl, transformers) | ❌ out of scope | Libraries called from training scripts, not deployed services. If a "training environments" track ever exists, it's a separate category — not project recipes under `references/projects/`. |
+| **CI runners** (GitHub Actions self-hosted, Buildkite agent) | ✅ in scope | Long-running daemon attached to a control plane. Standard recipe shape. |
+| **Standalone databases** (Postgres, ClickHouse, Redis) | ⚠️ borderline | Useful but usually a dependency of another recipe rather than a deployment goal. Document as a supporting service inside the consuming recipe; only write a standalone recipe when there's clear demand. |
+| **Storage backends** (MinIO, SeaweedFS, Garage) | ✅ in scope | Self-hostable services with HTTP APIs. Standard recipe shape. |
+
+### When in doubt
+
+Ask: *"Would the user need open-forge to walk them through provisioning + DNS + TLS + ongoing lifecycle for this?"* If yes, write a recipe. If no (e.g. they'd just `pip install` it inside their own scripts), it's out of scope — or fall back to Tier 2 (below) for one-off requests.
+
+## Operating principles
+
+1. **Do more, ask less. Non-tech-friendly.** Default to autonomous execution. Only prompt the user for things only they can decide or provide: credentials, opinionated choices, things that touch their accounts at other companies. Hide everything Claude can figure out from the recipe.
+2. **Towards production-ready architecture.** Even single-node hobby deploys should be on a path to backups, monitoring, TLS, key rotation, OS updates, and least-privilege firewalls. Don't write recipes that "work" but leave the system one outage away from data loss.
+3. **Security in mind.** Treat tokens/keys as toxic — never log them, rotate after chat exposure, prefer fragment URLs over query strings. Default firewalls to closed; open ports explicitly. Default to SSH key auth; never password. Let's Encrypt for any public endpoint. Sandbox agent tool execution where the runtime supports it.
+4. **One question at a time.** Use `AskUserQuestion` for structured choices. Reserve free-text for credentials and identifiers (domain names, emails). No upfront questionnaires.
+5. **Auto-install with confirmation, never silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run.
+6. **Reference upstream docs; don't replace them.** Recipes condense and translate upstream documentation into Claude-actionable steps — they aren't the source of truth for the product itself. Always link the upstream pages we summarized (e.g. `docs.openclaw.ai/install/docker`, AWS Lightsail user guide, Bitnami docs). Reasons: (a) users can verify what we condensed, (b) when upstream drifts our recipe goes stale fast and the link is the recovery path, (c) credit where due. **See *Strict doc-verification policy* below — every install method documented by upstream must have its own recipe section, verified against upstream before being written.**
+7. **Don't invent — interface.** open-forge is a chat-friendly interface to existing tools. Claude is the orchestrator; the user's existing software stack (AWS CLI, Docker, openclaw, ssh, gh, registrar UIs) is the substrate. **Do not** build custom DSLs, YAML schemas, CLI tools, deployment managers, or wrappers around upstream tools. **Do not** reimplement what an upstream tool already does (e.g. don't rebuild `openclaw onboard`'s prompts in chat — call the command). The state file is a thin orchestration helper for resume, nothing more. *Caveat:* "don't invent" applies to **fabricating a deployment path the upstream doesn't support** (e.g. authoring a Helm chart for a project that has no chart). It does **not** mean "no tooling." If upstream supports Docker / k8s / Helm / Terraform, lean on every skill and MCP that helps you orchestrate those paths well — see *Companion skills & MCPs* below.
+
+## Credential handling (expanded from Operating Principle #3)
+
+Pasting raw credentials into Claude Code is risky — secrets enter session history, may be relayed via MCP servers, and could appear in shared transcripts. The skill must offer safer alternatives **first** and only fall back to direct paste with explicit risk acknowledgement.
+
+### The five patterns (priority order)
+
+| # | Pattern | When to suggest |
+|---|---|---|
+| 1 | **Local file path** — user gives skill a path; skill `cat`s it | Personal-use API keys; user already has a `.env` or `.secrets` file |
+| 2 | **Env var name** — user pre-exports the secret; skill reads `$<NAME>` | Shell users with secrets in `.envrc` / `.bashrc` |
+| 3 | **Cloud-CLI session** — user runs `<provider> login` ahead of time; skill uses the resulting profile / session | Default for AWS, GCP, Azure, GitHub, DigitalOcean, Hetzner, Cloudflare |
+| 4 | **Secrets-manager reference** — user gives skill a `op://` / `bw://` / `vault://` reference; skill calls the matching CLI just-in-time | Users with proper secret management (1Password, Bitwarden, Vault, AWS Secrets Manager, GCP Secret Manager, `pass`) |
+| 5 | **Direct chat paste** — last resort, requires risk acknowledgement | When patterns 1-4 don't apply; user explicitly opts in |
+
+### Hard rules
+
+- **Always offer the five patterns** when asking for any sensitive input. Don't silently accept a paste; don't assume Claude Code is a vault.
+- **Surface the risk** before accepting a direct paste: *"the key will live in this session's history; rotate after deploy completes."*
+- **Never accept SSH key contents.** Always ask for the key file *path* (skill uses `ssh -i <path>`); never the key material itself in chat.
+- **Validate before proceeding**: `test -r <path>` for file paths; `test -n "$<VAR>"` for env vars; smoke-command for cloud-CLI sessions and secrets-manager refs.
+- **Refuse files with permissions wider than 600**; offer to `chmod 600` first.
+- **Detect accidental pastes** (regex for `re_*`, `sk-*`, `AKIA*`, etc. in a prompt that expected a path) and stop the user before the secret commits to chat.
+- **End-of-deploy rotation reminder** if the user pasted any secret directly during the deploy: list each pasted credential + the provider's dashboard URL; recommend rotating now that the deploy is done.
+
+The full pattern catalog with skill prompt templates, per-credential-class recommendations, and failure-mode handling lives in [`plugins/open-forge/skills/open-forge/references/modules/credentials.md`](plugins/open-forge/skills/open-forge/references/modules/credentials.md).
+
+## Strict doc-verification policy (mandatory before writing any recipe)
+
+Recipes are condensations of upstream docs; condensing what we haven't read is speculation. Past failures (the v0.7.0 Helm chart claim sourced from a search snippet, the v0.6.0 OpenClaw "every blessed path" claim that was 4 of 17 because we trusted the README's enumeration) traced back to this. The policy:
+
+### Before writing or expanding any project / infra recipe
+
+1. **Read the upstream README verbatim.** Not summarized — the actual README. Note: the README is necessary but **not sufficient** — many projects' READMEs are deliberately minimal and point at a separate docs site for install methods.
+2. **Locate the upstream install-method index.** Typically:
+   - The project's docs site (`docs.PROJECT.ai`, `PROJECT.com/docs`, `PROJECT.github.io`, etc.).
+   - The repo's `docs/install/` or `website/docs/getting-started/` tree.
+   - The repo's wiki (often a separate `<repo>.wiki.git` clone).
+3. **Enumerate every method documented under that index.** Include:
+   - First-party install scripts (`install.sh`, `install.ps1`, vendor blueprints).
+   - First-party Docker / Compose / Kubernetes / Helm support.
+   - First-party package-manager support (Homebrew, Nix, Pacman, etc.).
+   - First-party PaaS templates (`fly.toml`, `render.yaml`, Railway / Zeabur / Sealos one-click buttons published by upstream).
+   - First-party cloud templates (Terraform / CDK / Computing Nest published by upstream).
+4. **Read the canonical install artifacts in the repo:** `docker-compose.yml`, `Dockerfile`, `flake.nix`, the project's primary config-file example. These often surface details the docs gloss over (service inventory, env-var matrix).
+5. **Write one section per documented method.** No merging, no skipping. Each section's first line cites the upstream URL it's derived from.
+
+### What counts as "official"
+
+| Source | Official? |
+|---|---|
+| Upstream's own README | ✅ |
+| Upstream's own docs site (linked from README) | ✅ |
+| Upstream's repo `docs/` or `website/` tree | ✅ |
+| Upstream's repo wiki | ✅ |
+| Upstream-published PaaS deploy buttons (Railway/Render/Fly/etc.) where the manifest lives in the upstream repo | ✅ |
+| Community-maintained Docker images / Helm charts when upstream ships none | ⚠️ Allowed but **must be flagged** as "community-maintained, verify source"; recipe lists multiple options (most-active first), doesn't pick a winner |
+| Anything else (third-party blogs, search snippets, my training data) | ❌ Not allowed as the basis for a section. If upstream ships no path for X, do not invent one. |
+
+### When upstream-doc fetch fails
+
+- WebFetch rate-limited / 403 / 404 → try `raw.githubusercontent.com/<org>/<repo>/<branch>/<path>` for repo content.
+- Wiki page WebFetch fails → `git clone https://github.com/<org>/<repo>.wiki.git` and read locally.
+- All fetch paths fail → **stop**. Do not write speculative content. Either: (a) ask the user to paste relevant doc text, (b) wait until access is restored, or (c) write only the sections for methods we *did* read and note in the recipe's TODO that the rest is pending verification.
+
+### Community-maintained methods — flagging requirements
+
+When a recipe documents a method upstream doesn't ship (e.g. A1111 + ComfyUI Docker, Helm charts for many projects), the section MUST:
+
+1. Open with an explicit "community-maintained" note in a blockquote.
+2. List **multiple** options when they exist (most-active first; reference upstream README's pointer if upstream lists them).
+3. Frame commands as "illustrative — verify the README at the version you pull"; never present community-chart `--set` values as authoritative.
+4. Document the gap in the recipe's TODO section: "Verify which community option is most actively maintained at first-deploy time."
+
+### Retroactive application
+
+When this policy is added (or strengthened), every existing recipe must be re-verified against its upstream docs index. If the verification surfaces a missing method, file it in that recipe's TODO, write the missing section, and bump the plugin version.
+
+### When in doubt
+
+Ask the user whether to pause for verification or accept the README's enumeration. Don't silently downgrade thoroughness.
+
+---
+
+## Two-tier coverage model
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for everything else (Tier 2). Both tiers obey the strict-doc-policy above; the difference is *when* the verification happens.
+
+### Tier 1 — verified recipes (the catalogue)
+
+The current set under `references/projects/`. Authored ahead of time, audited against upstream docs, kept current via the first-run discipline + version bumps. **Quality bar:**
+
+- Every install method has a `> **Source:** <upstream URL>` line at the top of its section.
+- Community-maintained methods open with the required ⚠️ blockquote per *Community-maintained methods — flagging requirements*.
+- Gotchas captured from real deploys; TODOs track unresolved verifications.
+- Plugin version bumped on each user-visible change.
+
+### Tier 2 — derived live from upstream docs
+
+When a user asks for software that has no Tier 1 recipe, the skill **falls back** instead of refusing:
+
+1. **Announce the fallback in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Apply the strict-doc-policy on the fly** — same rules as Tier 1:
+   - Read upstream README via `WebFetch`. If 403/404, fall back to `raw.githubusercontent.com` paths and/or `git clone` the docs repo locally.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate methods from upstream — **do not invent**. If fetches fail, stop and tell the user; never speculate to fill a gap.
+   - Read canonical install artifacts (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`).
+3. **Reuse runtime + infra + cross-cutting modules** under `references/runtimes/`, `references/infra/`, `references/modules/` for all the reusable parts (Docker install, k8s prereqs, VM provisioning, DNS, TLS, SMTP). Tier 2 is mostly *software-specific* on top of those — same shape as Tier 1, just authored at request time.
+4. **Cite every upstream URL** the same way Tier 1 does.
+5. **Offer to capture the result** as a new Tier 1 recipe when the deploy succeeds — that's how the catalogue grows. The captured recipe must still go through first-run discipline before claiming Tier 1 status.
+
+### Routing
+
+The skill checks Tier 1 first by name match against `references/projects/*.md`. If no match, fall back to Tier 2 with the announcement above. **Never silently mix tiers** — the user should always know which tier they're in, since the verification depth differs.
+
+### Quality boundary
+
+Tier 2 output is **best-effort, not authoritative.** It will hallucinate at the edges of upstream docs we couldn't fetch; it skips the iterative refinement that Tier 1 recipes get from real deploys. Tell the user this. They're trading verification depth for coverage breadth.
+
+### Tier 2 → Tier 1 graduation criteria
+
+The catalogue grows demand-driven, not by guess. Promote a Tier 2 deploy to a Tier 1 recipe when ANY of:
+
+1. **3+ feedback issues** for the same software (demand signal — see *Issue-driven contribution model*).
+2. **Same user has deployed it 3+ times** and asks for first-run discipline applied.
+3. **A Tier 2 deploy surfaced a non-obvious gotcha** that's likely to bite the next person — capture the gotcha as a recipe even if demand is small (one-shot promotion is allowed when the value is in the captured knowledge).
+4. **A maintainer chooses to deploy the software themselves** (sunk cost is acceptable).
+
+Don't author Tier 1 recipes speculatively from a "popular self-host" list — without a real demand signal, the compounding effect can't kick in and the upfront cost goes to waste.
+
+---
+
+## Issue-driven contribution model
+
+The catalogue evolves through GitHub issues, not direct human PRs. AI coding sessions (whether triggered by a maintainer running this skill, by a scheduled job, or by a webhook) read incoming issues, verify them against upstream docs per *Strict doc-verification policy*, and author patches.
+
+### Three input channels
+
+GitHub issue templates under `.github/ISSUE_TEMPLATE/` define the structured input:
+
+| Template | When to use | Filed by |
+|---|---|---|
+| `recipe-feedback.yml` | A user deployed via the skill and wants to suggest recipe edits (gotchas captured, install steps that surprised them, sections that were wrong/outdated). The skill drafts these automatically at the end of a deploy. | End user (skill-assisted) |
+| `software-nomination.yml` | A user wants software added to the Tier 1 catalogue. Must include rationale + upstream URL + the user's intended deploy combo. | End user |
+| `method-proposal.yml` | A user knows an upstream-supported install method that an existing recipe doesn't cover. Must include the upstream URL where the method is documented. | End user |
+
+A blank-issue / off-template issue is treated as a request for routing — close politely with a pointer to the templates.
+
+### Why issues, not PRs
+
+- **Sanitization happens at submission time.** The skill (or a careful manual filer) redacts identifiers before posting; the issue templates encode the structure. PRs from random users could include credentials in commit history that can't be cleanly removed.
+- **Verification happens centrally.** Every change is re-verified against upstream by the AI session that processes the issue, not trusted because someone filed a PR.
+- **Demand signal lives in the issue stream.** Issues with the most thumbs-up / cross-linking / repeat filings are the demand signal that drives Tier 2 → Tier 1 graduation.
+
+### Direct human PRs
+
+Discouraged. If a maintainer writes a PR by hand, it's still subject to the strict-doc-policy and recipe-structure rules — the issue model is the documented contribution path.
+
+---
+
+## Sanitization principles
+
+User-shared content (deployment logs, gotchas, error output) routinely contains identifiers that **must not** end up in the public repo. Both the skill (when drafting issue content) and any session reviewing user-supplied content (when accepting a PR sourced from an issue) must apply these rules.
+
+### Always strip
+
+| Class | Replace with |
+|---|---|
+| Domain names (apex / canonical / admin) | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| IP addresses (public + private + IPv6) | `${PUBLIC_IP}` / `${PRIVATE_IP}` |
+| SSH key paths and contents | `${KEY_PATH}` / `<REDACTED-SSH-KEY>` |
+| API keys and bearer tokens (regex: `re_[A-Za-z0-9_]+`, `SG\.[A-Za-z0-9._-]+`, `sk-[A-Za-z0-9]+`, `xox[bp]-[A-Za-z0-9-]+`, `ghp_[A-Za-z0-9]+`, AWS access keys `AKIA[0-9A-Z]{16}` + secret `[A-Za-z0-9/+=]{40}`, GCP service-account JSON, generic `Bearer [A-Za-z0-9._-]{20,}`) | `<REDACTED>` |
+| AWS account IDs (12 consecutive digits in AWS context) | `${AWS_ACCOUNT}` |
+| AWS profile names | `${AWS_PROFILE}` |
+| Email addresses (LE email, SMTP from-address, user identity) | `${EMAIL}` |
+| State-file contents from `~/.open-forge/deployments/<name>.yaml` | Reference the file by name only, never paste contents |
+| Hostnames embedded in URLs that include the user's domain | `https://${CANONICAL_HOST}/path` |
+| Anything from the user's clipboard / env vars they pasted into chat | `<REDACTED>` |
+
+### Multi-step consent (no auto-post, ever)
+
+The skill flow when posting feedback to GitHub:
+
+1. **Opt-in prompt** — *"Want to share what you learned?"* User must explicitly opt in.
+2. **Show the redacted draft in chat** — full text, before any submission attempt.
+3. **Confirm post?** — explicit "yes" required.
+4. **If user edits the draft**, re-show + re-confirm before submitting.
+5. **Standing reminder text** in the prompt: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; edit if anything looks identifiable."*
+6. **Liability notice in the issue body**: *"Submitter grants a non-revocable license to use this content in the open-forge recipe; the project bears no liability for the submitter's choice to share."*
+
+### When reviewing PRs sourced from issues
+
+Issue-processing sessions must re-scan PR diffs against the same strip-list before merging. If any identifier slipped through, redact in the PR before merge — never merge content with live identifiers.
+
+---
+
+## Processing incoming issues
+
+When an AI coding session is asked to process incoming issues (whether by a maintainer prompt, a scheduled job, or a webhook), apply this workflow:
+
+### 1. Triage
+
+For each open issue without an `applied` / `out-of-scope` / `needs-info` label:
+
+- Identify the template type from the issue body's structured fields. If the issue doesn't follow a template, comment with a pointer to the templates and label `needs-info`.
+- Validate that the issue is in scope per *Is this software in scope?*. Out-of-scope → comment + `out-of-scope` label + close.
+- Otherwise, label `triaged` and proceed to validation.
+
+### 2. Validate against upstream
+
+Apply *Strict doc-verification policy* to every change:
+
+- For `recipe-feedback`: re-fetch the recipe's cited upstream URLs; verify the user's proposed change is consistent with current upstream content. If upstream has drifted in a way that conflicts with the user's report, prefer upstream and explain the discrepancy in the PR.
+- For `software-nomination`: confirm the software passes inclusion criteria; locate upstream's install-method index; do **not** start authoring a recipe until the index is reachable.
+- For `method-proposal`: confirm the cited upstream URL documents the method; if it's community-maintained, it must be flagged per *Community-maintained methods — flagging requirements*.
+
+If validation fails (upstream URL 404s, software is out of scope, methodology is unverifiable), comment on the issue explaining + label `needs-info` or `out-of-scope` as appropriate. Do not author a patch.
+
+### 3. Author the patch
+
+- Apply the change per *Recipe structure (must-have sections)*.
+- Cite the upstream URL at the top of every section per *Strict doc-verification policy*.
+- Flag community-maintained methods with the required ⚠️ blockquote.
+- Re-scan against the *Sanitization principles* strip-list — if any identifier slipped through user-supplied content, redact before drafting.
+- Bump `plugin.json` `version` per *Versioning + publish flow*.
+- If multiple feedback issues for the same recipe are pending, batch them into a single PR.
+
+### 4. Open the PR
+
+- **Branch naming**: `bot/issue-<N>-<short-slug>` (where `<N>` is the originating issue number).
+- **Commit author**: `Qi Zhang <zhangqi444@gmail.com>` per *Author convention*.
+- **PR body** must cite (a) the originating issue number(s), (b) every upstream URL re-verified, (c) the version bump rationale.
+- After opening, label the issue `in-progress`. After merge, relabel `applied`.
+
+### 5. State-machine via labels
+
+| Label | Meaning |
+|---|---|
+| (none) | New issue, not yet triaged |
+| `triaged` | Identified template type + scope-checked; ready to validate |
+| `in-progress` | A PR is open against this issue |
+| `applied` | PR merged; issue resolved |
+| `needs-info` | Author needs to provide more before processing can continue |
+| `out-of-scope` | Software / request doesn't meet inclusion criteria; closed |
+
+Optionally also: `recipe:<name>`, `tier:1`, `tier:2`, `infra:<cloud>`, `runtime:<runtime>` for filtering.
+
+### 6. Conflicts and ambiguity
+
+- **Contradicting suggestions across issues**: prefer upstream-doc-verified content; cite the upstream URL in the PR explaining which suggestion was chosen and why.
+- **Ambiguous suggestion**: if the issue is unclear about what should change, comment asking for clarification with a deadline (e.g. *"reply within 14 days or this issue will be auto-closed"*) and label `needs-info`.
+- **Idempotency**: never re-process an issue already labeled `applied`. If the same recipe issue resurfaces under a new issue number, treat it as a fresh demand signal (counts toward Tier 2 → Tier 1 graduation per *Two-tier coverage model*).
+
+---
+
+## Companion skills & MCPs
+
+open-forge orchestrates *upstream-blessed* deployment paths. To do that well, recipes are encouraged to depend on companion skills/MCPs as soft dependencies — declared in prose, not enforced. The filter is one question:
+
+> Does this tool help me **drive** an upstream-supported deploy path more reliably?
+
+| Shape | Stance | Examples |
+|---|---|---|
+| **Operators** — read state, query docs, drive existing CLIs more accurately | ✅ Embrace | `awsdocs` MCP, `gcp-docs` MCP, `cloudflare` MCP, GitHub MCP (fetch upstream `docker-compose.yml` / `charts/`), k8s state-query MCPs |
+| **Generators** — author config from scratch | ❌ Avoid by default | `dockerfile-generator`, `k8s-yaml-generator`, `helm-generator`, `terraform-generator`. Only justified when upstream genuinely ships nothing and we deliberately wrap. |
+| **Plain CLIs** | ✅ Default substrate | `docker`, `kubectl`, `helm`, `aws`, `gcloud`, `az`, `gh`, `ssh`, `terraform` |
+
+How to reference companion tooling — **fallback hierarchy**, in order of preference:
+
+1. **Companion skill/MCP**, if available. Name it in SKILL.md / recipe body in prose: *"If the k8s state MCP is available, use it to confirm pod readiness; otherwise parse `kubectl get pods -o json`."* Claude uses it when present, falls back gracefully when not.
+2. **Captured docs in `references/`**, if no skill/MCP exists. Distill the relevant upstream pages (Helm chart values, k8s CRD schema, AWS CLI flags for the specific service) into a focused reference under `references/modules/<topic>.md` or alongside the recipe. Cite the upstream URL as the source of truth — captured docs are a lossy snapshot, the link is the recovery path (principle #6).
+3. **Inline upstream-doc links** as a last resort, when even capture is overkill — let Claude WebFetch them on demand.
+
+Where to declare companion tooling:
+
+- **In recipe frontmatter**, optionally list `companion-skills:` / `companion-mcps:` as documentation (not enforced — no formal deps mechanism in plugin manifests yet).
+- **In `plugins/open-forge/.mcp.json`**, register MCPs the recipes depend on heavily so they install transparently with the plugin. Reserve this for read-only docs/state MCPs; never wrap deployment commands.
+- **For dev work on open-forge itself** (CI, settings audit, plugin packaging): use whatever skills help your local workflow (`gh-fix-ci`, `claude-settings-audit`) — these don't need to ship with the plugin.
+
+When a recipe is exercised end-to-end and a companion skill/MCP proved necessary — or a captured doc was added to `references/` — record it in the recipe's *Compatible runtimes* or a new *Companion tooling* note alongside upstream doc links. Same first-run discipline applies.
+
+## Recipe structure (must-have sections)
+
+Every `references/projects/<software>.md` should have:
+
+| Section | Purpose |
+|---|---|
+| **Frontmatter** (name + description) | Loaded into context whenever the skill triggers. Keep concise; this is for Claude, not the user. |
+| **Inputs to collect** (table keyed by phase) | Exact prompts, structured-choice options, defaults. So the same recipe is consistent across runs. |
+| **Compatible runtimes** | Which runtime modules this software supports + recommended default |
+| **Phase applicability** | Which of preflight/provision/dns/tls/smtp/inbound/hardening apply or skip |
+| **Per-phase content** | Project-specific commands, config patches, verification checks |
+| **Gotchas (consolidated)** | One-line summaries of every non-obvious thing learned in production. Single source of truth. |
+| **TODO — verify on subsequent deployments** | Open questions to resolve on the next real deploy. Empty = recipe is fully validated. |
+
+`references/runtimes/<name>.md` and `references/infra/<name>.md` mirror this with their own scope (no `Inputs to collect` for infra usually — preflight handles AWS profile/region; infra adds bundle/region-specific bits).
+
+## First-run discipline
+
+When a recipe is exercised end-to-end against a real deployment for the first time:
+
+1. Capture every gotcha that surprised us into the recipe's *Gotchas* section.
+2. Resolve / delete TODO items as they're answered.
+3. Update the deployment state file's phase notes.
+4. Bump `plugin.json` `version` (see *Versioning* below).
+5. Commit.
+
+This is how the recipe stops being a guess and becomes a known-working deployment template. Don't skip it.
+
+The dominant path for first-run discipline is now **user-submitted feedback issues** processed per *Processing incoming issues* — the skill drafts a sanitized issue at the end of each deploy and the user opts in to share. Maintainer-driven deploys (where the maintainer is also the recipe author) still apply for new recipes. Either way, the same five-step capture applies.
+
+## File layout
+
+```
+open-forge/
+├── CLAUDE.md                              ← you are reading
+├── README.md                              ← user-facing, lives on GitHub
+├── LICENSE                                ← MIT
+├── .claude-plugin/marketplace.json        ← marketplace manifest
+└── plugins/open-forge/
+    ├── .claude-plugin/plugin.json         ← plugin manifest (version!)
+    └── skills/open-forge/
+        ├── SKILL.md                       ← end-user-Claude entrypoint
+        ├── references/
+        │   ├── projects/<name>.md         ← software layer
+        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
+        │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
+        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
+        └── scripts/                       ← reused operational scripts; empty by default
+```
+
+`scripts/` stays empty unless something is reused 3+ times across deployments. Inline commands in recipes are clearer for one-off use.
+
+## Versioning + publish flow
+
+`plugin.json` `version` controls what the Claude Code marketplace fetches.
+
+- **Bump on**: skill description change, new project/runtime/infra, major recipe rewrite, anything that changes user-visible behavior.
+- **Don't bump on**: typo fixes, internal comment cleanups, lint-only changes.
+
+Publish flow (typical path: AI session processing an issue per *Issue-driven contribution model*):
+
+1. Commit the change with version bump if applicable. Author per *Author convention*.
+2. Push to `github.com/zhangqi444/open-forge` — typically as a PR opened against `main` (branch name per *Processing incoming issues*).
+3. After merge, end users run `/plugin marketplace update zhangqi444/open-forge` then re-install.
+
+Maintainer manual edits follow the same flow but skip the issue-tracking labels.
+
+## Author convention
+
+Commits authored as `Qi Zhang <zhangqi444@gmail.com>` — set inline via env vars (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`), **don't write to git config**.
+
+## Refactor (started 2026-04-24, completed 2026-04-26)
+
+Initial state collapsed three axes into linear "Path A/B/C" inside `openclaw.md`, which hid valid combos and biased preflight toward AWS even for non-AWS deployments. Migrated to the 3-layer file layout above. Order:
+
+1. ✅ CLAUDE.md model locked in (this section).
+2. ✅ Preflight refactor — branch on infra choice; only require AWS CLI when infra ∈ AWS.
+3. ✅ Skeleton infra adapters: `infra/aws/lightsail.md` (Bitnami + OpenClaw blueprints share this; the blueprint-vs-Ubuntu split is a project-recipe concern, not a separate adapter), `infra/aws/ec2.md`, `infra/azure/vm.md`, `infra/hetzner/cloud-cx.md`, `infra/digitalocean/droplet.md`, `infra/gcp/compute-engine.md`, `infra/oracle/free-tier-arm.md`, `infra/hostinger.md`, `infra/raspberry-pi.md`, `infra/macos-vm.md`, `infra/byo-vps.md`, `infra/localhost.md`, plus a PaaS family under `infra/paas/`: `fly.md`, `render.md`, `railway.md`, `northflank.md`, `exe-dev.md`.
+4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/podman.md`, `runtimes/native.md`, `runtimes/kubernetes.md`. Docker + native extracted from openclaw.md Paths B and C; kubernetes added when openclaw upstream's Kustomize-based path was wired in; podman added in v0.8.0.
+5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else. v0.8.0: corrected the Kubernetes section to be Kustomize-first (matches upstream `scripts/k8s/deploy.sh`); added Podman, ClawDock, Ansible, Nix, and Bun (experimental) sections; combo table now enumerates every upstream-blessed install method documented under `docs.openclaw.ai/install/*`.
+6. ✅ Add `modules/tunnels.md` for localhost public-reach (Cloudflare Tunnel / Tailscale / ngrok).
+7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.8.0).
+
+Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here. Cluster-provisioning adapters (EKS / GKE / AKS / DOKS) are intentionally not in scope — open-forge orchestrates an existing cluster; users own cluster create/delete in their cloud's k8s UI. Cloud-VM adapters and PaaS adapters added in v0.8.0 are documented from upstream docs only — none has been exercised end-to-end yet; first-run discipline (CLAUDE.md § *First-run discipline*) applies as those deployments happen.
+
+## Behavioral guidelines (echoes of bota CLAUDE.md, kept here for autonomy)
+
+- **Think before coding.** State assumptions; ask when uncertain; surface tradeoffs.
+- **Simplicity first.** Minimum recipe content that works; no speculative abstractions.
+- **Surgical changes.** When updating a recipe after a deploy, change only what the deploy taught us. Don't "improve" adjacent sections.
+- **Goal-driven execution.** A recipe edit is "done" when the next deploy can use it without manual fixes.
+- **Documentation updates** (the recipes themselves) are a deliverable of every deployment, not a follow-up.
+
+
+---
+
+---
+name: open-forge
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / Kubernetes / Fly.io / Render / Railway / Northflank / exe.dev", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game) or **Hermes-Agent** (Nous Research's self-improving AI agent at github.com/NousResearch/hermes-agent), wants to run **Ollama** (local-LLM inference server at ollama.com — pairs with every AI agent / chat UI as an OpenAI-compatible provider), wants to run **Open WebUI** (feature-rich self-hosted ChatGPT-like UI at github.com/open-webui/open-webui — pairs natively with Ollama and any OpenAI-compatible backend; adds RAG, web search, image gen, voice, multi-user), wants to run **Stable Diffusion WebUI** / **Automatic1111** / **A1111** (the most-popular open-source AI image generator at github.com/AUTOMATIC1111/stable-diffusion-webui — text-to-image, img2img, inpainting, ControlNet, LoRA; pairs with Open WebUI as an image-gen backend), wants to run **ComfyUI** (node-based AI image / video generation at github.com/comfyanonymous/ComfyUI — power-user alternative to A1111 with workflow graphs; same models, different UX; pairs with Open WebUI as image-gen backend), wants to deploy **Dify** (open-source LLMOps + AI app builder at github.com/langgenius/dify — visual workflow builder, RAG, multi-tenant; the "build a SaaS-grade AI app" platform, different category from chat UIs), wants to deploy **LibreChat** (multi-provider chat UI with deep enterprise plumbing at github.com/danny-avila/LibreChat — alternative to Open WebUI for teams; multi-user with social logins, per-user balance + transactions, agents + MCP, dedicated rag_api), wants to deploy **AnythingLLM** (RAG-focused workspace + agent platform at github.com/Mintplex-Labs/anything-llm — drop-in PDFs + URLs + GitHub repos, ask questions over them; built-in LanceDB; Desktop App + Docker + 8 cloud one-clicks), wants to install **Aider** (AI pair-programming CLI at github.com/Aider-AI/aider — runs in the terminal next to a git repo, edits files via diffs, auto-commits; pairs with any LLM provider including Ollama for local), wants to deploy **vLLM** (production-grade LLM inference server at github.com/vllm-project/vllm — high-throughput multi-tenant serving with PagedAttention + tensor parallelism + prefix caching; NVIDIA / AMD / Intel / CPU; Docker / Kubernetes / Helm / PaaS), wants to deploy **Langfuse** (open-source LLM engineering platform at github.com/langfuse/langfuse — observability, evals, prompt management, datasets, scoring; v3 six-service architecture with Postgres + ClickHouse + Redis + S3; Docker Compose, Kubernetes Helm chart, first-party Terraform modules for AWS / GCP / Azure, Railway one-click), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path documented at docs.openclaw.ai/install/* — AWS Lightsail blueprint, Docker Compose, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / macOS-VM (Lume) / BYO Linux server / localhost / Fly.io / Render / Railway / Northflank / exe.dev. More projects and infras added under `references/projects/` and `references/infra/`.
+---
+
+# open-forge
+
+## Overview
+
+Walk a user from "I have a cloud account and a domain" to "working app at `https://my.domain` with TLS and mail." Load the appropriate project recipe and infra adapter based on the user's stated intent; run phases sequentially; record state so the user can resume later.
+
+> **Platform note:** this skill is designed for Claude Code but the content is platform-agnostic. Tool names like `AskUserQuestion`, `WebFetch`, and `mcp__github__*` are Claude Code-specific — read them as *capabilities* (structured-choice prompt, URL fetch, GitHub API) and use whichever equivalent your platform exposes. See [`docs/platforms/`](../../../../docs/platforms/) in the repo for per-platform integration guides (Codex / Cursor / Aider / Continue / generic).
+
+## Operating principle
+
+**Claude does the work; the user makes the choices.** open-forge replaces the traditional "read a README, copy-paste 30 lines of bash, debug for hours" experience with a guided chat where Claude executes everything via the user's local CLI tools (aws, ssh, jq, curl) and only stops to ask when input is genuinely required.
+
+What this means in practice:
+
+- **Run, don't print.** When a recipe contains a bash block, *Claude executes it*. Announce it in one sentence first ("Opening port 22 in the Lightsail firewall now."), then run. Don't paste the block into chat for the user to run.
+- **Ask for choices and credentials only.** Things only the user can decide or provide: AWS profile name, domain choice, canonical www-vs-apex, SMTP API key, model provider preference. Everything else (which jq command to run, which sed pattern to apply, which IAM script URL to fetch) Claude figures out from the recipe.
+- **One question at a time when possible.** Use a structured-choice prompt for multiple-choice / single-select (Claude Code: `AskUserQuestion`; on other platforms, ask in prose with options listed). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
+- **Auto-install with confirmation, not silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run it. Never `sudo apt-get install` without asking.
+- **The recipe files in `references/projects/` and `references/infra/` are guidance for Claude, not pages for the user to read.** Keep that lens when extending or refactoring.
+
+## What's supported
+
+Check `references/projects/` and `references/infra/` for available recipes/adapters. As of this writing:
+
+Supported **software**:
+
+| Software | What it is |
+|---|---|
+| Ghost | Self-hosted blogging platform |
+| OpenClaw | Self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game) |
+| Hermes-Agent | Self-improving personal AI agent from Nous Research (github.com/NousResearch/hermes-agent). Native (`scripts/install.sh`), Docker, Nix, manual-dev, Termux (Android), Homebrew. Includes `hermes claw migrate` for OpenClaw users. |
+| Ollama | Local-LLM inference server (ollama.com). Foundation layer — pairs with OpenClaw / Hermes / Open WebUI / LibreChat / Aider / etc. as an OpenAI-compatible provider. Native (`install.sh` / `install.ps1` / `.dmg` / `.exe`), Docker (CPU + NVIDIA + AMD ROCm + Vulkan), Kubernetes (community Helm chart), Homebrew, Nix, Pacman. |
+| Open WebUI | Feature-rich web UI for any OpenAI-compatible LLM backend (github.com/open-webui/open-webui). Multi-user, RAG, web search, image gen, voice, MCP. Pairs naturally with Ollama. Docker (`:main` / `:cuda` / `:ollama` / `:dev` tags), docker-compose (with bundled or external Ollama), pip (Python 3.11), Kubernetes (community Helm). |
+| Stable Diffusion WebUI (A1111) | The most-popular open-source AI image generator (github.com/AUTOMATIC1111/stable-diffusion-webui). Pairs with Open WebUI as an image-gen backend. Native (`webui.sh` Linux/macOS, `webui-user.bat` Windows, `sd.webui.zip` one-click), GPU paths for NVIDIA CUDA / AMD ROCm Linux / AMD DirectML Windows fork / Apple Silicon MPS, plus community-maintained Docker images (AbdBarho recommended). |
+| ComfyUI | Node-based AI image / video generation (github.com/comfyanonymous/ComfyUI). Power-user alternative to A1111; same models, workflow-graph UX. Pairs with Open WebUI as image-gen backend. Desktop App (Windows/macOS), Windows portable 7z (NVIDIA / AMD / Intel variants), `comfy-cli`, manual install, plus broad GPU support (NVIDIA CUDA, AMD ROCm Linux + Windows nightly, Intel Arc XPU, Apple Silicon MPS) and community Docker (AbdBarho `comfy` profile, yanwk/comfyui-boot). |
+| Dify | Open-source LLMOps + AI app builder platform (github.com/langgenius/dify). Visual workflow builder, RAG with many vector-DB backends (Weaviate / Qdrant / Milvus / pgvector / Elasticsearch / OpenSearch / Couchbase / Chroma / +more), multi-tenant, plugin marketplace. Different category from chat UIs — Dify is the platform for *building* AI products. Docker Compose (canonical, ~12 services), Kubernetes via community Helm, source code, aaPanel one-click, plus cloud templates (Azure / GCP Terraform, AWS CDK for EKS/ECS, Alibaba Computing Nest). |
+| LibreChat | Multi-provider chat UI with deep enterprise plumbing (github.com/danny-avila/LibreChat). Multi-user with social logins (GitHub / Google / Discord / OIDC / SAML / Apple / Facebook), per-user balance + transactions, agents + assistants + MCP, RAG via pgvector + dedicated rag_api, web search, TTS/STT. Alternative to Open WebUI for teams. Docker Compose dev (`docker-compose.yml`), Docker Compose prod (`deploy-compose.yml` + Nginx), npm / source, **first-party Helm chart** (`helm/librechat/` v2.0.2), plus one-click deploys for Railway / Zeabur / Sealos. |
+| AnythingLLM | Open-source RAG-focused workspace + AI agent platform (github.com/Mintplex-Labs/anything-llm). Workspace-style "drop a folder of PDFs, ask questions over them" UX with built-in LanceDB vector store (or external Pinecone / Weaviate / Qdrant / Chroma / Milvus / Astra / pgvector), built-in agents, MCP support, multi-user, embeddable chat widget. Docker (canonical, `docker/HOW_TO_USE_DOCKER.md`), Desktop App (Mac / Windows / Linux installers), bare-metal source install (per `BARE_METAL.md`, "not supported by core team" — flagged), plus upstream-published one-click cloud deploys for AWS CloudFormation / GCP Cloud Run / DigitalOcean Terraform / Render / Railway / RepoCloud / Elestio / Northflank. |
+| Aider | AI pair-programming CLI (github.com/Aider-AI/aider). Different category — runs in the developer's terminal alongside their git repo, edits files via diffs, auto-commits per change. Pairs with any LLM provider (Anthropic / OpenAI / DeepSeek / Gemini / OpenRouter / Ollama / vLLM / OpenAI-compatible). `aider-install` (recommended, isolated Python 3.12 env), uv-based one-liner script (Mac / Linux / Windows), uv direct, pipx, plain pip, plus Docker (`paulgauthier/aider` + `paulgauthier/aider-full`), GitHub Codespaces, and Replit. |
+| vLLM | Production-grade LLM inference server (github.com/vllm-project/vllm). Different niche from Ollama (single-user / hobby) — vLLM is for high-throughput multi-tenant serving with PagedAttention, tensor parallelism, prefix caching. NVIDIA CUDA (canonical) + AMD ROCm + Intel XPU/Gaudi + CPU variants (x86 / ARM / Apple Silicon / s390x), Docker (`vllm/vllm-openai`), Kubernetes (raw manifests + first-party Helm chart + LeaderWorkerSet for distributed inference), plus upstream PaaS cookbooks (SkyPilot / RunPod / Modal / Cerebrium / dstack / Anyscale / Triton). |
+| Langfuse | Open-source LLM engineering platform (github.com/langfuse/langfuse). LLM observability + evaluation + prompt management + datasets + scoring; cross-cutting layer that pairs with vLLM / Ollama (inference) and Open WebUI / LibreChat / AnythingLLM / Dify / Aider (apps). v3 architecture is six services (web, worker, Postgres, ClickHouse, Redis, MinIO/S3). Docker Compose (local + single-VM), Kubernetes Helm chart (`langfuse/langfuse-k8s`, recommended for prod), first-party Terraform modules for AWS (EKS + Aurora + ElastiCache + S3 + ALB), GCP (GKE + Cloud SQL + Memorystore + GCS + LB), Azure (AKS + PG-Flex + Redis + Storage + App Gateway), plus upstream-published Railway one-click. |
+
+Supported **infras** (under `references/infra/`):
+
+| Cloud / where | Adapter |
+|---|---|
+| AWS | `aws/lightsail.md` (Ghost Bitnami + OpenClaw blueprints), `aws/ec2.md` (general-purpose VM) |
+| Azure | `azure/vm.md` (Bastion-hardened, no public IP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` (CX-line VPS via `hcloud`) |
+| DigitalOcean | `digitalocean/droplet.md` (Droplet via `doctl`) |
+| GCP Compute Engine | `gcp/compute-engine.md` (VM via `gcloud`) |
+| Oracle Cloud | `oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
+| Hostinger | `hostinger.md` (managed via hPanel — no CLI) |
+| Raspberry Pi | `raspberry-pi.md` (Pi 4/5 64-bit, ARM64) |
+| macOS VM (Apple Silicon) | `macos-vm.md` (Lume; for iMessage via BlueBubbles) |
+| Any Linux VM (other providers, on-prem) | `byo-vps.md` (SSH-only, no cloud APIs) |
+| Your own machine | `localhost.md` (Claude runs commands directly) |
+| Fly.io | `paas/fly.md` (`fly.toml` + persistent volume; public or private mode) |
+| Render | `paas/render.md` (`render.yaml` Blueprint, one-click) |
+| Railway | `paas/railway.md` (one-click template) |
+| Northflank | `paas/northflank.md` (one-click stack) |
+| exe.dev | `paas/exe-dev.md` (Shelley agent or manual nginx) |
+
+Supported **runtimes** (under `references/runtimes/`):
+
+| Runtime | Notes |
+|---|---|
+| Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
+| Podman | `podman.md` — rootless Docker-compatible alternative; Quadlet (systemd-user) supported. Reusable across every Linux/macOS infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd / Scheduled-Tasks lifecycle, reverse-proxy guidance. Covers `install.sh` (macOS / Linux / WSL2), `install-cli.sh` (local-prefix, no root), and `install.ps1` (native Windows). |
+| Kubernetes | `kubernetes.md` — kubectl + Kustomize (preferred, what openclaw upstream uses) and Helm orchestration. open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
+| Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
+
+## Selection — ask three questions
+
+Before provisioning, establish three things by asking (or inferring from the user's prompt):
+
+1. **What** to host? → loads `references/projects/<software>.md`
+2. **Where** to host? → loads `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`
+3. **How** to host? → loads the matching `references/runtimes/<runtime>.md` (skipped if the infra bundles the runtime, e.g. vendor blueprints)
+
+The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Ask a structured-choice question only when genuinely ambiguous.
+
+Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
+
+## Tier 1 vs Tier 2 routing
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for the long tail (Tier 2). When the user names a piece of software, decide which tier you're in **before** loading anything.
+
+### Tier 1 — verified recipe exists
+
+If `references/projects/<name>.md` matches the user's software, you're in Tier 1. Load it, follow it, and stay in the standard workflow below.
+
+### Tier 2 — no recipe; derive from upstream live
+
+If no recipe matches, **don't refuse — fall back to Tier 2**:
+
+1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Fetch upstream the same way Tier 1 does**:
+   - Fetch the upstream README first via the platform's URL-fetch capability (Claude Code: `WebFetch`; Cursor: `@Web`; Aider/generic: `curl` via shell). If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
+   - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
+3. **Reuse the existing modules**: drive the Docker install via `runtimes/docker.md`, Kubernetes via `runtimes/kubernetes.md`, VM provisioning via `infra/<cloud>/*.md`, DNS / TLS / SMTP via `references/modules/`. The Tier 2 work is only the software-specific bits on top.
+4. **Cite every upstream URL** in chat the same way Tier 1 sections do (`> Source: <url>`).
+5. **Offer to capture the result** as a new Tier 1 recipe once the deploy succeeds — that's how the catalogue grows. Captured recipes must go through first-run discipline before promotion.
+
+**Quality boundary:** Tier 2 output is best-effort, not authoritative. It will hallucinate at the edges of upstream docs we couldn't fetch and skips the real-deploy refinement Tier 1 recipes get. Always tell the user which tier you're in; never silently mix.
+
+### Out-of-scope software
+
+Some user requests are not deployable services at all (libraries like Unsloth or `requests`, desktop apps like Slack, SaaS like Notion). When you detect this, say so clearly and offer the closest in-scope alternative if there is one. See CLAUDE.md § *Is this software in scope?* for criteria.
+
+## Phased workflow
+
+Each phase is verifiable and resumable. Do NOT batch phases — complete, verify, and update state before moving on.
+
+```
+1. preflight     → check prerequisites (CLI tools, profiles, domain ownership); collect inputs
+2. provision     → create instance, allocate + attach static IP, retrieve SSH key
+3. dns           → print exact DNS records for user to add at registrar; poll until resolved
+4. tls           → obtain Let's Encrypt cert, fix reverse proxy, switch app URL to https
+5. smtp          → configure outbound email provider; verify a test send
+6. inbound       → (optional) set up forwarding or mailbox
+7. hardening     → rotate default admin creds, rotate any secrets pasted into chat
+```
+
+Infra adapter defines *how* to do each phase (what CLI commands to run). Project recipe defines *what's specific* about that app (config file paths, gotchas, mail block shape). Cross-cutting steps — DNS guidance, Let's Encrypt, SMTP providers, inbound forwarders — live in `references/modules/` and are loaded as needed.
+
+## State file
+
+Every deployment has a YAML state file at:
+
+```
+~/.open-forge/deployments/<name>.yaml
+```
+
+Shape:
+
+```yaml
+name: my-blog
+project: ghost
+infra: lightsail
+inputs:
+  aws_profile: qi-experiment
+  aws_region: us-east-1
+  domain: ariazhang.org
+  canonical: www  # or "apex"
+  letsencrypt_email: user@example.com
+outputs:
+  instance_name: my-blog
+  static_ip_name: my-blog-ip
+  public_ip: 54.156.69.42
+  ssh_key_path: ~/.ssh/lightsail-default.pem
+  admin_url: https://www.ariazhang.org/ghost
+phases:
+  preflight:   { status: done,  at: "2026-04-22T19:00Z" }
+  provision:   { status: done,  at: "2026-04-22T19:10Z" }
+  dns:         { status: done,  at: "2026-04-22T19:25Z" }
+  tls:         { status: done,  at: "2026-04-22T19:30Z" }
+  smtp:        { status: done,  at: "2026-04-22T20:05Z" }
+  inbound:     { status: skipped }
+  hardening:   { status: pending }
+```
+
+At the start of each session: if a state file exists for the named deployment, read it and resume from the first non-done phase. If the user says "start over", confirm destructively before unlinking.
+
+## Execution mode
+
+Default: **autonomous** — run AWS CLI, SSH, and file edits directly. Announce each external command in one sentence before running. Never fabricate outputs.
+
+Flag: **`--dry-run`** — print what would be done, do not execute. Useful for review.
+
+Commands that cross trust boundaries (paste secrets into config files, send real emails, spend money) should be announced and, when ambiguous, confirmed.
+
+## Inputs
+
+Inputs split across three layers:
+
+- **Cross-cutting (all deployments)** — handled by `references/modules/preflight.md`: AWS profile, region, deployment name, tool install confirmations.
+- **Infra-specific** — handled by the loaded infra adapter (e.g. `references/infra/lightsail.md`): bundle/blueprint choice, SSH key path defaults.
+- **Project-specific** — handled by the loaded project recipe (e.g. `references/projects/ghost.md`): domain, canonical preference, Let's Encrypt email, SMTP provider + API key, model provider, etc.
+
+Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use a structured-choice prompt where the platform supports one (Claude Code: `AskUserQuestion`; otherwise prose with options listed).
+
+## Asking for credentials
+
+Whenever the skill needs sensitive input — API keys, DB passwords, OAuth client secrets, cloud creds, SSH key paths — load `references/modules/credentials.md` and offer the **five patterns** (priority order):
+
+| # | Pattern | What user gives |
+|---|---|---|
+| 1 | Local file path | path to file containing the secret (skill `cat`s it) |
+| 2 | Env var name | name of an env var the user pre-exported (skill reads `$<NAME>`) |
+| 3 | Cloud-CLI session | "I've already run `aws sso login` for profile `<name>`" |
+| 4 | Secrets-manager ref | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` (skill calls matching CLI) |
+| 5 | Direct paste | **last resort** — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |
+
+**Never silently accept a paste.** When the skill detects sensitive input is needed, it should:
+
+1. **Offer the five patterns** with the credential class noted (e.g. *"I need a Resend API key — pick how to provide it: file path, env var, secrets-manager ref, or paste (last resort)"*).
+2. **Validate** before using:
+   - File path → `test -r <path>` + check mode is `≤ 600` (offer `chmod 600` if wider).
+   - Env var → `test -n "$<NAME>"` (refuse if empty; if user `export`ed after Claude Code started, ask them to restart).
+   - Cloud-CLI → smoke-command (e.g. `aws sts get-caller-identity --profile <name>`).
+   - Secrets-manager → smoke-command (`op read --no-newline <ref>`, `vault kv get`, etc.).
+   - Paste → require explicit risk acknowledgement first.
+3. **Detect accidental pastes**: if the user was prompted for a path but pasted a string matching `re_*` / `sk-*` / `AKIA[0-9A-Z]{16}` / etc., stop and ask: *"That looks like the key itself, not a path. Did you mean to paste directly? (see risks)"*.
+4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
+5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
+
+See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
+
+## Verification after each phase
+
+| Phase | Verify with |
+|---|---|
+| provision | `aws lightsail get-instance ... --query 'instance.state'` is `running`; SSH to `<user>@<ip>` succeeds |
+| dns | `dig +short <domain> @1.1.1.1` returns the static IP for apex AND the canonical host |
+| tls | `curl -sI https://<domain>/` returns 2xx/3xx with a valid cert; browser loads without warnings |
+| smtp | Send a test email from the app's admin UI; confirm arrival in the recipient inbox and in the provider's log |
+| inbound | Send a test email to the configured alias; confirm it lands in the destination inbox |
+
+Never mark a phase `done` without verification.
+
+## Post-deploy feedback (closes the catalogue evolution loop)
+
+After `hardening` (or after the user explicitly says "we're done", or after they abort mid-phase and want to share what they learned), offer to file a GitHub issue with the deployment notes. Per CLAUDE.md § *Issue-driven contribution model*, this is how the catalogue evolves — the bot or a future Claude session reads these issues and patches the recipes.
+
+Three flows the user can trigger from this prompt:
+
+1. **Recipe feedback** (default at end of deploy) — submit gotchas, suggested edits, or "the recipe was outdated". Claude self-summarizes from the session; the user reviews + opts in.
+2. **Software nomination** — when the user asked to deploy something not in the catalogue and Tier 2 worked, offer to nominate it for Tier 1.
+3. **Method proposal** — when the user discovered an upstream-supported install method the recipe doesn't cover.
+
+### The flow (multi-step consent — never auto-post)
+
+Load `references/modules/feedback.md` for the full sanitization rules + draft templates + submission paths. Summary:
+
+1. **Opt-in prompt**:
+   - Recipe feedback: *"Want to share what you learned with the open-forge project? I can draft a sanitized GitHub issue with the gotchas + suggested edits — you review, then post."*
+   - Software nomination (Tier 2 deploy): *"This software isn't in the Tier 1 catalogue yet. Want to nominate it? I'll draft an issue with the rationale + upstream URLs."*
+   - User must explicitly opt in (no auto-post).
+2. **Self-summarize the session**:
+   - Which recipe + combo was used, plugin version.
+   - Which phases ran, which retried, which failed.
+   - Where the user got prompted unexpectedly (gaps in the recipe).
+   - Any gotchas Claude observed (commands that failed, error messages, deviations from the documented path).
+3. **Draft the issue** in the format from `references/modules/feedback.md`:
+   - Specific recipe-edit suggestions (preferred: as a diff), not free-prose.
+   - All identifiers redacted per CLAUDE.md § *Sanitization principles*.
+4. **Show the redacted draft in chat — full text — before any submission attempt.**
+5. **Standing reminder**: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; if anything looks identifiable to you, edit before posting. By submitting, you grant a non-revocable license to use this content in the recipe; the project bears no liability for your decision to share."*
+6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
+7. **Submit via the first available path**:
+   - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
+   - Platform-native GitHub integration if available (Claude Code: `mcp__github__issue_write`; Cursor / generic: GitHub MCP server if installed).
+   - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
+
+### Sanitization is mandatory
+
+Per CLAUDE.md § *Sanitization principles* — strip every domain, IP, SSH key path, API key, AWS account ID, email address, state-file content, and anything from the user's clipboard / env vars before showing the draft. Use the patterns + replacements documented in `references/modules/feedback.md`.
+
+If you find something in the draft that you can't confidently classify as safe, **redact it** rather than ship it. The user's review pass is a safety net, not the only line of defense.
+
+### When to skip
+
+- User says "no thanks" or doesn't reply → drop it, don't pester.
+- Deploy aborted very early (before any state was created) → no useful feedback to capture; skip.
+- Tier 2 deploy that obviously wasn't in scope (e.g. user tried to "self-host" a library) → don't nominate; politely explain it's out of scope per CLAUDE.md § *Is this software in scope?*.
+
+## Common pitfalls across infras/projects
+
+- **Stale DNS**: browsers cache 301 responses with long max-age. After any HTTP↔HTTPS or apex↔www redirect change, suggest hard reload or incognito.
+- **Host key mismatch on new static IP**: the first SSH to a freshly-allocated IP needs `-o StrictHostKeyChecking=accept-new`; don't blindly blow away `~/.ssh/known_hosts` entries.
+- **Non-interactive cert tools**: some have quirky option-file or flag requirements. See the project recipe — do not assume `--unattended` works.
+- **Reverse-proxy misconfig after switching to https URL**: apps that enforce HTTPS redirects from the `url` config need `X-Forwarded-Proto` and `Host` preserved. See `references/modules/tls-letsencrypt.md`.
+
+## Adding a new project or infra
+
+A new project: add `references/projects/<name>.md` covering required services, config file paths, mail config shape, and any install/upgrade quirks. Follow the structure of the existing ghost.md.
+
+A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
+
+Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.
+
+
+---
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.
+
+
+---
+
+---
+name: feedback
+description: Post-deploy feedback module — sanitization rules + draft templates + submission paths for the three GitHub-issue input channels (recipe-feedback / software-nomination / method-proposal). Loaded by SKILL.md § Post-deploy feedback.
+---
+
+# Feedback module — drafting + submitting GitHub issues
+
+This module is loaded after a deploy completes (or is abandoned) when the user opts in to share what they learned. Implements the multi-step consent flow described in CLAUDE.md § *Sanitization principles* and SKILL.md § *Post-deploy feedback*.
+
+**Hard rule:** never post without showing the redacted draft + getting explicit "yes" from the user. The skill is the user's submitter; consent gates everything.
+
+---
+
+## Sanitization checklist
+
+Apply BEFORE drafting. Scan the deployment session — including chat transcript, any tool outputs Claude has in context, any state-file references — and replace identifiers per the table.
+
+### Strip-list (regex patterns + replacements)
+
+| Class | Detection | Replacement |
+|---|---|---|
+| **Domains** (apex, www, admin) | Anything matching the user's `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` collected during inputs, plus generic FQDNs in URL paths the user typed | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| **Public IPv4** | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (excluding RFC-1918 ranges if you want to allow them as `${PRIVATE_IP}`) | `${PUBLIC_IP}` |
+| **Private IPv4** | `\b(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)[0-9.]+\b` | `${PRIVATE_IP}` (or strip if it leaks network topology) |
+| **IPv6** | Standard IPv6 patterns | `${PUBLIC_IPV6}` / `${PRIVATE_IPV6}` |
+| **SSH key paths** | Anything matching `~/.ssh/[^ ]+`, `/home/[^/]+/\.ssh/[^ ]+`, `*.pem`, `*.priv`, `id_(rsa|ed25519|ecdsa)` | `${KEY_PATH}` |
+| **SSH key contents** | `-----BEGIN [A-Z ]+ KEY-----` blocks | `<REDACTED-SSH-KEY>` |
+| **Resend API key** | `re_[A-Za-z0-9_]+` | `<REDACTED-RESEND-KEY>` |
+| **SendGrid API key** | `SG\.[A-Za-z0-9._-]+` | `<REDACTED-SENDGRID-KEY>` |
+| **OpenAI API key** | `sk-[A-Za-z0-9]{20,}` | `<REDACTED-OPENAI-KEY>` |
+| **Anthropic API key** | `sk-ant-[A-Za-z0-9_-]{20,}` | `<REDACTED-ANTHROPIC-KEY>` |
+| **Slack tokens** | `xox[bp]-[A-Za-z0-9-]+` | `<REDACTED-SLACK-TOKEN>` |
+| **GitHub PAT** | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]+` | `<REDACTED-GH-PAT>` |
+| **AWS access key ID** | `AKIA[0-9A-Z]{16}` | `<REDACTED-AWS-KEY>` |
+| **AWS secret key** | After `aws_secret_access_key`, 40-char base64 | `<REDACTED-AWS-SECRET>` |
+| **AWS account ID** | 12 consecutive digits in AWS context (ARN, account-id field) | `${AWS_ACCOUNT}` |
+| **AWS profile name** | Whatever the user collected as `aws_profile` during inputs | `${AWS_PROFILE}` |
+| **GCP service-account JSON** | `"type": "service_account"` blocks | `<REDACTED-GCP-SA>` |
+| **Generic Bearer token** | `Bearer [A-Za-z0-9._~+/=-]{20,}` | `<REDACTED-BEARER>` |
+| **Email addresses** | RFC-822 pattern; especially the LE email + SMTP from-address + any user identity email | `${EMAIL}` |
+| **State-file contents** | Anything from `~/.open-forge/deployments/<name>.yaml` raw | Reference by deployment name only, never paste contents |
+| **MySQL/Postgres password** | After `password=` / `--password ` / `IDENTIFIED BY ` | `<REDACTED-DB-PASSWORD>` |
+| **OAuth client secrets** | After `client_secret` / `CLIENT_SECRET` | `<REDACTED-CLIENT-SECRET>` |
+| **Random bytes from `openssl rand -hex N`** that the user generated as a secret | Long hex strings used as secrets | `<REDACTED-RANDOM-SECRET>` |
+
+### Manual review pass (after regex)
+
+After regex-based sanitization, do a final read-through looking for:
+
+- **Hostnames in URL paths** that contain the user's domain (sed/regex may have missed embedded URLs).
+- **Username conventions** that are personally identifiable (e.g. `qi-experiment` as an AWS profile).
+- **Stack-trace lines** containing absolute filesystem paths (`/home/<user>/...`).
+- **Anything pasted from the user's clipboard or env vars** that wasn't covered by the strip-list.
+
+If you can't confidently classify something as safe, **redact it** — the user's final review is a safety net, not the only line of defense.
+
+### What you may keep
+
+| Class | OK to keep | Why |
+|---|---|---|
+| Recipe filenames (`ghost.md`, `openclaw.md`) | ✅ | Public; needed for context |
+| Plugin version (`0.20.0`) | ✅ | Public; needed for triage |
+| Combo names (`Ghost-CLI on Ubuntu`, `DigitalOcean droplet`) | ✅ | Public; needed for context |
+| Generic error messages quoted from upstream tools | ⚠️ | OK if no identifiers; redact paths and IPs from stack traces |
+| `${VAR}` placeholders | ✅ | These are the redactions; they're fine |
+| Public repo URLs (upstream docs you're proposing to add) | ✅ | Public |
+
+---
+
+## Draft templates
+
+Each template renders into the matching `.github/ISSUE_TEMPLATE/*.yml` form. The structure mirrors the form fields so the user pastes the body and the form auto-validates the sanitization checkboxes.
+
+### Channel 1 — recipe feedback (default at end of deploy)
+
+```markdown
+**Recipe**: <recipe-filename>
+**Combo**: <infra adapter> / <runtime>
+**Plugin version**: <version-from-plugin.json>
+**Outcome**: <one-of: Deploy succeeded with notes / Deploy succeeded after retries / Deploy failed; recovered manually / Deploy failed; abandoned / Recipe was outdated>
+
+## What the recipe missed
+
+<Concrete description: what surprised you, what failed, what required manual intervention. Sanitized.>
+
+## Suggested edit (optional — diff format preferred)
+
+```diff
+@@ <section header from the recipe> @@
+- <line that was wrong / missing>
++ <line that should be there>
+```
+
+## Sanitization confirmation
+- [x] All domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses stripped from this issue body.
+- [x] I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+```
+
+### Channel 2 — software nomination (Tier 2 → Tier 1)
+
+```markdown
+**Software name**: <project>
+**Upstream repo**: <github URL>
+**Upstream install-method index**: <docs / repo path / wiki URL>
+**Intended deploy combo**: <infra> / <runtime>
+
+## Why Tier 1?
+
+<What's painful about this software's install that compounds across deploys?
+Per the demand-driven graduation criteria in CLAUDE.md, a Tier 1 recipe earns
+its keep when the captured tribal knowledge saves the next user real pain.>
+
+## In-scope check (per CLAUDE.md § Is this software in scope?)
+
+This software is: <one-of: deployable service / static-site generator / AI inference server / CI runner / storage backend / not sure>
+
+## Confirmation
+- [x] I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+- [x] This software has at least one upstream-documented install method or canonical install artifact in-repo.
+```
+
+### Channel 3 — method proposal
+
+```markdown
+**Recipe to extend**: <recipe-filename>
+**Method name**: <e.g. "Snap package", "Helm chart">
+**Upstream URL documenting this method**: <URL>
+**Source type**: <First-party — published by upstream / Community-maintained>
+
+## Canonical install command(s)
+
+```bash
+<paste verbatim from upstream>
+```
+
+## Why this method matters
+
+<When would a user pick this method over the existing options in the recipe?>
+
+## Confirmation
+- [x] I have verified the upstream URL above shows this install method on the current upstream version.
+- [x] No credentials, IPs, or other identifiers in this issue.
+```
+
+---
+
+## Submission paths (try in order)
+
+The skill never opens a browser silently or POSTs without explicit user confirmation. Three submission paths in priority order:
+
+### 1. `gh` CLI (preferred when available)
+
+```bash
+# Check if gh is authenticated for the right account
+gh auth status
+
+# If yes, submit
+gh issue create \
+  --repo zhangqi444/open-forge \
+  --title "<title from template>" \
+  --body-file /tmp/feedback-draft.md \
+  --label recipe-feedback,recipe:<name>
+```
+
+Strengths: works headlessly in chat; respects user's existing GitHub auth.
+
+Caveats: user must have `gh` installed + authenticated. If `gh auth status` errors, fall through to path 2.
+
+### 2. GitHub MCP server (if available)
+
+If `mcp__github__issue_write` is available in the tool list, use it:
+
+```
+mcp__github__issue_write({
+  method: "create",
+  owner: "zhangqi444",
+  repo: "open-forge",
+  title: "<title>",
+  body: "<full body>",
+  labels: ["recipe-feedback", "recipe:<name>"]
+})
+```
+
+Strengths: no `gh` install needed; uses the MCP server's auth.
+
+Caveats: only works if the MCP server is configured with appropriate scopes.
+
+### 3. Prefilled URL (always-available fallback)
+
+When neither `gh` nor the GitHub MCP works, generate a URL the user opens in a browser:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=<URL-encoded-title>&body=<URL-encoded-body>
+```
+
+Print the URL in chat with the instruction:
+
+> *"I can't post for you in this environment. Open this URL in a browser, review one more time, and click Submit:*
+>
+> *<URL>*
+>
+> *The form has the same sanitization checkboxes from the template — they'll be checked based on what you've already confirmed in chat."*
+
+URL-encode the title + body. GitHub URL length limit is ~8 KB total; if the body is longer, truncate the body and put the rest in a `<details>` block (or warn the user to paste it manually).
+
+---
+
+## Liability + license boilerplate (paste at end of every issue body)
+
+Append this exact block as the final paragraph of every issue body before submission:
+
+```markdown
+---
+
+> By submitting this issue, I grant a non-revocable license to the open-forge project to use this content in recipes and documentation. The open-forge project bears no liability for my choice to share. I have reviewed the issue body for credentials and personal information per CLAUDE.md § *Sanitization principles*.
+```
+
+This is in addition to the checkboxes in the issue-template form — it's an extra paper trail in the issue body itself.
+
+---
+
+## When the deploy aborted before completion
+
+If the user wants to file feedback about a deploy that failed mid-phase (e.g. preflight passed, provisioning failed at the security-group step), the `Outcome` field should be *"Deploy failed; abandoned"* and the body should include:
+
+- Which phase failed.
+- What the error was (sanitized — strip stack traces of paths/IPs).
+- What workaround the user attempted (if any).
+- Whether the user wants the recipe edited to handle this case, or whether they think it was an upstream / cloud-account issue (out of recipe scope).
+
+These are often the highest-value feedback issues — they catch recipes that succeed in the maintainer's environment but fail in others.
+
+---
+
+## Failure modes to watch for
+
+- **User says "post it" too quickly.** Respect their consent, but flag any line you weren't 100% sure about: *"Posting now. One last thing — line 14 mentions a username `qi-experiment` that might be your AWS profile name. Was that intentional?"*
+- **Drafts that quote upstream error messages with embedded user data.** Common with Bitnami's `bncert-tool` output, AWS CLI errors quoting account IDs in ARNs.
+- **State-file leaks.** If the user asks Claude to read `~/.open-forge/deployments/<name>.yaml` while drafting, do **not** paste contents — reference by deployment name only.
+- **Multiple rapid yes-clicks.** If the user says "yes, yes, yes, post" to skip the review, slow down: re-show the draft once, get confirmation, then submit. Speed is not a user safety feature.

--- a/dist/continue/config.snippet.yaml
+++ b/dist/continue/config.snippet.yaml
@@ -1,0 +1,26 @@
+# Add to ~/.continue/config.yaml. Merge into existing top-level keys.
+
+contextProviders:
+  - name: file
+    params:
+      baseDir: /home/user/open-forge/plugins/open-forge/skills/open-forge
+
+prompts:
+  - name: self-host
+    description: "Deploy a self-hostable app via open-forge recipes"
+    systemMessage: |
+      You are the open-forge skill. When the user asks to self-host a service,
+      look up the matching recipe at /home/user/open-forge/plugins/open-forge/skills/open-forge/references/projects/<software>.md and
+      follow the phased workflow defined in /home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md.
+
+      Apply credential-handling patterns from references/modules/credentials.md
+      (five patterns; paste is last-resort).
+
+      Tool names like AskUserQuestion / WebFetch / mcp__github__* are Claude
+      Code-specific — use Continue equivalents (prose with options listed,
+      @Web context provider, gh CLI via terminal).
+
+slashCommands:
+  - name: deploy
+    description: "Self-host an open-source app via open-forge"
+    prompt: "self-host"

--- a/dist/cursor/00-skill-slim.mdc
+++ b/dist/cursor/00-skill-slim.mdc
@@ -1,0 +1,15 @@
+---
+description: open-forge skill (slim) — self-host open-source apps; full content at github.com/zhangqi444/open-forge
+alwaysApply: true
+---
+
+When the user asks to self-host a service, follow the open-forge phased workflow:
+preflight → provision → dns → tls → smtp → inbound → hardening → feedback.
+
+Look up the matching recipe at github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects/<software>.md.
+
+Apply credential-handling patterns from references/modules/credentials.md (five patterns; paste is last-resort).
+
+After hardening, offer the post-deploy feedback flow per references/modules/feedback.md.
+
+Tool names in the canonical content (AskUserQuestion, WebFetch, mcp__github__*) are Claude Code-specific — use Cursor equivalents (prose prompts with options; @Web; gh CLI via terminal tool).

--- a/dist/cursor/00-skill.mdc
+++ b/dist/cursor/00-skill.mdc
@@ -1,0 +1,294 @@
+---
+description: open-forge skill — self-host any open-source app on your own infrastructure
+alwaysApply: true
+---
+
+---
+name: open-forge
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / Kubernetes / Fly.io / Render / Railway / Northflank / exe.dev", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game) or **Hermes-Agent** (Nous Research's self-improving AI agent at github.com/NousResearch/hermes-agent), wants to run **Ollama** (local-LLM inference server at ollama.com — pairs with every AI agent / chat UI as an OpenAI-compatible provider), wants to run **Open WebUI** (feature-rich self-hosted ChatGPT-like UI at github.com/open-webui/open-webui — pairs natively with Ollama and any OpenAI-compatible backend; adds RAG, web search, image gen, voice, multi-user), wants to run **Stable Diffusion WebUI** / **Automatic1111** / **A1111** (the most-popular open-source AI image generator at github.com/AUTOMATIC1111/stable-diffusion-webui — text-to-image, img2img, inpainting, ControlNet, LoRA; pairs with Open WebUI as an image-gen backend), wants to run **ComfyUI** (node-based AI image / video generation at github.com/comfyanonymous/ComfyUI — power-user alternative to A1111 with workflow graphs; same models, different UX; pairs with Open WebUI as image-gen backend), wants to deploy **Dify** (open-source LLMOps + AI app builder at github.com/langgenius/dify — visual workflow builder, RAG, multi-tenant; the "build a SaaS-grade AI app" platform, different category from chat UIs), wants to deploy **LibreChat** (multi-provider chat UI with deep enterprise plumbing at github.com/danny-avila/LibreChat — alternative to Open WebUI for teams; multi-user with social logins, per-user balance + transactions, agents + MCP, dedicated rag_api), wants to deploy **AnythingLLM** (RAG-focused workspace + agent platform at github.com/Mintplex-Labs/anything-llm — drop-in PDFs + URLs + GitHub repos, ask questions over them; built-in LanceDB; Desktop App + Docker + 8 cloud one-clicks), wants to install **Aider** (AI pair-programming CLI at github.com/Aider-AI/aider — runs in the terminal next to a git repo, edits files via diffs, auto-commits; pairs with any LLM provider including Ollama for local), wants to deploy **vLLM** (production-grade LLM inference server at github.com/vllm-project/vllm — high-throughput multi-tenant serving with PagedAttention + tensor parallelism + prefix caching; NVIDIA / AMD / Intel / CPU; Docker / Kubernetes / Helm / PaaS), wants to deploy **Langfuse** (open-source LLM engineering platform at github.com/langfuse/langfuse — observability, evals, prompt management, datasets, scoring; v3 six-service architecture with Postgres + ClickHouse + Redis + S3; Docker Compose, Kubernetes Helm chart, first-party Terraform modules for AWS / GCP / Azure, Railway one-click), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path documented at docs.openclaw.ai/install/* — AWS Lightsail blueprint, Docker Compose, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / macOS-VM (Lume) / BYO Linux server / localhost / Fly.io / Render / Railway / Northflank / exe.dev. More projects and infras added under `references/projects/` and `references/infra/`.
+---
+
+# open-forge
+
+## Overview
+
+Walk a user from "I have a cloud account and a domain" to "working app at `https://my.domain` with TLS and mail." Load the appropriate project recipe and infra adapter based on the user's stated intent; run phases sequentially; record state so the user can resume later.
+
+> **Platform note:** this skill is designed for Claude Code but the content is platform-agnostic. Tool names like `AskUserQuestion`, `WebFetch`, and `mcp__github__*` are Claude Code-specific — read them as *capabilities* (structured-choice prompt, URL fetch, GitHub API) and use whichever equivalent your platform exposes. See [`docs/platforms/`](../../../../docs/platforms/) in the repo for per-platform integration guides (Codex / Cursor / Aider / Continue / generic).
+
+## Operating principle
+
+**Claude does the work; the user makes the choices.** open-forge replaces the traditional "read a README, copy-paste 30 lines of bash, debug for hours" experience with a guided chat where Claude executes everything via the user's local CLI tools (aws, ssh, jq, curl) and only stops to ask when input is genuinely required.
+
+What this means in practice:
+
+- **Run, don't print.** When a recipe contains a bash block, *Claude executes it*. Announce it in one sentence first ("Opening port 22 in the Lightsail firewall now."), then run. Don't paste the block into chat for the user to run.
+- **Ask for choices and credentials only.** Things only the user can decide or provide: AWS profile name, domain choice, canonical www-vs-apex, SMTP API key, model provider preference. Everything else (which jq command to run, which sed pattern to apply, which IAM script URL to fetch) Claude figures out from the recipe.
+- **One question at a time when possible.** Use a structured-choice prompt for multiple-choice / single-select (Claude Code: `AskUserQuestion`; on other platforms, ask in prose with options listed). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
+- **Auto-install with confirmation, not silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run it. Never `sudo apt-get install` without asking.
+- **The recipe files in `references/projects/` and `references/infra/` are guidance for Claude, not pages for the user to read.** Keep that lens when extending or refactoring.
+
+## What's supported
+
+Check `references/projects/` and `references/infra/` for available recipes/adapters. As of this writing:
+
+Supported **software**:
+
+| Software | What it is |
+|---|---|
+| Ghost | Self-hosted blogging platform |
+| OpenClaw | Self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game) |
+| Hermes-Agent | Self-improving personal AI agent from Nous Research (github.com/NousResearch/hermes-agent). Native (`scripts/install.sh`), Docker, Nix, manual-dev, Termux (Android), Homebrew. Includes `hermes claw migrate` for OpenClaw users. |
+| Ollama | Local-LLM inference server (ollama.com). Foundation layer — pairs with OpenClaw / Hermes / Open WebUI / LibreChat / Aider / etc. as an OpenAI-compatible provider. Native (`install.sh` / `install.ps1` / `.dmg` / `.exe`), Docker (CPU + NVIDIA + AMD ROCm + Vulkan), Kubernetes (community Helm chart), Homebrew, Nix, Pacman. |
+| Open WebUI | Feature-rich web UI for any OpenAI-compatible LLM backend (github.com/open-webui/open-webui). Multi-user, RAG, web search, image gen, voice, MCP. Pairs naturally with Ollama. Docker (`:main` / `:cuda` / `:ollama` / `:dev` tags), docker-compose (with bundled or external Ollama), pip (Python 3.11), Kubernetes (community Helm). |
+| Stable Diffusion WebUI (A1111) | The most-popular open-source AI image generator (github.com/AUTOMATIC1111/stable-diffusion-webui). Pairs with Open WebUI as an image-gen backend. Native (`webui.sh` Linux/macOS, `webui-user.bat` Windows, `sd.webui.zip` one-click), GPU paths for NVIDIA CUDA / AMD ROCm Linux / AMD DirectML Windows fork / Apple Silicon MPS, plus community-maintained Docker images (AbdBarho recommended). |
+| ComfyUI | Node-based AI image / video generation (github.com/comfyanonymous/ComfyUI). Power-user alternative to A1111; same models, workflow-graph UX. Pairs with Open WebUI as image-gen backend. Desktop App (Windows/macOS), Windows portable 7z (NVIDIA / AMD / Intel variants), `comfy-cli`, manual install, plus broad GPU support (NVIDIA CUDA, AMD ROCm Linux + Windows nightly, Intel Arc XPU, Apple Silicon MPS) and community Docker (AbdBarho `comfy` profile, yanwk/comfyui-boot). |
+| Dify | Open-source LLMOps + AI app builder platform (github.com/langgenius/dify). Visual workflow builder, RAG with many vector-DB backends (Weaviate / Qdrant / Milvus / pgvector / Elasticsearch / OpenSearch / Couchbase / Chroma / +more), multi-tenant, plugin marketplace. Different category from chat UIs — Dify is the platform for *building* AI products. Docker Compose (canonical, ~12 services), Kubernetes via community Helm, source code, aaPanel one-click, plus cloud templates (Azure / GCP Terraform, AWS CDK for EKS/ECS, Alibaba Computing Nest). |
+| LibreChat | Multi-provider chat UI with deep enterprise plumbing (github.com/danny-avila/LibreChat). Multi-user with social logins (GitHub / Google / Discord / OIDC / SAML / Apple / Facebook), per-user balance + transactions, agents + assistants + MCP, RAG via pgvector + dedicated rag_api, web search, TTS/STT. Alternative to Open WebUI for teams. Docker Compose dev (`docker-compose.yml`), Docker Compose prod (`deploy-compose.yml` + Nginx), npm / source, **first-party Helm chart** (`helm/librechat/` v2.0.2), plus one-click deploys for Railway / Zeabur / Sealos. |
+| AnythingLLM | Open-source RAG-focused workspace + AI agent platform (github.com/Mintplex-Labs/anything-llm). Workspace-style "drop a folder of PDFs, ask questions over them" UX with built-in LanceDB vector store (or external Pinecone / Weaviate / Qdrant / Chroma / Milvus / Astra / pgvector), built-in agents, MCP support, multi-user, embeddable chat widget. Docker (canonical, `docker/HOW_TO_USE_DOCKER.md`), Desktop App (Mac / Windows / Linux installers), bare-metal source install (per `BARE_METAL.md`, "not supported by core team" — flagged), plus upstream-published one-click cloud deploys for AWS CloudFormation / GCP Cloud Run / DigitalOcean Terraform / Render / Railway / RepoCloud / Elestio / Northflank. |
+| Aider | AI pair-programming CLI (github.com/Aider-AI/aider). Different category — runs in the developer's terminal alongside their git repo, edits files via diffs, auto-commits per change. Pairs with any LLM provider (Anthropic / OpenAI / DeepSeek / Gemini / OpenRouter / Ollama / vLLM / OpenAI-compatible). `aider-install` (recommended, isolated Python 3.12 env), uv-based one-liner script (Mac / Linux / Windows), uv direct, pipx, plain pip, plus Docker (`paulgauthier/aider` + `paulgauthier/aider-full`), GitHub Codespaces, and Replit. |
+| vLLM | Production-grade LLM inference server (github.com/vllm-project/vllm). Different niche from Ollama (single-user / hobby) — vLLM is for high-throughput multi-tenant serving with PagedAttention, tensor parallelism, prefix caching. NVIDIA CUDA (canonical) + AMD ROCm + Intel XPU/Gaudi + CPU variants (x86 / ARM / Apple Silicon / s390x), Docker (`vllm/vllm-openai`), Kubernetes (raw manifests + first-party Helm chart + LeaderWorkerSet for distributed inference), plus upstream PaaS cookbooks (SkyPilot / RunPod / Modal / Cerebrium / dstack / Anyscale / Triton). |
+| Langfuse | Open-source LLM engineering platform (github.com/langfuse/langfuse). LLM observability + evaluation + prompt management + datasets + scoring; cross-cutting layer that pairs with vLLM / Ollama (inference) and Open WebUI / LibreChat / AnythingLLM / Dify / Aider (apps). v3 architecture is six services (web, worker, Postgres, ClickHouse, Redis, MinIO/S3). Docker Compose (local + single-VM), Kubernetes Helm chart (`langfuse/langfuse-k8s`, recommended for prod), first-party Terraform modules for AWS (EKS + Aurora + ElastiCache + S3 + ALB), GCP (GKE + Cloud SQL + Memorystore + GCS + LB), Azure (AKS + PG-Flex + Redis + Storage + App Gateway), plus upstream-published Railway one-click. |
+
+Supported **infras** (under `references/infra/`):
+
+| Cloud / where | Adapter |
+|---|---|
+| AWS | `aws/lightsail.md` (Ghost Bitnami + OpenClaw blueprints), `aws/ec2.md` (general-purpose VM) |
+| Azure | `azure/vm.md` (Bastion-hardened, no public IP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` (CX-line VPS via `hcloud`) |
+| DigitalOcean | `digitalocean/droplet.md` (Droplet via `doctl`) |
+| GCP Compute Engine | `gcp/compute-engine.md` (VM via `gcloud`) |
+| Oracle Cloud | `oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
+| Hostinger | `hostinger.md` (managed via hPanel — no CLI) |
+| Raspberry Pi | `raspberry-pi.md` (Pi 4/5 64-bit, ARM64) |
+| macOS VM (Apple Silicon) | `macos-vm.md` (Lume; for iMessage via BlueBubbles) |
+| Any Linux VM (other providers, on-prem) | `byo-vps.md` (SSH-only, no cloud APIs) |
+| Your own machine | `localhost.md` (Claude runs commands directly) |
+| Fly.io | `paas/fly.md` (`fly.toml` + persistent volume; public or private mode) |
+| Render | `paas/render.md` (`render.yaml` Blueprint, one-click) |
+| Railway | `paas/railway.md` (one-click template) |
+| Northflank | `paas/northflank.md` (one-click stack) |
+| exe.dev | `paas/exe-dev.md` (Shelley agent or manual nginx) |
+
+Supported **runtimes** (under `references/runtimes/`):
+
+| Runtime | Notes |
+|---|---|
+| Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
+| Podman | `podman.md` — rootless Docker-compatible alternative; Quadlet (systemd-user) supported. Reusable across every Linux/macOS infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd / Scheduled-Tasks lifecycle, reverse-proxy guidance. Covers `install.sh` (macOS / Linux / WSL2), `install-cli.sh` (local-prefix, no root), and `install.ps1` (native Windows). |
+| Kubernetes | `kubernetes.md` — kubectl + Kustomize (preferred, what openclaw upstream uses) and Helm orchestration. open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
+| Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
+
+## Selection — ask three questions
+
+Before provisioning, establish three things by asking (or inferring from the user's prompt):
+
+1. **What** to host? → loads `references/projects/<software>.md`
+2. **Where** to host? → loads `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`
+3. **How** to host? → loads the matching `references/runtimes/<runtime>.md` (skipped if the infra bundles the runtime, e.g. vendor blueprints)
+
+The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Ask a structured-choice question only when genuinely ambiguous.
+
+Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
+
+## Tier 1 vs Tier 2 routing
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for the long tail (Tier 2). When the user names a piece of software, decide which tier you're in **before** loading anything.
+
+### Tier 1 — verified recipe exists
+
+If `references/projects/<name>.md` matches the user's software, you're in Tier 1. Load it, follow it, and stay in the standard workflow below.
+
+### Tier 2 — no recipe; derive from upstream live
+
+If no recipe matches, **don't refuse — fall back to Tier 2**:
+
+1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Fetch upstream the same way Tier 1 does**:
+   - Fetch the upstream README first via the platform's URL-fetch capability (Claude Code: `WebFetch`; Cursor: `@Web`; Aider/generic: `curl` via shell). If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
+   - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
+3. **Reuse the existing modules**: drive the Docker install via `runtimes/docker.md`, Kubernetes via `runtimes/kubernetes.md`, VM provisioning via `infra/<cloud>/*.md`, DNS / TLS / SMTP via `references/modules/`. The Tier 2 work is only the software-specific bits on top.
+4. **Cite every upstream URL** in chat the same way Tier 1 sections do (`> Source: <url>`).
+5. **Offer to capture the result** as a new Tier 1 recipe once the deploy succeeds — that's how the catalogue grows. Captured recipes must go through first-run discipline before promotion.
+
+**Quality boundary:** Tier 2 output is best-effort, not authoritative. It will hallucinate at the edges of upstream docs we couldn't fetch and skips the real-deploy refinement Tier 1 recipes get. Always tell the user which tier you're in; never silently mix.
+
+### Out-of-scope software
+
+Some user requests are not deployable services at all (libraries like Unsloth or `requests`, desktop apps like Slack, SaaS like Notion). When you detect this, say so clearly and offer the closest in-scope alternative if there is one. See CLAUDE.md § *Is this software in scope?* for criteria.
+
+## Phased workflow
+
+Each phase is verifiable and resumable. Do NOT batch phases — complete, verify, and update state before moving on.
+
+```
+1. preflight     → check prerequisites (CLI tools, profiles, domain ownership); collect inputs
+2. provision     → create instance, allocate + attach static IP, retrieve SSH key
+3. dns           → print exact DNS records for user to add at registrar; poll until resolved
+4. tls           → obtain Let's Encrypt cert, fix reverse proxy, switch app URL to https
+5. smtp          → configure outbound email provider; verify a test send
+6. inbound       → (optional) set up forwarding or mailbox
+7. hardening     → rotate default admin creds, rotate any secrets pasted into chat
+```
+
+Infra adapter defines *how* to do each phase (what CLI commands to run). Project recipe defines *what's specific* about that app (config file paths, gotchas, mail block shape). Cross-cutting steps — DNS guidance, Let's Encrypt, SMTP providers, inbound forwarders — live in `references/modules/` and are loaded as needed.
+
+## State file
+
+Every deployment has a YAML state file at:
+
+```
+~/.open-forge/deployments/<name>.yaml
+```
+
+Shape:
+
+```yaml
+name: my-blog
+project: ghost
+infra: lightsail
+inputs:
+  aws_profile: qi-experiment
+  aws_region: us-east-1
+  domain: ariazhang.org
+  canonical: www  # or "apex"
+  letsencrypt_email: user@example.com
+outputs:
+  instance_name: my-blog
+  static_ip_name: my-blog-ip
+  public_ip: 54.156.69.42
+  ssh_key_path: ~/.ssh/lightsail-default.pem
+  admin_url: https://www.ariazhang.org/ghost
+phases:
+  preflight:   { status: done,  at: "2026-04-22T19:00Z" }
+  provision:   { status: done,  at: "2026-04-22T19:10Z" }
+  dns:         { status: done,  at: "2026-04-22T19:25Z" }
+  tls:         { status: done,  at: "2026-04-22T19:30Z" }
+  smtp:        { status: done,  at: "2026-04-22T20:05Z" }
+  inbound:     { status: skipped }
+  hardening:   { status: pending }
+```
+
+At the start of each session: if a state file exists for the named deployment, read it and resume from the first non-done phase. If the user says "start over", confirm destructively before unlinking.
+
+## Execution mode
+
+Default: **autonomous** — run AWS CLI, SSH, and file edits directly. Announce each external command in one sentence before running. Never fabricate outputs.
+
+Flag: **`--dry-run`** — print what would be done, do not execute. Useful for review.
+
+Commands that cross trust boundaries (paste secrets into config files, send real emails, spend money) should be announced and, when ambiguous, confirmed.
+
+## Inputs
+
+Inputs split across three layers:
+
+- **Cross-cutting (all deployments)** — handled by `references/modules/preflight.md`: AWS profile, region, deployment name, tool install confirmations.
+- **Infra-specific** — handled by the loaded infra adapter (e.g. `references/infra/lightsail.md`): bundle/blueprint choice, SSH key path defaults.
+- **Project-specific** — handled by the loaded project recipe (e.g. `references/projects/ghost.md`): domain, canonical preference, Let's Encrypt email, SMTP provider + API key, model provider, etc.
+
+Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use a structured-choice prompt where the platform supports one (Claude Code: `AskUserQuestion`; otherwise prose with options listed).
+
+## Asking for credentials
+
+Whenever the skill needs sensitive input — API keys, DB passwords, OAuth client secrets, cloud creds, SSH key paths — load `references/modules/credentials.md` and offer the **five patterns** (priority order):
+
+| # | Pattern | What user gives |
+|---|---|---|
+| 1 | Local file path | path to file containing the secret (skill `cat`s it) |
+| 2 | Env var name | name of an env var the user pre-exported (skill reads `$<NAME>`) |
+| 3 | Cloud-CLI session | "I've already run `aws sso login` for profile `<name>`" |
+| 4 | Secrets-manager ref | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` (skill calls matching CLI) |
+| 5 | Direct paste | **last resort** — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |
+
+**Never silently accept a paste.** When the skill detects sensitive input is needed, it should:
+
+1. **Offer the five patterns** with the credential class noted (e.g. *"I need a Resend API key — pick how to provide it: file path, env var, secrets-manager ref, or paste (last resort)"*).
+2. **Validate** before using:
+   - File path → `test -r <path>` + check mode is `≤ 600` (offer `chmod 600` if wider).
+   - Env var → `test -n "$<NAME>"` (refuse if empty; if user `export`ed after Claude Code started, ask them to restart).
+   - Cloud-CLI → smoke-command (e.g. `aws sts get-caller-identity --profile <name>`).
+   - Secrets-manager → smoke-command (`op read --no-newline <ref>`, `vault kv get`, etc.).
+   - Paste → require explicit risk acknowledgement first.
+3. **Detect accidental pastes**: if the user was prompted for a path but pasted a string matching `re_*` / `sk-*` / `AKIA[0-9A-Z]{16}` / etc., stop and ask: *"That looks like the key itself, not a path. Did you mean to paste directly? (see risks)"*.
+4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
+5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
+
+See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
+
+## Verification after each phase
+
+| Phase | Verify with |
+|---|---|
+| provision | `aws lightsail get-instance ... --query 'instance.state'` is `running`; SSH to `<user>@<ip>` succeeds |
+| dns | `dig +short <domain> @1.1.1.1` returns the static IP for apex AND the canonical host |
+| tls | `curl -sI https://<domain>/` returns 2xx/3xx with a valid cert; browser loads without warnings |
+| smtp | Send a test email from the app's admin UI; confirm arrival in the recipient inbox and in the provider's log |
+| inbound | Send a test email to the configured alias; confirm it lands in the destination inbox |
+
+Never mark a phase `done` without verification.
+
+## Post-deploy feedback (closes the catalogue evolution loop)
+
+After `hardening` (or after the user explicitly says "we're done", or after they abort mid-phase and want to share what they learned), offer to file a GitHub issue with the deployment notes. Per CLAUDE.md § *Issue-driven contribution model*, this is how the catalogue evolves — the bot or a future Claude session reads these issues and patches the recipes.
+
+Three flows the user can trigger from this prompt:
+
+1. **Recipe feedback** (default at end of deploy) — submit gotchas, suggested edits, or "the recipe was outdated". Claude self-summarizes from the session; the user reviews + opts in.
+2. **Software nomination** — when the user asked to deploy something not in the catalogue and Tier 2 worked, offer to nominate it for Tier 1.
+3. **Method proposal** — when the user discovered an upstream-supported install method the recipe doesn't cover.
+
+### The flow (multi-step consent — never auto-post)
+
+Load `references/modules/feedback.md` for the full sanitization rules + draft templates + submission paths. Summary:
+
+1. **Opt-in prompt**:
+   - Recipe feedback: *"Want to share what you learned with the open-forge project? I can draft a sanitized GitHub issue with the gotchas + suggested edits — you review, then post."*
+   - Software nomination (Tier 2 deploy): *"This software isn't in the Tier 1 catalogue yet. Want to nominate it? I'll draft an issue with the rationale + upstream URLs."*
+   - User must explicitly opt in (no auto-post).
+2. **Self-summarize the session**:
+   - Which recipe + combo was used, plugin version.
+   - Which phases ran, which retried, which failed.
+   - Where the user got prompted unexpectedly (gaps in the recipe).
+   - Any gotchas Claude observed (commands that failed, error messages, deviations from the documented path).
+3. **Draft the issue** in the format from `references/modules/feedback.md`:
+   - Specific recipe-edit suggestions (preferred: as a diff), not free-prose.
+   - All identifiers redacted per CLAUDE.md § *Sanitization principles*.
+4. **Show the redacted draft in chat — full text — before any submission attempt.**
+5. **Standing reminder**: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; if anything looks identifiable to you, edit before posting. By submitting, you grant a non-revocable license to use this content in the recipe; the project bears no liability for your decision to share."*
+6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
+7. **Submit via the first available path**:
+   - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
+   - Platform-native GitHub integration if available (Claude Code: `mcp__github__issue_write`; Cursor / generic: GitHub MCP server if installed).
+   - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
+
+### Sanitization is mandatory
+
+Per CLAUDE.md § *Sanitization principles* — strip every domain, IP, SSH key path, API key, AWS account ID, email address, state-file content, and anything from the user's clipboard / env vars before showing the draft. Use the patterns + replacements documented in `references/modules/feedback.md`.
+
+If you find something in the draft that you can't confidently classify as safe, **redact it** rather than ship it. The user's review pass is a safety net, not the only line of defense.
+
+### When to skip
+
+- User says "no thanks" or doesn't reply → drop it, don't pester.
+- Deploy aborted very early (before any state was created) → no useful feedback to capture; skip.
+- Tier 2 deploy that obviously wasn't in scope (e.g. user tried to "self-host" a library) → don't nominate; politely explain it's out of scope per CLAUDE.md § *Is this software in scope?*.
+
+## Common pitfalls across infras/projects
+
+- **Stale DNS**: browsers cache 301 responses with long max-age. After any HTTP↔HTTPS or apex↔www redirect change, suggest hard reload or incognito.
+- **Host key mismatch on new static IP**: the first SSH to a freshly-allocated IP needs `-o StrictHostKeyChecking=accept-new`; don't blindly blow away `~/.ssh/known_hosts` entries.
+- **Non-interactive cert tools**: some have quirky option-file or flag requirements. See the project recipe — do not assume `--unattended` works.
+- **Reverse-proxy misconfig after switching to https URL**: apps that enforce HTTPS redirects from the `url` config need `X-Forwarded-Proto` and `Host` preserved. See `references/modules/tls-letsencrypt.md`.
+
+## Adding a new project or infra
+
+A new project: add `references/projects/<name>.md` covering required services, config file paths, mail config shape, and any install/upgrade quirks. Follow the structure of the existing ghost.md.
+
+A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
+
+Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.

--- a/dist/cursor/01-credentials.mdc
+++ b/dist/cursor/01-credentials.mdc
@@ -1,0 +1,226 @@
+---
+description: Credential-handling patterns for open-forge — five patterns prioritizing safer alternatives over chat paste
+globs: ["**/*.env*", "**/secrets/**", "**/credentials/**"]
+---
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.

--- a/dist/cursor/02-feedback.mdc
+++ b/dist/cursor/02-feedback.mdc
@@ -1,0 +1,244 @@
+---
+description: open-forge post-deploy feedback flow — sanitization + multi-step consent + GitHub issue submission
+---
+
+---
+name: feedback
+description: Post-deploy feedback module — sanitization rules + draft templates + submission paths for the three GitHub-issue input channels (recipe-feedback / software-nomination / method-proposal). Loaded by SKILL.md § Post-deploy feedback.
+---
+
+# Feedback module — drafting + submitting GitHub issues
+
+This module is loaded after a deploy completes (or is abandoned) when the user opts in to share what they learned. Implements the multi-step consent flow described in CLAUDE.md § *Sanitization principles* and SKILL.md § *Post-deploy feedback*.
+
+**Hard rule:** never post without showing the redacted draft + getting explicit "yes" from the user. The skill is the user's submitter; consent gates everything.
+
+---
+
+## Sanitization checklist
+
+Apply BEFORE drafting. Scan the deployment session — including chat transcript, any tool outputs Claude has in context, any state-file references — and replace identifiers per the table.
+
+### Strip-list (regex patterns + replacements)
+
+| Class | Detection | Replacement |
+|---|---|---|
+| **Domains** (apex, www, admin) | Anything matching the user's `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` collected during inputs, plus generic FQDNs in URL paths the user typed | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| **Public IPv4** | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (excluding RFC-1918 ranges if you want to allow them as `${PRIVATE_IP}`) | `${PUBLIC_IP}` |
+| **Private IPv4** | `\b(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)[0-9.]+\b` | `${PRIVATE_IP}` (or strip if it leaks network topology) |
+| **IPv6** | Standard IPv6 patterns | `${PUBLIC_IPV6}` / `${PRIVATE_IPV6}` |
+| **SSH key paths** | Anything matching `~/.ssh/[^ ]+`, `/home/[^/]+/\.ssh/[^ ]+`, `*.pem`, `*.priv`, `id_(rsa|ed25519|ecdsa)` | `${KEY_PATH}` |
+| **SSH key contents** | `-----BEGIN [A-Z ]+ KEY-----` blocks | `<REDACTED-SSH-KEY>` |
+| **Resend API key** | `re_[A-Za-z0-9_]+` | `<REDACTED-RESEND-KEY>` |
+| **SendGrid API key** | `SG\.[A-Za-z0-9._-]+` | `<REDACTED-SENDGRID-KEY>` |
+| **OpenAI API key** | `sk-[A-Za-z0-9]{20,}` | `<REDACTED-OPENAI-KEY>` |
+| **Anthropic API key** | `sk-ant-[A-Za-z0-9_-]{20,}` | `<REDACTED-ANTHROPIC-KEY>` |
+| **Slack tokens** | `xox[bp]-[A-Za-z0-9-]+` | `<REDACTED-SLACK-TOKEN>` |
+| **GitHub PAT** | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]+` | `<REDACTED-GH-PAT>` |
+| **AWS access key ID** | `AKIA[0-9A-Z]{16}` | `<REDACTED-AWS-KEY>` |
+| **AWS secret key** | After `aws_secret_access_key`, 40-char base64 | `<REDACTED-AWS-SECRET>` |
+| **AWS account ID** | 12 consecutive digits in AWS context (ARN, account-id field) | `${AWS_ACCOUNT}` |
+| **AWS profile name** | Whatever the user collected as `aws_profile` during inputs | `${AWS_PROFILE}` |
+| **GCP service-account JSON** | `"type": "service_account"` blocks | `<REDACTED-GCP-SA>` |
+| **Generic Bearer token** | `Bearer [A-Za-z0-9._~+/=-]{20,}` | `<REDACTED-BEARER>` |
+| **Email addresses** | RFC-822 pattern; especially the LE email + SMTP from-address + any user identity email | `${EMAIL}` |
+| **State-file contents** | Anything from `~/.open-forge/deployments/<name>.yaml` raw | Reference by deployment name only, never paste contents |
+| **MySQL/Postgres password** | After `password=` / `--password ` / `IDENTIFIED BY ` | `<REDACTED-DB-PASSWORD>` |
+| **OAuth client secrets** | After `client_secret` / `CLIENT_SECRET` | `<REDACTED-CLIENT-SECRET>` |
+| **Random bytes from `openssl rand -hex N`** that the user generated as a secret | Long hex strings used as secrets | `<REDACTED-RANDOM-SECRET>` |
+
+### Manual review pass (after regex)
+
+After regex-based sanitization, do a final read-through looking for:
+
+- **Hostnames in URL paths** that contain the user's domain (sed/regex may have missed embedded URLs).
+- **Username conventions** that are personally identifiable (e.g. `qi-experiment` as an AWS profile).
+- **Stack-trace lines** containing absolute filesystem paths (`/home/<user>/...`).
+- **Anything pasted from the user's clipboard or env vars** that wasn't covered by the strip-list.
+
+If you can't confidently classify something as safe, **redact it** — the user's final review is a safety net, not the only line of defense.
+
+### What you may keep
+
+| Class | OK to keep | Why |
+|---|---|---|
+| Recipe filenames (`ghost.md`, `openclaw.md`) | ✅ | Public; needed for context |
+| Plugin version (`0.20.0`) | ✅ | Public; needed for triage |
+| Combo names (`Ghost-CLI on Ubuntu`, `DigitalOcean droplet`) | ✅ | Public; needed for context |
+| Generic error messages quoted from upstream tools | ⚠️ | OK if no identifiers; redact paths and IPs from stack traces |
+| `${VAR}` placeholders | ✅ | These are the redactions; they're fine |
+| Public repo URLs (upstream docs you're proposing to add) | ✅ | Public |
+
+---
+
+## Draft templates
+
+Each template renders into the matching `.github/ISSUE_TEMPLATE/*.yml` form. The structure mirrors the form fields so the user pastes the body and the form auto-validates the sanitization checkboxes.
+
+### Channel 1 — recipe feedback (default at end of deploy)
+
+```markdown
+**Recipe**: <recipe-filename>
+**Combo**: <infra adapter> / <runtime>
+**Plugin version**: <version-from-plugin.json>
+**Outcome**: <one-of: Deploy succeeded with notes / Deploy succeeded after retries / Deploy failed; recovered manually / Deploy failed; abandoned / Recipe was outdated>
+
+## What the recipe missed
+
+<Concrete description: what surprised you, what failed, what required manual intervention. Sanitized.>
+
+## Suggested edit (optional — diff format preferred)
+
+```diff
+@@ <section header from the recipe> @@
+- <line that was wrong / missing>
++ <line that should be there>
+```
+
+## Sanitization confirmation
+- [x] All domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses stripped from this issue body.
+- [x] I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+```
+
+### Channel 2 — software nomination (Tier 2 → Tier 1)
+
+```markdown
+**Software name**: <project>
+**Upstream repo**: <github URL>
+**Upstream install-method index**: <docs / repo path / wiki URL>
+**Intended deploy combo**: <infra> / <runtime>
+
+## Why Tier 1?
+
+<What's painful about this software's install that compounds across deploys?
+Per the demand-driven graduation criteria in CLAUDE.md, a Tier 1 recipe earns
+its keep when the captured tribal knowledge saves the next user real pain.>
+
+## In-scope check (per CLAUDE.md § Is this software in scope?)
+
+This software is: <one-of: deployable service / static-site generator / AI inference server / CI runner / storage backend / not sure>
+
+## Confirmation
+- [x] I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+- [x] This software has at least one upstream-documented install method or canonical install artifact in-repo.
+```
+
+### Channel 3 — method proposal
+
+```markdown
+**Recipe to extend**: <recipe-filename>
+**Method name**: <e.g. "Snap package", "Helm chart">
+**Upstream URL documenting this method**: <URL>
+**Source type**: <First-party — published by upstream / Community-maintained>
+
+## Canonical install command(s)
+
+```bash
+<paste verbatim from upstream>
+```
+
+## Why this method matters
+
+<When would a user pick this method over the existing options in the recipe?>
+
+## Confirmation
+- [x] I have verified the upstream URL above shows this install method on the current upstream version.
+- [x] No credentials, IPs, or other identifiers in this issue.
+```
+
+---
+
+## Submission paths (try in order)
+
+The skill never opens a browser silently or POSTs without explicit user confirmation. Three submission paths in priority order:
+
+### 1. `gh` CLI (preferred when available)
+
+```bash
+# Check if gh is authenticated for the right account
+gh auth status
+
+# If yes, submit
+gh issue create \
+  --repo zhangqi444/open-forge \
+  --title "<title from template>" \
+  --body-file /tmp/feedback-draft.md \
+  --label recipe-feedback,recipe:<name>
+```
+
+Strengths: works headlessly in chat; respects user's existing GitHub auth.
+
+Caveats: user must have `gh` installed + authenticated. If `gh auth status` errors, fall through to path 2.
+
+### 2. GitHub MCP server (if available)
+
+If `mcp__github__issue_write` is available in the tool list, use it:
+
+```
+mcp__github__issue_write({
+  method: "create",
+  owner: "zhangqi444",
+  repo: "open-forge",
+  title: "<title>",
+  body: "<full body>",
+  labels: ["recipe-feedback", "recipe:<name>"]
+})
+```
+
+Strengths: no `gh` install needed; uses the MCP server's auth.
+
+Caveats: only works if the MCP server is configured with appropriate scopes.
+
+### 3. Prefilled URL (always-available fallback)
+
+When neither `gh` nor the GitHub MCP works, generate a URL the user opens in a browser:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=<URL-encoded-title>&body=<URL-encoded-body>
+```
+
+Print the URL in chat with the instruction:
+
+> *"I can't post for you in this environment. Open this URL in a browser, review one more time, and click Submit:*
+>
+> *<URL>*
+>
+> *The form has the same sanitization checkboxes from the template — they'll be checked based on what you've already confirmed in chat."*
+
+URL-encode the title + body. GitHub URL length limit is ~8 KB total; if the body is longer, truncate the body and put the rest in a `<details>` block (or warn the user to paste it manually).
+
+---
+
+## Liability + license boilerplate (paste at end of every issue body)
+
+Append this exact block as the final paragraph of every issue body before submission:
+
+```markdown
+---
+
+> By submitting this issue, I grant a non-revocable license to the open-forge project to use this content in recipes and documentation. The open-forge project bears no liability for my choice to share. I have reviewed the issue body for credentials and personal information per CLAUDE.md § *Sanitization principles*.
+```
+
+This is in addition to the checkboxes in the issue-template form — it's an extra paper trail in the issue body itself.
+
+---
+
+## When the deploy aborted before completion
+
+If the user wants to file feedback about a deploy that failed mid-phase (e.g. preflight passed, provisioning failed at the security-group step), the `Outcome` field should be *"Deploy failed; abandoned"* and the body should include:
+
+- Which phase failed.
+- What the error was (sanitized — strip stack traces of paths/IPs).
+- What workaround the user attempted (if any).
+- Whether the user wants the recipe edited to handle this case, or whether they think it was an upstream / cloud-account issue (out of recipe scope).
+
+These are often the highest-value feedback issues — they catch recipes that succeed in the maintainer's environment but fail in others.
+
+---
+
+## Failure modes to watch for
+
+- **User says "post it" too quickly.** Respect their consent, but flag any line you weren't 100% sure about: *"Posting now. One last thing — line 14 mentions a username `qi-experiment` that might be your AWS profile name. Was that intentional?"*
+- **Drafts that quote upstream error messages with embedded user data.** Common with Bitnami's `bncert-tool` output, AWS CLI errors quoting account IDs in ARNs.
+- **State-file leaks.** If the user asks Claude to read `~/.open-forge/deployments/<name>.yaml` while drafting, do **not** paste contents — reference by deployment name only.
+- **Multiple rapid yes-clicks.** If the user says "yes, yes, yes, post" to skip the review, slow down: re-show the draft once, get confirmation, then submit. Speed is not a user safety feature.

--- a/dist/generic/open-forge-bundle.md
+++ b/dist/generic/open-forge-bundle.md
@@ -1,0 +1,1238 @@
+# open-forge — single-file bundle for any tools-using LLM agent
+
+This is a concatenation of the canonical open-forge skill content. Feed it as a system prompt or a long-context document to any LLM agent that supports tool use. The agent acts as a deployment runbook for self-hostable open-source apps.
+
+For per-recipe content (~180 individual recipes under references/projects/), browse:
+  https://deepwiki.com/zhangqi444/open-forge
+
+Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specific — read as capabilities (structured-choice prompt; URL fetch; GitHub API) and use your platform's equivalents.
+
+---
+
+# CLAUDE.md
+
+Instructions for any Claude Code session working *on* the open-forge plugin (not running it). Different audience from `plugins/open-forge/skills/open-forge/SKILL.md`, which is what an end-user's Claude reads to *use* the plugin.
+
+## What is open-forge
+
+A Claude Code plugin/skill that turns "read a README, copy-paste 30 lines of bash, debug for hours" into a guided chat where Claude executes everything via the user's local CLI tools and the user only makes choices.
+
+## Architecture — 3 layers, asked in 3 questions
+
+A deployment is a tuple of three independent axes, asked in this order:
+
+| # | Question | Layer | Examples |
+|---|---|---|---|
+| 1 | **What** to host? | software | OpenClaw, Ghost, Mastodon, Vaultwarden, Nextcloud |
+| 2 | **Where** to host? | infra (cloud or local) | AWS / Hetzner / DigitalOcean / GCP / Azure / bring-your-own-VPS / **localhost** |
+| 3 | **How** to host (within that cloud)? | infra-service + runtime | AWS: Lightsail blueprint, Lightsail Ubuntu + Docker, EC2 + native, EKS, ECS Fargate. Hetzner: Cloud CX + Docker, Cloud CX + native. localhost: Docker Desktop, native. |
+
+The third question is *dynamically generated* from (software, cloud) — different clouds expose different compute services, and some software has vendor-bundled blueprints on specific clouds.
+
+**Some infra services bundle the runtime** — EKS → Kubernetes, Lightsail OpenClaw blueprint → vendor's pre-baked install. In those cases the "runtime" question is not asked separately. **Other services give runtime choice** — EC2, plain VPS, localhost — there we ask Docker vs native vs k3s.
+
+**Reusability is the test.** "Install Docker + run docker-compose" is the same on Lightsail Ubuntu, Hetzner CX-line, a DO droplet, and a localhost — write it once in the runtime layer, reference from every project. "Install k3s" is the same across clouds — write it once. Project recipes should be 80% software-specific concerns and contain *no* per-runtime install commands beyond a one-line link.
+
+### File layout for the 3 layers
+
+```
+references/
+├── projects/<sw>.md                       # software layer (thin)
+├── infra/
+│   ├── aws/
+│   │   ├── lightsail-blueprint.md         # vendor-bundled, software-specific
+│   │   ├── lightsail-ubuntu.md            # Lightsail as a plain VM
+│   │   ├── ec2.md
+│   │   ├── eks.md
+│   │   └── ecs-fargate.md
+│   ├── hetzner/cloud-cx.md
+│   ├── digitalocean/droplet.md
+│   ├── gcp/compute-engine.md
+│   ├── byo-vps.md                         # user provides any Linux VPS, Claude SSH-es in
+│   └── localhost.md                       # user's own machine, Claude runs commands directly
+├── runtimes/
+│   ├── docker.md                          # reusable wherever Docker works
+│   ├── native.md                          # native installer (curl/apt)
+│   └── kubernetes.md                      # reusable across EKS/GKE/AKS/k3s
+└── modules/                               # cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
+```
+
+`localhost.md` is a first-class infra — for many projects (especially OpenClaw), running locally is the default upstream path. Same conversational UX as a cloud deploy; differences are: no SSH (Claude runs commands directly), no provisioning, public reach via tunnel (`references/modules/tunnels.md`).
+
+## Is this software in scope?
+
+open-forge is for **deployable self-hosted services**. Use these criteria when deciding whether a piece of software belongs as a Tier 1 recipe (see *Two-tier coverage model* below).
+
+### Inclusion criteria — recipe is in scope when ALL are true
+
+1. **Software runs as a deployed service or is served from a host the user owns**: long-running daemon, scheduled job, web service, API, CLI agent, or static asset published to a host.
+2. **Source code or binaries are user-installable on infrastructure they control**: cloud VM, VPS, k3s cluster, or localhost. Paid AMIs / vendor stacks (Bitnami, Dify Premium, etc.) count — closed-source SaaS-only does not.
+3. **At least one upstream-documented install method or canonical install artifact in-repo** exists, so the strict-doc-policy below has something to verify against.
+
+### Exclusion criteria — out of scope
+
+- **Pure libraries / SDKs / packages** that you `import` or call (Unsloth, requests, lodash). No deployment surface.
+- **Desktop / mobile end-user apps** with no self-hosted server side (Slack desktop, VS Code, Discord client).
+- **SaaS / managed-only products** with no self-host distribution (Notion, Linear, Figma).
+- **Dev-only tooling that runs ephemerally on a developer machine** and is never deployed (Storybook *dev* mode, Vite dev server, REPLs).
+
+### Edge cases — borderline classes
+
+| Class | Verdict | Recipe shape |
+|---|---|---|
+| **Static-site generators** (Hugo, Jekyll, Docusaurus, Storybook in production-preview mode) | ✅ in scope | Thin: `<sg> build` → static dir → deploy via a static-host module (nginx / S3+CDN / Pages). The SG-specific bit is build config, theme path, content tree. |
+| **CLI agents** (Aider, OpenClaw, Hermes-Agent) | ✅ in scope | Install on a host, run as daemon or interactive CLI. Standard recipe shape. |
+| **AI inference servers** (vLLM, Ollama, TGI) | ✅ in scope | Deployed services exposing HTTP APIs. Standard recipe shape. |
+| **AI training libraries** (Unsloth, axolotl, transformers) | ❌ out of scope | Libraries called from training scripts, not deployed services. If a "training environments" track ever exists, it's a separate category — not project recipes under `references/projects/`. |
+| **CI runners** (GitHub Actions self-hosted, Buildkite agent) | ✅ in scope | Long-running daemon attached to a control plane. Standard recipe shape. |
+| **Standalone databases** (Postgres, ClickHouse, Redis) | ⚠️ borderline | Useful but usually a dependency of another recipe rather than a deployment goal. Document as a supporting service inside the consuming recipe; only write a standalone recipe when there's clear demand. |
+| **Storage backends** (MinIO, SeaweedFS, Garage) | ✅ in scope | Self-hostable services with HTTP APIs. Standard recipe shape. |
+
+### When in doubt
+
+Ask: *"Would the user need open-forge to walk them through provisioning + DNS + TLS + ongoing lifecycle for this?"* If yes, write a recipe. If no (e.g. they'd just `pip install` it inside their own scripts), it's out of scope — or fall back to Tier 2 (below) for one-off requests.
+
+## Operating principles
+
+1. **Do more, ask less. Non-tech-friendly.** Default to autonomous execution. Only prompt the user for things only they can decide or provide: credentials, opinionated choices, things that touch their accounts at other companies. Hide everything Claude can figure out from the recipe.
+2. **Towards production-ready architecture.** Even single-node hobby deploys should be on a path to backups, monitoring, TLS, key rotation, OS updates, and least-privilege firewalls. Don't write recipes that "work" but leave the system one outage away from data loss.
+3. **Security in mind.** Treat tokens/keys as toxic — never log them, rotate after chat exposure, prefer fragment URLs over query strings. Default firewalls to closed; open ports explicitly. Default to SSH key auth; never password. Let's Encrypt for any public endpoint. Sandbox agent tool execution where the runtime supports it.
+4. **One question at a time.** Use `AskUserQuestion` for structured choices. Reserve free-text for credentials and identifiers (domain names, emails). No upfront questionnaires.
+5. **Auto-install with confirmation, never silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run.
+6. **Reference upstream docs; don't replace them.** Recipes condense and translate upstream documentation into Claude-actionable steps — they aren't the source of truth for the product itself. Always link the upstream pages we summarized (e.g. `docs.openclaw.ai/install/docker`, AWS Lightsail user guide, Bitnami docs). Reasons: (a) users can verify what we condensed, (b) when upstream drifts our recipe goes stale fast and the link is the recovery path, (c) credit where due. **See *Strict doc-verification policy* below — every install method documented by upstream must have its own recipe section, verified against upstream before being written.**
+7. **Don't invent — interface.** open-forge is a chat-friendly interface to existing tools. Claude is the orchestrator; the user's existing software stack (AWS CLI, Docker, openclaw, ssh, gh, registrar UIs) is the substrate. **Do not** build custom DSLs, YAML schemas, CLI tools, deployment managers, or wrappers around upstream tools. **Do not** reimplement what an upstream tool already does (e.g. don't rebuild `openclaw onboard`'s prompts in chat — call the command). The state file is a thin orchestration helper for resume, nothing more. *Caveat:* "don't invent" applies to **fabricating a deployment path the upstream doesn't support** (e.g. authoring a Helm chart for a project that has no chart). It does **not** mean "no tooling." If upstream supports Docker / k8s / Helm / Terraform, lean on every skill and MCP that helps you orchestrate those paths well — see *Companion skills & MCPs* below.
+
+## Credential handling (expanded from Operating Principle #3)
+
+Pasting raw credentials into Claude Code is risky — secrets enter session history, may be relayed via MCP servers, and could appear in shared transcripts. The skill must offer safer alternatives **first** and only fall back to direct paste with explicit risk acknowledgement.
+
+### The five patterns (priority order)
+
+| # | Pattern | When to suggest |
+|---|---|---|
+| 1 | **Local file path** — user gives skill a path; skill `cat`s it | Personal-use API keys; user already has a `.env` or `.secrets` file |
+| 2 | **Env var name** — user pre-exports the secret; skill reads `$<NAME>` | Shell users with secrets in `.envrc` / `.bashrc` |
+| 3 | **Cloud-CLI session** — user runs `<provider> login` ahead of time; skill uses the resulting profile / session | Default for AWS, GCP, Azure, GitHub, DigitalOcean, Hetzner, Cloudflare |
+| 4 | **Secrets-manager reference** — user gives skill a `op://` / `bw://` / `vault://` reference; skill calls the matching CLI just-in-time | Users with proper secret management (1Password, Bitwarden, Vault, AWS Secrets Manager, GCP Secret Manager, `pass`) |
+| 5 | **Direct chat paste** — last resort, requires risk acknowledgement | When patterns 1-4 don't apply; user explicitly opts in |
+
+### Hard rules
+
+- **Always offer the five patterns** when asking for any sensitive input. Don't silently accept a paste; don't assume Claude Code is a vault.
+- **Surface the risk** before accepting a direct paste: *"the key will live in this session's history; rotate after deploy completes."*
+- **Never accept SSH key contents.** Always ask for the key file *path* (skill uses `ssh -i <path>`); never the key material itself in chat.
+- **Validate before proceeding**: `test -r <path>` for file paths; `test -n "$<VAR>"` for env vars; smoke-command for cloud-CLI sessions and secrets-manager refs.
+- **Refuse files with permissions wider than 600**; offer to `chmod 600` first.
+- **Detect accidental pastes** (regex for `re_*`, `sk-*`, `AKIA*`, etc. in a prompt that expected a path) and stop the user before the secret commits to chat.
+- **End-of-deploy rotation reminder** if the user pasted any secret directly during the deploy: list each pasted credential + the provider's dashboard URL; recommend rotating now that the deploy is done.
+
+The full pattern catalog with skill prompt templates, per-credential-class recommendations, and failure-mode handling lives in [`plugins/open-forge/skills/open-forge/references/modules/credentials.md`](plugins/open-forge/skills/open-forge/references/modules/credentials.md).
+
+## Strict doc-verification policy (mandatory before writing any recipe)
+
+Recipes are condensations of upstream docs; condensing what we haven't read is speculation. Past failures (the v0.7.0 Helm chart claim sourced from a search snippet, the v0.6.0 OpenClaw "every blessed path" claim that was 4 of 17 because we trusted the README's enumeration) traced back to this. The policy:
+
+### Before writing or expanding any project / infra recipe
+
+1. **Read the upstream README verbatim.** Not summarized — the actual README. Note: the README is necessary but **not sufficient** — many projects' READMEs are deliberately minimal and point at a separate docs site for install methods.
+2. **Locate the upstream install-method index.** Typically:
+   - The project's docs site (`docs.PROJECT.ai`, `PROJECT.com/docs`, `PROJECT.github.io`, etc.).
+   - The repo's `docs/install/` or `website/docs/getting-started/` tree.
+   - The repo's wiki (often a separate `<repo>.wiki.git` clone).
+3. **Enumerate every method documented under that index.** Include:
+   - First-party install scripts (`install.sh`, `install.ps1`, vendor blueprints).
+   - First-party Docker / Compose / Kubernetes / Helm support.
+   - First-party package-manager support (Homebrew, Nix, Pacman, etc.).
+   - First-party PaaS templates (`fly.toml`, `render.yaml`, Railway / Zeabur / Sealos one-click buttons published by upstream).
+   - First-party cloud templates (Terraform / CDK / Computing Nest published by upstream).
+4. **Read the canonical install artifacts in the repo:** `docker-compose.yml`, `Dockerfile`, `flake.nix`, the project's primary config-file example. These often surface details the docs gloss over (service inventory, env-var matrix).
+5. **Write one section per documented method.** No merging, no skipping. Each section's first line cites the upstream URL it's derived from.
+
+### What counts as "official"
+
+| Source | Official? |
+|---|---|
+| Upstream's own README | ✅ |
+| Upstream's own docs site (linked from README) | ✅ |
+| Upstream's repo `docs/` or `website/` tree | ✅ |
+| Upstream's repo wiki | ✅ |
+| Upstream-published PaaS deploy buttons (Railway/Render/Fly/etc.) where the manifest lives in the upstream repo | ✅ |
+| Community-maintained Docker images / Helm charts when upstream ships none | ⚠️ Allowed but **must be flagged** as "community-maintained, verify source"; recipe lists multiple options (most-active first), doesn't pick a winner |
+| Anything else (third-party blogs, search snippets, my training data) | ❌ Not allowed as the basis for a section. If upstream ships no path for X, do not invent one. |
+
+### When upstream-doc fetch fails
+
+- WebFetch rate-limited / 403 / 404 → try `raw.githubusercontent.com/<org>/<repo>/<branch>/<path>` for repo content.
+- Wiki page WebFetch fails → `git clone https://github.com/<org>/<repo>.wiki.git` and read locally.
+- All fetch paths fail → **stop**. Do not write speculative content. Either: (a) ask the user to paste relevant doc text, (b) wait until access is restored, or (c) write only the sections for methods we *did* read and note in the recipe's TODO that the rest is pending verification.
+
+### Community-maintained methods — flagging requirements
+
+When a recipe documents a method upstream doesn't ship (e.g. A1111 + ComfyUI Docker, Helm charts for many projects), the section MUST:
+
+1. Open with an explicit "community-maintained" note in a blockquote.
+2. List **multiple** options when they exist (most-active first; reference upstream README's pointer if upstream lists them).
+3. Frame commands as "illustrative — verify the README at the version you pull"; never present community-chart `--set` values as authoritative.
+4. Document the gap in the recipe's TODO section: "Verify which community option is most actively maintained at first-deploy time."
+
+### Retroactive application
+
+When this policy is added (or strengthened), every existing recipe must be re-verified against its upstream docs index. If the verification surfaces a missing method, file it in that recipe's TODO, write the missing section, and bump the plugin version.
+
+### When in doubt
+
+Ask the user whether to pause for verification or accept the README's enumeration. Don't silently downgrade thoroughness.
+
+---
+
+## Two-tier coverage model
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for everything else (Tier 2). Both tiers obey the strict-doc-policy above; the difference is *when* the verification happens.
+
+### Tier 1 — verified recipes (the catalogue)
+
+The current set under `references/projects/`. Authored ahead of time, audited against upstream docs, kept current via the first-run discipline + version bumps. **Quality bar:**
+
+- Every install method has a `> **Source:** <upstream URL>` line at the top of its section.
+- Community-maintained methods open with the required ⚠️ blockquote per *Community-maintained methods — flagging requirements*.
+- Gotchas captured from real deploys; TODOs track unresolved verifications.
+- Plugin version bumped on each user-visible change.
+
+### Tier 2 — derived live from upstream docs
+
+When a user asks for software that has no Tier 1 recipe, the skill **falls back** instead of refusing:
+
+1. **Announce the fallback in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Apply the strict-doc-policy on the fly** — same rules as Tier 1:
+   - Read upstream README via `WebFetch`. If 403/404, fall back to `raw.githubusercontent.com` paths and/or `git clone` the docs repo locally.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate methods from upstream — **do not invent**. If fetches fail, stop and tell the user; never speculate to fill a gap.
+   - Read canonical install artifacts (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`).
+3. **Reuse runtime + infra + cross-cutting modules** under `references/runtimes/`, `references/infra/`, `references/modules/` for all the reusable parts (Docker install, k8s prereqs, VM provisioning, DNS, TLS, SMTP). Tier 2 is mostly *software-specific* on top of those — same shape as Tier 1, just authored at request time.
+4. **Cite every upstream URL** the same way Tier 1 does.
+5. **Offer to capture the result** as a new Tier 1 recipe when the deploy succeeds — that's how the catalogue grows. The captured recipe must still go through first-run discipline before claiming Tier 1 status.
+
+### Routing
+
+The skill checks Tier 1 first by name match against `references/projects/*.md`. If no match, fall back to Tier 2 with the announcement above. **Never silently mix tiers** — the user should always know which tier they're in, since the verification depth differs.
+
+### Quality boundary
+
+Tier 2 output is **best-effort, not authoritative.** It will hallucinate at the edges of upstream docs we couldn't fetch; it skips the iterative refinement that Tier 1 recipes get from real deploys. Tell the user this. They're trading verification depth for coverage breadth.
+
+### Tier 2 → Tier 1 graduation criteria
+
+The catalogue grows demand-driven, not by guess. Promote a Tier 2 deploy to a Tier 1 recipe when ANY of:
+
+1. **3+ feedback issues** for the same software (demand signal — see *Issue-driven contribution model*).
+2. **Same user has deployed it 3+ times** and asks for first-run discipline applied.
+3. **A Tier 2 deploy surfaced a non-obvious gotcha** that's likely to bite the next person — capture the gotcha as a recipe even if demand is small (one-shot promotion is allowed when the value is in the captured knowledge).
+4. **A maintainer chooses to deploy the software themselves** (sunk cost is acceptable).
+
+Don't author Tier 1 recipes speculatively from a "popular self-host" list — without a real demand signal, the compounding effect can't kick in and the upfront cost goes to waste.
+
+---
+
+## Issue-driven contribution model
+
+The catalogue evolves through GitHub issues, not direct human PRs. AI coding sessions (whether triggered by a maintainer running this skill, by a scheduled job, or by a webhook) read incoming issues, verify them against upstream docs per *Strict doc-verification policy*, and author patches.
+
+### Three input channels
+
+GitHub issue templates under `.github/ISSUE_TEMPLATE/` define the structured input:
+
+| Template | When to use | Filed by |
+|---|---|---|
+| `recipe-feedback.yml` | A user deployed via the skill and wants to suggest recipe edits (gotchas captured, install steps that surprised them, sections that were wrong/outdated). The skill drafts these automatically at the end of a deploy. | End user (skill-assisted) |
+| `software-nomination.yml` | A user wants software added to the Tier 1 catalogue. Must include rationale + upstream URL + the user's intended deploy combo. | End user |
+| `method-proposal.yml` | A user knows an upstream-supported install method that an existing recipe doesn't cover. Must include the upstream URL where the method is documented. | End user |
+
+A blank-issue / off-template issue is treated as a request for routing — close politely with a pointer to the templates.
+
+### Why issues, not PRs
+
+- **Sanitization happens at submission time.** The skill (or a careful manual filer) redacts identifiers before posting; the issue templates encode the structure. PRs from random users could include credentials in commit history that can't be cleanly removed.
+- **Verification happens centrally.** Every change is re-verified against upstream by the AI session that processes the issue, not trusted because someone filed a PR.
+- **Demand signal lives in the issue stream.** Issues with the most thumbs-up / cross-linking / repeat filings are the demand signal that drives Tier 2 → Tier 1 graduation.
+
+### Direct human PRs
+
+Discouraged. If a maintainer writes a PR by hand, it's still subject to the strict-doc-policy and recipe-structure rules — the issue model is the documented contribution path.
+
+---
+
+## Sanitization principles
+
+User-shared content (deployment logs, gotchas, error output) routinely contains identifiers that **must not** end up in the public repo. Both the skill (when drafting issue content) and any session reviewing user-supplied content (when accepting a PR sourced from an issue) must apply these rules.
+
+### Always strip
+
+| Class | Replace with |
+|---|---|
+| Domain names (apex / canonical / admin) | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| IP addresses (public + private + IPv6) | `${PUBLIC_IP}` / `${PRIVATE_IP}` |
+| SSH key paths and contents | `${KEY_PATH}` / `<REDACTED-SSH-KEY>` |
+| API keys and bearer tokens (regex: `re_[A-Za-z0-9_]+`, `SG\.[A-Za-z0-9._-]+`, `sk-[A-Za-z0-9]+`, `xox[bp]-[A-Za-z0-9-]+`, `ghp_[A-Za-z0-9]+`, AWS access keys `AKIA[0-9A-Z]{16}` + secret `[A-Za-z0-9/+=]{40}`, GCP service-account JSON, generic `Bearer [A-Za-z0-9._-]{20,}`) | `<REDACTED>` |
+| AWS account IDs (12 consecutive digits in AWS context) | `${AWS_ACCOUNT}` |
+| AWS profile names | `${AWS_PROFILE}` |
+| Email addresses (LE email, SMTP from-address, user identity) | `${EMAIL}` |
+| State-file contents from `~/.open-forge/deployments/<name>.yaml` | Reference the file by name only, never paste contents |
+| Hostnames embedded in URLs that include the user's domain | `https://${CANONICAL_HOST}/path` |
+| Anything from the user's clipboard / env vars they pasted into chat | `<REDACTED>` |
+
+### Multi-step consent (no auto-post, ever)
+
+The skill flow when posting feedback to GitHub:
+
+1. **Opt-in prompt** — *"Want to share what you learned?"* User must explicitly opt in.
+2. **Show the redacted draft in chat** — full text, before any submission attempt.
+3. **Confirm post?** — explicit "yes" required.
+4. **If user edits the draft**, re-show + re-confirm before submitting.
+5. **Standing reminder text** in the prompt: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; edit if anything looks identifiable."*
+6. **Liability notice in the issue body**: *"Submitter grants a non-revocable license to use this content in the open-forge recipe; the project bears no liability for the submitter's choice to share."*
+
+### When reviewing PRs sourced from issues
+
+Issue-processing sessions must re-scan PR diffs against the same strip-list before merging. If any identifier slipped through, redact in the PR before merge — never merge content with live identifiers.
+
+---
+
+## Processing incoming issues
+
+When an AI coding session is asked to process incoming issues (whether by a maintainer prompt, a scheduled job, or a webhook), apply this workflow:
+
+### 1. Triage
+
+For each open issue without an `applied` / `out-of-scope` / `needs-info` label:
+
+- Identify the template type from the issue body's structured fields. If the issue doesn't follow a template, comment with a pointer to the templates and label `needs-info`.
+- Validate that the issue is in scope per *Is this software in scope?*. Out-of-scope → comment + `out-of-scope` label + close.
+- Otherwise, label `triaged` and proceed to validation.
+
+### 2. Validate against upstream
+
+Apply *Strict doc-verification policy* to every change:
+
+- For `recipe-feedback`: re-fetch the recipe's cited upstream URLs; verify the user's proposed change is consistent with current upstream content. If upstream has drifted in a way that conflicts with the user's report, prefer upstream and explain the discrepancy in the PR.
+- For `software-nomination`: confirm the software passes inclusion criteria; locate upstream's install-method index; do **not** start authoring a recipe until the index is reachable.
+- For `method-proposal`: confirm the cited upstream URL documents the method; if it's community-maintained, it must be flagged per *Community-maintained methods — flagging requirements*.
+
+If validation fails (upstream URL 404s, software is out of scope, methodology is unverifiable), comment on the issue explaining + label `needs-info` or `out-of-scope` as appropriate. Do not author a patch.
+
+### 3. Author the patch
+
+- Apply the change per *Recipe structure (must-have sections)*.
+- Cite the upstream URL at the top of every section per *Strict doc-verification policy*.
+- Flag community-maintained methods with the required ⚠️ blockquote.
+- Re-scan against the *Sanitization principles* strip-list — if any identifier slipped through user-supplied content, redact before drafting.
+- Bump `plugin.json` `version` per *Versioning + publish flow*.
+- If multiple feedback issues for the same recipe are pending, batch them into a single PR.
+
+### 4. Open the PR
+
+- **Branch naming**: `bot/issue-<N>-<short-slug>` (where `<N>` is the originating issue number).
+- **Commit author**: `Qi Zhang <zhangqi444@gmail.com>` per *Author convention*.
+- **PR body** must cite (a) the originating issue number(s), (b) every upstream URL re-verified, (c) the version bump rationale.
+- After opening, label the issue `in-progress`. After merge, relabel `applied`.
+
+### 5. State-machine via labels
+
+| Label | Meaning |
+|---|---|
+| (none) | New issue, not yet triaged |
+| `triaged` | Identified template type + scope-checked; ready to validate |
+| `in-progress` | A PR is open against this issue |
+| `applied` | PR merged; issue resolved |
+| `needs-info` | Author needs to provide more before processing can continue |
+| `out-of-scope` | Software / request doesn't meet inclusion criteria; closed |
+
+Optionally also: `recipe:<name>`, `tier:1`, `tier:2`, `infra:<cloud>`, `runtime:<runtime>` for filtering.
+
+### 6. Conflicts and ambiguity
+
+- **Contradicting suggestions across issues**: prefer upstream-doc-verified content; cite the upstream URL in the PR explaining which suggestion was chosen and why.
+- **Ambiguous suggestion**: if the issue is unclear about what should change, comment asking for clarification with a deadline (e.g. *"reply within 14 days or this issue will be auto-closed"*) and label `needs-info`.
+- **Idempotency**: never re-process an issue already labeled `applied`. If the same recipe issue resurfaces under a new issue number, treat it as a fresh demand signal (counts toward Tier 2 → Tier 1 graduation per *Two-tier coverage model*).
+
+---
+
+## Companion skills & MCPs
+
+open-forge orchestrates *upstream-blessed* deployment paths. To do that well, recipes are encouraged to depend on companion skills/MCPs as soft dependencies — declared in prose, not enforced. The filter is one question:
+
+> Does this tool help me **drive** an upstream-supported deploy path more reliably?
+
+| Shape | Stance | Examples |
+|---|---|---|
+| **Operators** — read state, query docs, drive existing CLIs more accurately | ✅ Embrace | `awsdocs` MCP, `gcp-docs` MCP, `cloudflare` MCP, GitHub MCP (fetch upstream `docker-compose.yml` / `charts/`), k8s state-query MCPs |
+| **Generators** — author config from scratch | ❌ Avoid by default | `dockerfile-generator`, `k8s-yaml-generator`, `helm-generator`, `terraform-generator`. Only justified when upstream genuinely ships nothing and we deliberately wrap. |
+| **Plain CLIs** | ✅ Default substrate | `docker`, `kubectl`, `helm`, `aws`, `gcloud`, `az`, `gh`, `ssh`, `terraform` |
+
+How to reference companion tooling — **fallback hierarchy**, in order of preference:
+
+1. **Companion skill/MCP**, if available. Name it in SKILL.md / recipe body in prose: *"If the k8s state MCP is available, use it to confirm pod readiness; otherwise parse `kubectl get pods -o json`."* Claude uses it when present, falls back gracefully when not.
+2. **Captured docs in `references/`**, if no skill/MCP exists. Distill the relevant upstream pages (Helm chart values, k8s CRD schema, AWS CLI flags for the specific service) into a focused reference under `references/modules/<topic>.md` or alongside the recipe. Cite the upstream URL as the source of truth — captured docs are a lossy snapshot, the link is the recovery path (principle #6).
+3. **Inline upstream-doc links** as a last resort, when even capture is overkill — let Claude WebFetch them on demand.
+
+Where to declare companion tooling:
+
+- **In recipe frontmatter**, optionally list `companion-skills:` / `companion-mcps:` as documentation (not enforced — no formal deps mechanism in plugin manifests yet).
+- **In `plugins/open-forge/.mcp.json`**, register MCPs the recipes depend on heavily so they install transparently with the plugin. Reserve this for read-only docs/state MCPs; never wrap deployment commands.
+- **For dev work on open-forge itself** (CI, settings audit, plugin packaging): use whatever skills help your local workflow (`gh-fix-ci`, `claude-settings-audit`) — these don't need to ship with the plugin.
+
+When a recipe is exercised end-to-end and a companion skill/MCP proved necessary — or a captured doc was added to `references/` — record it in the recipe's *Compatible runtimes* or a new *Companion tooling* note alongside upstream doc links. Same first-run discipline applies.
+
+## Recipe structure (must-have sections)
+
+Every `references/projects/<software>.md` should have:
+
+| Section | Purpose |
+|---|---|
+| **Frontmatter** (name + description) | Loaded into context whenever the skill triggers. Keep concise; this is for Claude, not the user. |
+| **Inputs to collect** (table keyed by phase) | Exact prompts, structured-choice options, defaults. So the same recipe is consistent across runs. |
+| **Compatible runtimes** | Which runtime modules this software supports + recommended default |
+| **Phase applicability** | Which of preflight/provision/dns/tls/smtp/inbound/hardening apply or skip |
+| **Per-phase content** | Project-specific commands, config patches, verification checks |
+| **Gotchas (consolidated)** | One-line summaries of every non-obvious thing learned in production. Single source of truth. |
+| **TODO — verify on subsequent deployments** | Open questions to resolve on the next real deploy. Empty = recipe is fully validated. |
+
+`references/runtimes/<name>.md` and `references/infra/<name>.md` mirror this with their own scope (no `Inputs to collect` for infra usually — preflight handles AWS profile/region; infra adds bundle/region-specific bits).
+
+## First-run discipline
+
+When a recipe is exercised end-to-end against a real deployment for the first time:
+
+1. Capture every gotcha that surprised us into the recipe's *Gotchas* section.
+2. Resolve / delete TODO items as they're answered.
+3. Update the deployment state file's phase notes.
+4. Bump `plugin.json` `version` (see *Versioning* below).
+5. Commit.
+
+This is how the recipe stops being a guess and becomes a known-working deployment template. Don't skip it.
+
+The dominant path for first-run discipline is now **user-submitted feedback issues** processed per *Processing incoming issues* — the skill drafts a sanitized issue at the end of each deploy and the user opts in to share. Maintainer-driven deploys (where the maintainer is also the recipe author) still apply for new recipes. Either way, the same five-step capture applies.
+
+## File layout
+
+```
+open-forge/
+├── CLAUDE.md                              ← you are reading
+├── README.md                              ← user-facing, lives on GitHub
+├── LICENSE                                ← MIT
+├── .claude-plugin/marketplace.json        ← marketplace manifest
+└── plugins/open-forge/
+    ├── .claude-plugin/plugin.json         ← plugin manifest (version!)
+    └── skills/open-forge/
+        ├── SKILL.md                       ← end-user-Claude entrypoint
+        ├── references/
+        │   ├── projects/<name>.md         ← software layer
+        │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
+        │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
+        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
+        └── scripts/                       ← reused operational scripts; empty by default
+```
+
+`scripts/` stays empty unless something is reused 3+ times across deployments. Inline commands in recipes are clearer for one-off use.
+
+## Versioning + publish flow
+
+`plugin.json` `version` controls what the Claude Code marketplace fetches.
+
+- **Bump on**: skill description change, new project/runtime/infra, major recipe rewrite, anything that changes user-visible behavior.
+- **Don't bump on**: typo fixes, internal comment cleanups, lint-only changes.
+
+Publish flow (typical path: AI session processing an issue per *Issue-driven contribution model*):
+
+1. Commit the change with version bump if applicable. Author per *Author convention*.
+2. Push to `github.com/zhangqi444/open-forge` — typically as a PR opened against `main` (branch name per *Processing incoming issues*).
+3. After merge, end users run `/plugin marketplace update zhangqi444/open-forge` then re-install.
+
+Maintainer manual edits follow the same flow but skip the issue-tracking labels.
+
+## Author convention
+
+Commits authored as `Qi Zhang <zhangqi444@gmail.com>` — set inline via env vars (`GIT_AUTHOR_NAME`, `GIT_AUTHOR_EMAIL`, `GIT_COMMITTER_NAME`, `GIT_COMMITTER_EMAIL`), **don't write to git config**.
+
+## Refactor (started 2026-04-24, completed 2026-04-26)
+
+Initial state collapsed three axes into linear "Path A/B/C" inside `openclaw.md`, which hid valid combos and biased preflight toward AWS even for non-AWS deployments. Migrated to the 3-layer file layout above. Order:
+
+1. ✅ CLAUDE.md model locked in (this section).
+2. ✅ Preflight refactor — branch on infra choice; only require AWS CLI when infra ∈ AWS.
+3. ✅ Skeleton infra adapters: `infra/aws/lightsail.md` (Bitnami + OpenClaw blueprints share this; the blueprint-vs-Ubuntu split is a project-recipe concern, not a separate adapter), `infra/aws/ec2.md`, `infra/azure/vm.md`, `infra/hetzner/cloud-cx.md`, `infra/digitalocean/droplet.md`, `infra/gcp/compute-engine.md`, `infra/oracle/free-tier-arm.md`, `infra/hostinger.md`, `infra/raspberry-pi.md`, `infra/macos-vm.md`, `infra/byo-vps.md`, `infra/localhost.md`, plus a PaaS family under `infra/paas/`: `fly.md`, `render.md`, `railway.md`, `northflank.md`, `exe-dev.md`.
+4. ✅ Runtime modules: `runtimes/docker.md`, `runtimes/podman.md`, `runtimes/native.md`, `runtimes/kubernetes.md`. Docker + native extracted from openclaw.md Paths B and C; kubernetes added when openclaw upstream's Kustomize-based path was wired in; podman added in v0.8.0.
+5. ✅ Slim down `projects/openclaw.md` — software-layer concerns only; reference runtimes + infra modules for everything else. v0.8.0: corrected the Kubernetes section to be Kustomize-first (matches upstream `scripts/k8s/deploy.sh`); added Podman, ClawDock, Ansible, Nix, and Bun (experimental) sections; combo table now enumerates every upstream-blessed install method documented under `docs.openclaw.ai/install/*`.
+6. ✅ Add `modules/tunnels.md` for localhost public-reach (Cloudflare Tunnel / Tailscale / ngrok).
+7. ✅ Update SKILL.md, README.md support tables and prompts. Bump plugin version (→ 0.8.0).
+
+Path A/B/C terminology retired. Future work tracked in each adapter's *TODO — verify on subsequent deployments* section, not here. Cluster-provisioning adapters (EKS / GKE / AKS / DOKS) are intentionally not in scope — open-forge orchestrates an existing cluster; users own cluster create/delete in their cloud's k8s UI. Cloud-VM adapters and PaaS adapters added in v0.8.0 are documented from upstream docs only — none has been exercised end-to-end yet; first-run discipline (CLAUDE.md § *First-run discipline*) applies as those deployments happen.
+
+## Behavioral guidelines (echoes of bota CLAUDE.md, kept here for autonomy)
+
+- **Think before coding.** State assumptions; ask when uncertain; surface tradeoffs.
+- **Simplicity first.** Minimum recipe content that works; no speculative abstractions.
+- **Surgical changes.** When updating a recipe after a deploy, change only what the deploy taught us. Don't "improve" adjacent sections.
+- **Goal-driven execution.** A recipe edit is "done" when the next deploy can use it without manual fixes.
+- **Documentation updates** (the recipes themselves) are a deliverable of every deployment, not a follow-up.
+
+
+---
+
+---
+name: open-forge
+description: Automate self-hosting of open-source apps on cloud infrastructure the user owns. Use when the user asks to "self-host", "deploy to my own cloud", "install X on AWS / Lightsail / EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / Kubernetes / Fly.io / Render / Railway / Northflank / exe.dev", "set up my own Ghost blog / Mastodon / WordPress / Nextcloud", wants to deploy the self-hosted personal AI agent **OpenClaw** (openclaw.ai — NOT the Captain Claw platformer game) or **Hermes-Agent** (Nous Research's self-improving AI agent at github.com/NousResearch/hermes-agent), wants to run **Ollama** (local-LLM inference server at ollama.com — pairs with every AI agent / chat UI as an OpenAI-compatible provider), wants to run **Open WebUI** (feature-rich self-hosted ChatGPT-like UI at github.com/open-webui/open-webui — pairs natively with Ollama and any OpenAI-compatible backend; adds RAG, web search, image gen, voice, multi-user), wants to run **Stable Diffusion WebUI** / **Automatic1111** / **A1111** (the most-popular open-source AI image generator at github.com/AUTOMATIC1111/stable-diffusion-webui — text-to-image, img2img, inpainting, ControlNet, LoRA; pairs with Open WebUI as an image-gen backend), wants to run **ComfyUI** (node-based AI image / video generation at github.com/comfyanonymous/ComfyUI — power-user alternative to A1111 with workflow graphs; same models, different UX; pairs with Open WebUI as image-gen backend), wants to deploy **Dify** (open-source LLMOps + AI app builder at github.com/langgenius/dify — visual workflow builder, RAG, multi-tenant; the "build a SaaS-grade AI app" platform, different category from chat UIs), wants to deploy **LibreChat** (multi-provider chat UI with deep enterprise plumbing at github.com/danny-avila/LibreChat — alternative to Open WebUI for teams; multi-user with social logins, per-user balance + transactions, agents + MCP, dedicated rag_api), wants to deploy **AnythingLLM** (RAG-focused workspace + agent platform at github.com/Mintplex-Labs/anything-llm — drop-in PDFs + URLs + GitHub repos, ask questions over them; built-in LanceDB; Desktop App + Docker + 8 cloud one-clicks), wants to install **Aider** (AI pair-programming CLI at github.com/Aider-AI/aider — runs in the terminal next to a git repo, edits files via diffs, auto-commits; pairs with any LLM provider including Ollama for local), wants to deploy **vLLM** (production-grade LLM inference server at github.com/vllm-project/vllm — high-throughput multi-tenant serving with PagedAttention + tensor parallelism + prefix caching; NVIDIA / AMD / Intel / CPU; Docker / Kubernetes / Helm / PaaS), wants to deploy **Langfuse** (open-source LLM engineering platform at github.com/langfuse/langfuse — observability, evals, prompt management, datasets, scoring; v3 six-service architecture with Postgres + ClickHouse + Redis + S3; Docker Compose, Kubernetes Helm chart, first-party Terraform modules for AWS / GCP / Azure, Railway one-click), or names any combination of an open-source app and a cloud provider. Walks the user through provisioning, DNS, TLS, outbound email (SMTP), and inbound email, in phases that are resumable across sessions via a state file at `~/.open-forge/deployments/<name>.yaml`. Supported today: Ghost on AWS Lightsail (Bitnami blueprint); OpenClaw via every upstream-blessed path documented at docs.openclaw.ai/install/* — AWS Lightsail blueprint, Docker Compose, Podman, Kubernetes (Kustomize), native installers (install.sh / install-cli.sh / install.ps1), ClawDock, Ansible, Nix, Bun, plus per-host adapters for AWS EC2 / Azure / Hetzner / DigitalOcean / GCP / Oracle Cloud / Hostinger / Raspberry Pi / macOS-VM (Lume) / BYO Linux server / localhost / Fly.io / Render / Railway / Northflank / exe.dev. More projects and infras added under `references/projects/` and `references/infra/`.
+---
+
+# open-forge
+
+## Overview
+
+Walk a user from "I have a cloud account and a domain" to "working app at `https://my.domain` with TLS and mail." Load the appropriate project recipe and infra adapter based on the user's stated intent; run phases sequentially; record state so the user can resume later.
+
+> **Platform note:** this skill is designed for Claude Code but the content is platform-agnostic. Tool names like `AskUserQuestion`, `WebFetch`, and `mcp__github__*` are Claude Code-specific — read them as *capabilities* (structured-choice prompt, URL fetch, GitHub API) and use whichever equivalent your platform exposes. See [`docs/platforms/`](../../../../docs/platforms/) in the repo for per-platform integration guides (Codex / Cursor / Aider / Continue / generic).
+
+## Operating principle
+
+**Claude does the work; the user makes the choices.** open-forge replaces the traditional "read a README, copy-paste 30 lines of bash, debug for hours" experience with a guided chat where Claude executes everything via the user's local CLI tools (aws, ssh, jq, curl) and only stops to ask when input is genuinely required.
+
+What this means in practice:
+
+- **Run, don't print.** When a recipe contains a bash block, *Claude executes it*. Announce it in one sentence first ("Opening port 22 in the Lightsail firewall now."), then run. Don't paste the block into chat for the user to run.
+- **Ask for choices and credentials only.** Things only the user can decide or provide: AWS profile name, domain choice, canonical www-vs-apex, SMTP API key, model provider preference. Everything else (which jq command to run, which sed pattern to apply, which IAM script URL to fetch) Claude figures out from the recipe.
+- **One question at a time when possible.** Use a structured-choice prompt for multiple-choice / single-select (Claude Code: `AskUserQuestion`; on other platforms, ask in prose with options listed). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
+- **Auto-install with confirmation, not silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run it. Never `sudo apt-get install` without asking.
+- **The recipe files in `references/projects/` and `references/infra/` are guidance for Claude, not pages for the user to read.** Keep that lens when extending or refactoring.
+
+## What's supported
+
+Check `references/projects/` and `references/infra/` for available recipes/adapters. As of this writing:
+
+Supported **software**:
+
+| Software | What it is |
+|---|---|
+| Ghost | Self-hosted blogging platform |
+| OpenClaw | Self-hosted personal AI agent (openclaw.ai — NOT the Captain Claw platformer game) |
+| Hermes-Agent | Self-improving personal AI agent from Nous Research (github.com/NousResearch/hermes-agent). Native (`scripts/install.sh`), Docker, Nix, manual-dev, Termux (Android), Homebrew. Includes `hermes claw migrate` for OpenClaw users. |
+| Ollama | Local-LLM inference server (ollama.com). Foundation layer — pairs with OpenClaw / Hermes / Open WebUI / LibreChat / Aider / etc. as an OpenAI-compatible provider. Native (`install.sh` / `install.ps1` / `.dmg` / `.exe`), Docker (CPU + NVIDIA + AMD ROCm + Vulkan), Kubernetes (community Helm chart), Homebrew, Nix, Pacman. |
+| Open WebUI | Feature-rich web UI for any OpenAI-compatible LLM backend (github.com/open-webui/open-webui). Multi-user, RAG, web search, image gen, voice, MCP. Pairs naturally with Ollama. Docker (`:main` / `:cuda` / `:ollama` / `:dev` tags), docker-compose (with bundled or external Ollama), pip (Python 3.11), Kubernetes (community Helm). |
+| Stable Diffusion WebUI (A1111) | The most-popular open-source AI image generator (github.com/AUTOMATIC1111/stable-diffusion-webui). Pairs with Open WebUI as an image-gen backend. Native (`webui.sh` Linux/macOS, `webui-user.bat` Windows, `sd.webui.zip` one-click), GPU paths for NVIDIA CUDA / AMD ROCm Linux / AMD DirectML Windows fork / Apple Silicon MPS, plus community-maintained Docker images (AbdBarho recommended). |
+| ComfyUI | Node-based AI image / video generation (github.com/comfyanonymous/ComfyUI). Power-user alternative to A1111; same models, workflow-graph UX. Pairs with Open WebUI as image-gen backend. Desktop App (Windows/macOS), Windows portable 7z (NVIDIA / AMD / Intel variants), `comfy-cli`, manual install, plus broad GPU support (NVIDIA CUDA, AMD ROCm Linux + Windows nightly, Intel Arc XPU, Apple Silicon MPS) and community Docker (AbdBarho `comfy` profile, yanwk/comfyui-boot). |
+| Dify | Open-source LLMOps + AI app builder platform (github.com/langgenius/dify). Visual workflow builder, RAG with many vector-DB backends (Weaviate / Qdrant / Milvus / pgvector / Elasticsearch / OpenSearch / Couchbase / Chroma / +more), multi-tenant, plugin marketplace. Different category from chat UIs — Dify is the platform for *building* AI products. Docker Compose (canonical, ~12 services), Kubernetes via community Helm, source code, aaPanel one-click, plus cloud templates (Azure / GCP Terraform, AWS CDK for EKS/ECS, Alibaba Computing Nest). |
+| LibreChat | Multi-provider chat UI with deep enterprise plumbing (github.com/danny-avila/LibreChat). Multi-user with social logins (GitHub / Google / Discord / OIDC / SAML / Apple / Facebook), per-user balance + transactions, agents + assistants + MCP, RAG via pgvector + dedicated rag_api, web search, TTS/STT. Alternative to Open WebUI for teams. Docker Compose dev (`docker-compose.yml`), Docker Compose prod (`deploy-compose.yml` + Nginx), npm / source, **first-party Helm chart** (`helm/librechat/` v2.0.2), plus one-click deploys for Railway / Zeabur / Sealos. |
+| AnythingLLM | Open-source RAG-focused workspace + AI agent platform (github.com/Mintplex-Labs/anything-llm). Workspace-style "drop a folder of PDFs, ask questions over them" UX with built-in LanceDB vector store (or external Pinecone / Weaviate / Qdrant / Chroma / Milvus / Astra / pgvector), built-in agents, MCP support, multi-user, embeddable chat widget. Docker (canonical, `docker/HOW_TO_USE_DOCKER.md`), Desktop App (Mac / Windows / Linux installers), bare-metal source install (per `BARE_METAL.md`, "not supported by core team" — flagged), plus upstream-published one-click cloud deploys for AWS CloudFormation / GCP Cloud Run / DigitalOcean Terraform / Render / Railway / RepoCloud / Elestio / Northflank. |
+| Aider | AI pair-programming CLI (github.com/Aider-AI/aider). Different category — runs in the developer's terminal alongside their git repo, edits files via diffs, auto-commits per change. Pairs with any LLM provider (Anthropic / OpenAI / DeepSeek / Gemini / OpenRouter / Ollama / vLLM / OpenAI-compatible). `aider-install` (recommended, isolated Python 3.12 env), uv-based one-liner script (Mac / Linux / Windows), uv direct, pipx, plain pip, plus Docker (`paulgauthier/aider` + `paulgauthier/aider-full`), GitHub Codespaces, and Replit. |
+| vLLM | Production-grade LLM inference server (github.com/vllm-project/vllm). Different niche from Ollama (single-user / hobby) — vLLM is for high-throughput multi-tenant serving with PagedAttention, tensor parallelism, prefix caching. NVIDIA CUDA (canonical) + AMD ROCm + Intel XPU/Gaudi + CPU variants (x86 / ARM / Apple Silicon / s390x), Docker (`vllm/vllm-openai`), Kubernetes (raw manifests + first-party Helm chart + LeaderWorkerSet for distributed inference), plus upstream PaaS cookbooks (SkyPilot / RunPod / Modal / Cerebrium / dstack / Anyscale / Triton). |
+| Langfuse | Open-source LLM engineering platform (github.com/langfuse/langfuse). LLM observability + evaluation + prompt management + datasets + scoring; cross-cutting layer that pairs with vLLM / Ollama (inference) and Open WebUI / LibreChat / AnythingLLM / Dify / Aider (apps). v3 architecture is six services (web, worker, Postgres, ClickHouse, Redis, MinIO/S3). Docker Compose (local + single-VM), Kubernetes Helm chart (`langfuse/langfuse-k8s`, recommended for prod), first-party Terraform modules for AWS (EKS + Aurora + ElastiCache + S3 + ALB), GCP (GKE + Cloud SQL + Memorystore + GCS + LB), Azure (AKS + PG-Flex + Redis + Storage + App Gateway), plus upstream-published Railway one-click. |
+
+Supported **infras** (under `references/infra/`):
+
+| Cloud / where | Adapter |
+|---|---|
+| AWS | `aws/lightsail.md` (Ghost Bitnami + OpenClaw blueprints), `aws/ec2.md` (general-purpose VM) |
+| Azure | `azure/vm.md` (Bastion-hardened, no public IP) |
+| Hetzner Cloud | `hetzner/cloud-cx.md` (CX-line VPS via `hcloud`) |
+| DigitalOcean | `digitalocean/droplet.md` (Droplet via `doctl`) |
+| GCP Compute Engine | `gcp/compute-engine.md` (VM via `gcloud`) |
+| Oracle Cloud | `oracle/free-tier-arm.md` (Always-Free A1.Flex ARM + Tailscale) |
+| Hostinger | `hostinger.md` (managed via hPanel — no CLI) |
+| Raspberry Pi | `raspberry-pi.md` (Pi 4/5 64-bit, ARM64) |
+| macOS VM (Apple Silicon) | `macos-vm.md` (Lume; for iMessage via BlueBubbles) |
+| Any Linux VM (other providers, on-prem) | `byo-vps.md` (SSH-only, no cloud APIs) |
+| Your own machine | `localhost.md` (Claude runs commands directly) |
+| Fly.io | `paas/fly.md` (`fly.toml` + persistent volume; public or private mode) |
+| Render | `paas/render.md` (`render.yaml` Blueprint, one-click) |
+| Railway | `paas/railway.md` (one-click template) |
+| Northflank | `paas/northflank.md` (one-click stack) |
+| exe.dev | `paas/exe-dev.md` (Shelley agent or manual nginx) |
+
+Supported **runtimes** (under `references/runtimes/`):
+
+| Runtime | Notes |
+|---|---|
+| Docker | `docker.md` — install Docker on host + lifecycle via docker-compose. Reusable across every infra. |
+| Podman | `podman.md` — rootless Docker-compatible alternative; Quadlet (systemd-user) supported. Reusable across every Linux/macOS infra. |
+| Native | `native.md` — OS prereqs, systemd / launchd / Scheduled-Tasks lifecycle, reverse-proxy guidance. Covers `install.sh` (macOS / Linux / WSL2), `install-cli.sh` (local-prefix, no root), and `install.ps1` (native Windows). |
+| Kubernetes | `kubernetes.md` — kubectl + Kustomize (preferred, what openclaw upstream uses) and Helm orchestration. open-forge does not provision clusters — point `kubectl` at one and we'll deploy into it. |
+| Vendor blueprints | Bundled into infra adapters (e.g. Lightsail Ghost-Bitnami, Lightsail OpenClaw) — runtime choice is the vendor's |
+
+## Selection — ask three questions
+
+Before provisioning, establish three things by asking (or inferring from the user's prompt):
+
+1. **What** to host? → loads `references/projects/<software>.md`
+2. **Where** to host? → loads `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`
+3. **How** to host? → loads the matching `references/runtimes/<runtime>.md` (skipped if the infra bundles the runtime, e.g. vendor blueprints)
+
+The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Ask a structured-choice question only when genuinely ambiguous.
+
+Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
+
+## Tier 1 vs Tier 2 routing
+
+open-forge ships a finite catalogue of verified recipes (Tier 1) plus a documented fallback for the long tail (Tier 2). When the user names a piece of software, decide which tier you're in **before** loading anything.
+
+### Tier 1 — verified recipe exists
+
+If `references/projects/<name>.md` matches the user's software, you're in Tier 1. Load it, follow it, and stay in the standard workflow below.
+
+### Tier 2 — no recipe; derive from upstream live
+
+If no recipe matches, **don't refuse — fall back to Tier 2**:
+
+1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
+2. **Fetch upstream the same way Tier 1 does**:
+   - Fetch the upstream README first via the platform's URL-fetch capability (Claude Code: `WebFetch`; Cursor: `@Web`; Aider/generic: `curl` via shell). If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
+   - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
+   - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
+3. **Reuse the existing modules**: drive the Docker install via `runtimes/docker.md`, Kubernetes via `runtimes/kubernetes.md`, VM provisioning via `infra/<cloud>/*.md`, DNS / TLS / SMTP via `references/modules/`. The Tier 2 work is only the software-specific bits on top.
+4. **Cite every upstream URL** in chat the same way Tier 1 sections do (`> Source: <url>`).
+5. **Offer to capture the result** as a new Tier 1 recipe once the deploy succeeds — that's how the catalogue grows. Captured recipes must go through first-run discipline before promotion.
+
+**Quality boundary:** Tier 2 output is best-effort, not authoritative. It will hallucinate at the edges of upstream docs we couldn't fetch and skips the real-deploy refinement Tier 1 recipes get. Always tell the user which tier you're in; never silently mix.
+
+### Out-of-scope software
+
+Some user requests are not deployable services at all (libraries like Unsloth or `requests`, desktop apps like Slack, SaaS like Notion). When you detect this, say so clearly and offer the closest in-scope alternative if there is one. See CLAUDE.md § *Is this software in scope?* for criteria.
+
+## Phased workflow
+
+Each phase is verifiable and resumable. Do NOT batch phases — complete, verify, and update state before moving on.
+
+```
+1. preflight     → check prerequisites (CLI tools, profiles, domain ownership); collect inputs
+2. provision     → create instance, allocate + attach static IP, retrieve SSH key
+3. dns           → print exact DNS records for user to add at registrar; poll until resolved
+4. tls           → obtain Let's Encrypt cert, fix reverse proxy, switch app URL to https
+5. smtp          → configure outbound email provider; verify a test send
+6. inbound       → (optional) set up forwarding or mailbox
+7. hardening     → rotate default admin creds, rotate any secrets pasted into chat
+```
+
+Infra adapter defines *how* to do each phase (what CLI commands to run). Project recipe defines *what's specific* about that app (config file paths, gotchas, mail block shape). Cross-cutting steps — DNS guidance, Let's Encrypt, SMTP providers, inbound forwarders — live in `references/modules/` and are loaded as needed.
+
+## State file
+
+Every deployment has a YAML state file at:
+
+```
+~/.open-forge/deployments/<name>.yaml
+```
+
+Shape:
+
+```yaml
+name: my-blog
+project: ghost
+infra: lightsail
+inputs:
+  aws_profile: qi-experiment
+  aws_region: us-east-1
+  domain: ariazhang.org
+  canonical: www  # or "apex"
+  letsencrypt_email: user@example.com
+outputs:
+  instance_name: my-blog
+  static_ip_name: my-blog-ip
+  public_ip: 54.156.69.42
+  ssh_key_path: ~/.ssh/lightsail-default.pem
+  admin_url: https://www.ariazhang.org/ghost
+phases:
+  preflight:   { status: done,  at: "2026-04-22T19:00Z" }
+  provision:   { status: done,  at: "2026-04-22T19:10Z" }
+  dns:         { status: done,  at: "2026-04-22T19:25Z" }
+  tls:         { status: done,  at: "2026-04-22T19:30Z" }
+  smtp:        { status: done,  at: "2026-04-22T20:05Z" }
+  inbound:     { status: skipped }
+  hardening:   { status: pending }
+```
+
+At the start of each session: if a state file exists for the named deployment, read it and resume from the first non-done phase. If the user says "start over", confirm destructively before unlinking.
+
+## Execution mode
+
+Default: **autonomous** — run AWS CLI, SSH, and file edits directly. Announce each external command in one sentence before running. Never fabricate outputs.
+
+Flag: **`--dry-run`** — print what would be done, do not execute. Useful for review.
+
+Commands that cross trust boundaries (paste secrets into config files, send real emails, spend money) should be announced and, when ambiguous, confirmed.
+
+## Inputs
+
+Inputs split across three layers:
+
+- **Cross-cutting (all deployments)** — handled by `references/modules/preflight.md`: AWS profile, region, deployment name, tool install confirmations.
+- **Infra-specific** — handled by the loaded infra adapter (e.g. `references/infra/lightsail.md`): bundle/blueprint choice, SSH key path defaults.
+- **Project-specific** — handled by the loaded project recipe (e.g. `references/projects/ghost.md`): domain, canonical preference, Let's Encrypt email, SMTP provider + API key, model provider, etc.
+
+Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use a structured-choice prompt where the platform supports one (Claude Code: `AskUserQuestion`; otherwise prose with options listed).
+
+## Asking for credentials
+
+Whenever the skill needs sensitive input — API keys, DB passwords, OAuth client secrets, cloud creds, SSH key paths — load `references/modules/credentials.md` and offer the **five patterns** (priority order):
+
+| # | Pattern | What user gives |
+|---|---|---|
+| 1 | Local file path | path to file containing the secret (skill `cat`s it) |
+| 2 | Env var name | name of an env var the user pre-exported (skill reads `$<NAME>`) |
+| 3 | Cloud-CLI session | "I've already run `aws sso login` for profile `<name>`" |
+| 4 | Secrets-manager ref | `op://Personal/Resend/api-key`, `vault://...`, `bw://...` (skill calls matching CLI) |
+| 5 | Direct paste | **last resort** — skill surfaces risk, accepts after explicit yes, reminds to rotate at hardening |
+
+**Never silently accept a paste.** When the skill detects sensitive input is needed, it should:
+
+1. **Offer the five patterns** with the credential class noted (e.g. *"I need a Resend API key — pick how to provide it: file path, env var, secrets-manager ref, or paste (last resort)"*).
+2. **Validate** before using:
+   - File path → `test -r <path>` + check mode is `≤ 600` (offer `chmod 600` if wider).
+   - Env var → `test -n "$<NAME>"` (refuse if empty; if user `export`ed after Claude Code started, ask them to restart).
+   - Cloud-CLI → smoke-command (e.g. `aws sts get-caller-identity --profile <name>`).
+   - Secrets-manager → smoke-command (`op read --no-newline <ref>`, `vault kv get`, etc.).
+   - Paste → require explicit risk acknowledgement first.
+3. **Detect accidental pastes**: if the user was prompted for a path but pasted a string matching `re_*` / `sk-*` / `AKIA[0-9A-Z]{16}` / etc., stop and ask: *"That looks like the key itself, not a path. Did you mean to paste directly? (see risks)"*.
+4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
+5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
+
+See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
+
+## Verification after each phase
+
+| Phase | Verify with |
+|---|---|
+| provision | `aws lightsail get-instance ... --query 'instance.state'` is `running`; SSH to `<user>@<ip>` succeeds |
+| dns | `dig +short <domain> @1.1.1.1` returns the static IP for apex AND the canonical host |
+| tls | `curl -sI https://<domain>/` returns 2xx/3xx with a valid cert; browser loads without warnings |
+| smtp | Send a test email from the app's admin UI; confirm arrival in the recipient inbox and in the provider's log |
+| inbound | Send a test email to the configured alias; confirm it lands in the destination inbox |
+
+Never mark a phase `done` without verification.
+
+## Post-deploy feedback (closes the catalogue evolution loop)
+
+After `hardening` (or after the user explicitly says "we're done", or after they abort mid-phase and want to share what they learned), offer to file a GitHub issue with the deployment notes. Per CLAUDE.md § *Issue-driven contribution model*, this is how the catalogue evolves — the bot or a future Claude session reads these issues and patches the recipes.
+
+Three flows the user can trigger from this prompt:
+
+1. **Recipe feedback** (default at end of deploy) — submit gotchas, suggested edits, or "the recipe was outdated". Claude self-summarizes from the session; the user reviews + opts in.
+2. **Software nomination** — when the user asked to deploy something not in the catalogue and Tier 2 worked, offer to nominate it for Tier 1.
+3. **Method proposal** — when the user discovered an upstream-supported install method the recipe doesn't cover.
+
+### The flow (multi-step consent — never auto-post)
+
+Load `references/modules/feedback.md` for the full sanitization rules + draft templates + submission paths. Summary:
+
+1. **Opt-in prompt**:
+   - Recipe feedback: *"Want to share what you learned with the open-forge project? I can draft a sanitized GitHub issue with the gotchas + suggested edits — you review, then post."*
+   - Software nomination (Tier 2 deploy): *"This software isn't in the Tier 1 catalogue yet. Want to nominate it? I'll draft an issue with the rationale + upstream URLs."*
+   - User must explicitly opt in (no auto-post).
+2. **Self-summarize the session**:
+   - Which recipe + combo was used, plugin version.
+   - Which phases ran, which retried, which failed.
+   - Where the user got prompted unexpectedly (gaps in the recipe).
+   - Any gotchas Claude observed (commands that failed, error messages, deviations from the documented path).
+3. **Draft the issue** in the format from `references/modules/feedback.md`:
+   - Specific recipe-edit suggestions (preferred: as a diff), not free-prose.
+   - All identifiers redacted per CLAUDE.md § *Sanitization principles*.
+4. **Show the redacted draft in chat — full text — before any submission attempt.**
+5. **Standing reminder**: *"GitHub issues are public and permanent. Once posted, this can't be unposted. Review every line; if anything looks identifiable to you, edit before posting. By submitting, you grant a non-revocable license to use this content in the recipe; the project bears no liability for your decision to share."*
+6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
+7. **Submit via the first available path**:
+   - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
+   - Platform-native GitHub integration if available (Claude Code: `mcp__github__issue_write`; Cursor / generic: GitHub MCP server if installed).
+   - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
+
+### Sanitization is mandatory
+
+Per CLAUDE.md § *Sanitization principles* — strip every domain, IP, SSH key path, API key, AWS account ID, email address, state-file content, and anything from the user's clipboard / env vars before showing the draft. Use the patterns + replacements documented in `references/modules/feedback.md`.
+
+If you find something in the draft that you can't confidently classify as safe, **redact it** rather than ship it. The user's review pass is a safety net, not the only line of defense.
+
+### When to skip
+
+- User says "no thanks" or doesn't reply → drop it, don't pester.
+- Deploy aborted very early (before any state was created) → no useful feedback to capture; skip.
+- Tier 2 deploy that obviously wasn't in scope (e.g. user tried to "self-host" a library) → don't nominate; politely explain it's out of scope per CLAUDE.md § *Is this software in scope?*.
+
+## Common pitfalls across infras/projects
+
+- **Stale DNS**: browsers cache 301 responses with long max-age. After any HTTP↔HTTPS or apex↔www redirect change, suggest hard reload or incognito.
+- **Host key mismatch on new static IP**: the first SSH to a freshly-allocated IP needs `-o StrictHostKeyChecking=accept-new`; don't blindly blow away `~/.ssh/known_hosts` entries.
+- **Non-interactive cert tools**: some have quirky option-file or flag requirements. See the project recipe — do not assume `--unattended` works.
+- **Reverse-proxy misconfig after switching to https URL**: apps that enforce HTTPS redirects from the `url` config need `X-Forwarded-Proto` and `Host` preserved. See `references/modules/tls-letsencrypt.md`.
+
+## Adding a new project or infra
+
+A new project: add `references/projects/<name>.md` covering required services, config file paths, mail config shape, and any install/upgrade quirks. Follow the structure of the existing ghost.md.
+
+A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
+
+Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.
+
+
+---
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.
+
+
+---
+
+---
+name: feedback
+description: Post-deploy feedback module — sanitization rules + draft templates + submission paths for the three GitHub-issue input channels (recipe-feedback / software-nomination / method-proposal). Loaded by SKILL.md § Post-deploy feedback.
+---
+
+# Feedback module — drafting + submitting GitHub issues
+
+This module is loaded after a deploy completes (or is abandoned) when the user opts in to share what they learned. Implements the multi-step consent flow described in CLAUDE.md § *Sanitization principles* and SKILL.md § *Post-deploy feedback*.
+
+**Hard rule:** never post without showing the redacted draft + getting explicit "yes" from the user. The skill is the user's submitter; consent gates everything.
+
+---
+
+## Sanitization checklist
+
+Apply BEFORE drafting. Scan the deployment session — including chat transcript, any tool outputs Claude has in context, any state-file references — and replace identifiers per the table.
+
+### Strip-list (regex patterns + replacements)
+
+| Class | Detection | Replacement |
+|---|---|---|
+| **Domains** (apex, www, admin) | Anything matching the user's `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` collected during inputs, plus generic FQDNs in URL paths the user typed | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| **Public IPv4** | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (excluding RFC-1918 ranges if you want to allow them as `${PRIVATE_IP}`) | `${PUBLIC_IP}` |
+| **Private IPv4** | `\b(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)[0-9.]+\b` | `${PRIVATE_IP}` (or strip if it leaks network topology) |
+| **IPv6** | Standard IPv6 patterns | `${PUBLIC_IPV6}` / `${PRIVATE_IPV6}` |
+| **SSH key paths** | Anything matching `~/.ssh/[^ ]+`, `/home/[^/]+/\.ssh/[^ ]+`, `*.pem`, `*.priv`, `id_(rsa|ed25519|ecdsa)` | `${KEY_PATH}` |
+| **SSH key contents** | `-----BEGIN [A-Z ]+ KEY-----` blocks | `<REDACTED-SSH-KEY>` |
+| **Resend API key** | `re_[A-Za-z0-9_]+` | `<REDACTED-RESEND-KEY>` |
+| **SendGrid API key** | `SG\.[A-Za-z0-9._-]+` | `<REDACTED-SENDGRID-KEY>` |
+| **OpenAI API key** | `sk-[A-Za-z0-9]{20,}` | `<REDACTED-OPENAI-KEY>` |
+| **Anthropic API key** | `sk-ant-[A-Za-z0-9_-]{20,}` | `<REDACTED-ANTHROPIC-KEY>` |
+| **Slack tokens** | `xox[bp]-[A-Za-z0-9-]+` | `<REDACTED-SLACK-TOKEN>` |
+| **GitHub PAT** | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]+` | `<REDACTED-GH-PAT>` |
+| **AWS access key ID** | `AKIA[0-9A-Z]{16}` | `<REDACTED-AWS-KEY>` |
+| **AWS secret key** | After `aws_secret_access_key`, 40-char base64 | `<REDACTED-AWS-SECRET>` |
+| **AWS account ID** | 12 consecutive digits in AWS context (ARN, account-id field) | `${AWS_ACCOUNT}` |
+| **AWS profile name** | Whatever the user collected as `aws_profile` during inputs | `${AWS_PROFILE}` |
+| **GCP service-account JSON** | `"type": "service_account"` blocks | `<REDACTED-GCP-SA>` |
+| **Generic Bearer token** | `Bearer [A-Za-z0-9._~+/=-]{20,}` | `<REDACTED-BEARER>` |
+| **Email addresses** | RFC-822 pattern; especially the LE email + SMTP from-address + any user identity email | `${EMAIL}` |
+| **State-file contents** | Anything from `~/.open-forge/deployments/<name>.yaml` raw | Reference by deployment name only, never paste contents |
+| **MySQL/Postgres password** | After `password=` / `--password ` / `IDENTIFIED BY ` | `<REDACTED-DB-PASSWORD>` |
+| **OAuth client secrets** | After `client_secret` / `CLIENT_SECRET` | `<REDACTED-CLIENT-SECRET>` |
+| **Random bytes from `openssl rand -hex N`** that the user generated as a secret | Long hex strings used as secrets | `<REDACTED-RANDOM-SECRET>` |
+
+### Manual review pass (after regex)
+
+After regex-based sanitization, do a final read-through looking for:
+
+- **Hostnames in URL paths** that contain the user's domain (sed/regex may have missed embedded URLs).
+- **Username conventions** that are personally identifiable (e.g. `qi-experiment` as an AWS profile).
+- **Stack-trace lines** containing absolute filesystem paths (`/home/<user>/...`).
+- **Anything pasted from the user's clipboard or env vars** that wasn't covered by the strip-list.
+
+If you can't confidently classify something as safe, **redact it** — the user's final review is a safety net, not the only line of defense.
+
+### What you may keep
+
+| Class | OK to keep | Why |
+|---|---|---|
+| Recipe filenames (`ghost.md`, `openclaw.md`) | ✅ | Public; needed for context |
+| Plugin version (`0.20.0`) | ✅ | Public; needed for triage |
+| Combo names (`Ghost-CLI on Ubuntu`, `DigitalOcean droplet`) | ✅ | Public; needed for context |
+| Generic error messages quoted from upstream tools | ⚠️ | OK if no identifiers; redact paths and IPs from stack traces |
+| `${VAR}` placeholders | ✅ | These are the redactions; they're fine |
+| Public repo URLs (upstream docs you're proposing to add) | ✅ | Public |
+
+---
+
+## Draft templates
+
+Each template renders into the matching `.github/ISSUE_TEMPLATE/*.yml` form. The structure mirrors the form fields so the user pastes the body and the form auto-validates the sanitization checkboxes.
+
+### Channel 1 — recipe feedback (default at end of deploy)
+
+```markdown
+**Recipe**: <recipe-filename>
+**Combo**: <infra adapter> / <runtime>
+**Plugin version**: <version-from-plugin.json>
+**Outcome**: <one-of: Deploy succeeded with notes / Deploy succeeded after retries / Deploy failed; recovered manually / Deploy failed; abandoned / Recipe was outdated>
+
+## What the recipe missed
+
+<Concrete description: what surprised you, what failed, what required manual intervention. Sanitized.>
+
+## Suggested edit (optional — diff format preferred)
+
+```diff
+@@ <section header from the recipe> @@
+- <line that was wrong / missing>
++ <line that should be there>
+```
+
+## Sanitization confirmation
+- [x] All domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses stripped from this issue body.
+- [x] I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+```
+
+### Channel 2 — software nomination (Tier 2 → Tier 1)
+
+```markdown
+**Software name**: <project>
+**Upstream repo**: <github URL>
+**Upstream install-method index**: <docs / repo path / wiki URL>
+**Intended deploy combo**: <infra> / <runtime>
+
+## Why Tier 1?
+
+<What's painful about this software's install that compounds across deploys?
+Per the demand-driven graduation criteria in CLAUDE.md, a Tier 1 recipe earns
+its keep when the captured tribal knowledge saves the next user real pain.>
+
+## In-scope check (per CLAUDE.md § Is this software in scope?)
+
+This software is: <one-of: deployable service / static-site generator / AI inference server / CI runner / storage backend / not sure>
+
+## Confirmation
+- [x] I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+- [x] This software has at least one upstream-documented install method or canonical install artifact in-repo.
+```
+
+### Channel 3 — method proposal
+
+```markdown
+**Recipe to extend**: <recipe-filename>
+**Method name**: <e.g. "Snap package", "Helm chart">
+**Upstream URL documenting this method**: <URL>
+**Source type**: <First-party — published by upstream / Community-maintained>
+
+## Canonical install command(s)
+
+```bash
+<paste verbatim from upstream>
+```
+
+## Why this method matters
+
+<When would a user pick this method over the existing options in the recipe?>
+
+## Confirmation
+- [x] I have verified the upstream URL above shows this install method on the current upstream version.
+- [x] No credentials, IPs, or other identifiers in this issue.
+```
+
+---
+
+## Submission paths (try in order)
+
+The skill never opens a browser silently or POSTs without explicit user confirmation. Three submission paths in priority order:
+
+### 1. `gh` CLI (preferred when available)
+
+```bash
+# Check if gh is authenticated for the right account
+gh auth status
+
+# If yes, submit
+gh issue create \
+  --repo zhangqi444/open-forge \
+  --title "<title from template>" \
+  --body-file /tmp/feedback-draft.md \
+  --label recipe-feedback,recipe:<name>
+```
+
+Strengths: works headlessly in chat; respects user's existing GitHub auth.
+
+Caveats: user must have `gh` installed + authenticated. If `gh auth status` errors, fall through to path 2.
+
+### 2. GitHub MCP server (if available)
+
+If `mcp__github__issue_write` is available in the tool list, use it:
+
+```
+mcp__github__issue_write({
+  method: "create",
+  owner: "zhangqi444",
+  repo: "open-forge",
+  title: "<title>",
+  body: "<full body>",
+  labels: ["recipe-feedback", "recipe:<name>"]
+})
+```
+
+Strengths: no `gh` install needed; uses the MCP server's auth.
+
+Caveats: only works if the MCP server is configured with appropriate scopes.
+
+### 3. Prefilled URL (always-available fallback)
+
+When neither `gh` nor the GitHub MCP works, generate a URL the user opens in a browser:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=<URL-encoded-title>&body=<URL-encoded-body>
+```
+
+Print the URL in chat with the instruction:
+
+> *"I can't post for you in this environment. Open this URL in a browser, review one more time, and click Submit:*
+>
+> *<URL>*
+>
+> *The form has the same sanitization checkboxes from the template — they'll be checked based on what you've already confirmed in chat."*
+
+URL-encode the title + body. GitHub URL length limit is ~8 KB total; if the body is longer, truncate the body and put the rest in a `<details>` block (or warn the user to paste it manually).
+
+---
+
+## Liability + license boilerplate (paste at end of every issue body)
+
+Append this exact block as the final paragraph of every issue body before submission:
+
+```markdown
+---
+
+> By submitting this issue, I grant a non-revocable license to the open-forge project to use this content in recipes and documentation. The open-forge project bears no liability for my choice to share. I have reviewed the issue body for credentials and personal information per CLAUDE.md § *Sanitization principles*.
+```
+
+This is in addition to the checkboxes in the issue-template form — it's an extra paper trail in the issue body itself.
+
+---
+
+## When the deploy aborted before completion
+
+If the user wants to file feedback about a deploy that failed mid-phase (e.g. preflight passed, provisioning failed at the security-group step), the `Outcome` field should be *"Deploy failed; abandoned"* and the body should include:
+
+- Which phase failed.
+- What the error was (sanitized — strip stack traces of paths/IPs).
+- What workaround the user attempted (if any).
+- Whether the user wants the recipe edited to handle this case, or whether they think it was an upstream / cloud-account issue (out of recipe scope).
+
+These are often the highest-value feedback issues — they catch recipes that succeed in the maintainer's environment but fail in others.
+
+---
+
+## Failure modes to watch for
+
+- **User says "post it" too quickly.** Respect their consent, but flag any line you weren't 100% sure about: *"Posting now. One last thing — line 14 mentions a username `qi-experiment` that might be your AWS profile name. Was that intentional?"*
+- **Drafts that quote upstream error messages with embedded user data.** Common with Bitnami's `bncert-tool` output, AWS CLI errors quoting account IDs in ARNs.
+- **State-file leaks.** If the user asks Claude to read `~/.open-forge/deployments/<name>.yaml` while drafting, do **not** paste contents — reference by deployment name only.
+- **Multiple rapid yes-clicks.** If the user says "yes, yes, yes, post" to skip the review, slow down: re-show the draft once, get confirmation, then submit. Speed is not a user safety feature.

--- a/docs/platforms/aider.md
+++ b/docs/platforms/aider.md
@@ -1,0 +1,103 @@
+# Using open-forge with Aider
+
+Aider is terminal-based AI pair programming. It's already in the open-forge catalog as a deployable target — and it can also be used as the *agent* that drives an open-forge deploy. Aider can `--read` files into context and follow `CONVENTIONS.md`-style guidance.
+
+## Install
+
+1. Clone open-forge:
+
+   ```bash
+   git clone https://github.com/zhangqi444/open-forge ~/code/open-forge
+   ```
+
+2. Generate the Aider-flavored bundle:
+
+   ```bash
+   cd ~/code/open-forge
+   ./scripts/build-dist.sh aider
+   # Outputs:
+   #   dist/aider/CONVENTIONS.md         (concatenated SKILL.md + CLAUDE.md core)
+   #   dist/aider/read-files.txt         (one-per-line file paths to --read)
+   #   dist/aider/.aider.conf.yml        (drop-in config)
+   ```
+
+## Invoke
+
+### One-shot (recommended for a single deploy)
+
+```bash
+aider --message "Self-host OpenClaw on a Hetzner CX22" \
+      --read ~/code/open-forge/dist/aider/CONVENTIONS.md \
+      $(cat ~/code/open-forge/dist/aider/read-files.txt | xargs -I{} echo "--read {}")
+```
+
+### Project-level (recurring deploys to the same target)
+
+Drop `dist/aider/.aider.conf.yml` into your project root:
+
+```yaml
+# .aider.conf.yml
+read:
+  - ~/code/open-forge/CLAUDE.md
+  - ~/code/open-forge/plugins/open-forge/skills/open-forge/SKILL.md
+  - ~/code/open-forge/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+  - ~/code/open-forge/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+
+auto-commits: false      # open-forge state files shouldn't be auto-committed
+```
+
+Then `aider` in that project loads open-forge automatically.
+
+### Conventions file
+
+Aider auto-loads `CONVENTIONS.md` from the project root. The bundle's `CONVENTIONS.md` distills SKILL.md + CLAUDE.md into Aider's preferred format:
+
+```bash
+cp ~/code/open-forge/dist/aider/CONVENTIONS.md /path/to/your/project/
+```
+
+## Tool translation
+
+| open-forge concept | Aider equivalent |
+|---|---|
+| `AskUserQuestion` (structured choice) | Aider asks via chat with bulleted options; user replies in terminal |
+| `WebFetch` | Aider doesn't have a native fetch tool; user pastes upstream doc content, or `aider` shells out to `curl` via the `/run` command |
+| `mcp__github__issue_write` | Aider's `/run gh issue create ...` — works if `gh` is authenticated locally |
+| Persistent state file | Same path; Aider operates on the file directly via its filesystem ops |
+
+## Limitations
+
+- **No native browser/fetch.** For Tier 2 deploys (live-derived from upstream docs), Aider can't fetch upstream pages on its own. Either (a) clone the relevant docs repo locally and `--read` the files, or (b) the user pastes upstream content into chat for Aider to use.
+- **Recipe loading is per-invocation.** Unlike Claude Code's auto-load on intent, Aider's `--read` is explicit. The `read-files.txt` approach loads everything; for large catalogs this fills context. Use per-recipe `--read` for tighter context.
+- **No structured `AskUserQuestion`.** Aider's chat interface is plain text; the agent will phrase questions as prose with options listed.
+
+## Example session
+
+```bash
+$ aider --message "Self-host OpenClaw on a Hetzner CX22 with Bedrock" \
+        --read ~/code/open-forge/dist/aider/CONVENTIONS.md \
+        --read ~/code/open-forge/plugins/open-forge/skills/open-forge/references/projects/openclaw.md \
+        --read ~/code/open-forge/plugins/open-forge/skills/open-forge/references/infra/hetzner/cloud-cx.md \
+        --read ~/code/open-forge/plugins/open-forge/skills/open-forge/references/runtimes/docker.md
+
+aider> Following the open-forge skill flow.
+
+       Combo: Hetzner Cloud CX × Docker (OpenClaw via the AWS Lightsail
+       blueprint isn't available on Hetzner — falling back to Docker
+       runtime + manual Bedrock IAM, see openclaw.md § AWS EC2 setup
+       for the IAM script).
+
+       For preflight: do you have your Hetzner API token in a file
+       or env var? (per credentials.md, paste is last-resort)
+
+User> hcloud token at ~/.config/hcloud/token
+
+aider> /run cat ~/.config/hcloud/token | head -c 20
+       [reads token, never echoes it back]
+       /run hcloud server create --type cx22 --image ubuntu-24.04 ...
+       ...
+```
+
+## Reporting issues / contributing
+
+Use Aider's `/run gh issue create ...` to file recipe-feedback issues per the open-forge templates. The skill's drafted issue body can be passed via `--body-file`.

--- a/docs/platforms/codex.md
+++ b/docs/platforms/codex.md
@@ -1,0 +1,100 @@
+# Using open-forge with OpenAI Codex
+
+Codex (the OpenAI coding agent in ChatGPT and the open-source Codex CLI) can ingest open-forge as a system-prompt extension or a workspace-level instruction set. open-forge becomes a deployment runbook Codex follows whenever the user asks to self-host something.
+
+> **Best-effort:** Codex doesn't have Claude Code's plugin auto-loading. The user must load the open-forge content explicitly (as a system prompt, in workspace files, or by referencing the cloned repo). Once loaded, Codex uses it the same way Claude Code does.
+
+## Install
+
+Two paths, pick one:
+
+### Option A — system-prompt embedding (ChatGPT Codex with custom instructions)
+
+1. Generate a paste-ready system prompt:
+
+   ```bash
+   git clone https://github.com/zhangqi444/open-forge
+   cd open-forge
+   ./scripts/build-dist.sh codex
+   # Outputs: dist/codex/system-prompt.md
+   ```
+
+2. Open ChatGPT → **Settings** → **Personalization** → **Custom Instructions** → paste `dist/codex/system-prompt.md` into the *"How would you like ChatGPT to respond?"* box.
+
+3. (Optional) Set a context-window-friendly slimmer version: `./scripts/build-dist.sh codex --slim` produces `dist/codex/system-prompt-slim.md` with just the architectural skeleton.
+
+### Option B — workspace files (Codex CLI)
+
+1. Clone `open-forge` into your project's parent directory:
+
+   ```bash
+   git clone https://github.com/zhangqi444/open-forge ../open-forge
+   ```
+
+2. When invoking Codex CLI, point it at the open-forge content:
+
+   ```bash
+   codex --include-files ../open-forge/CLAUDE.md \
+         --include-files ../open-forge/plugins/open-forge/skills/open-forge/SKILL.md \
+         --include-dir ../open-forge/plugins/open-forge/skills/open-forge/references/
+   ```
+
+   Or use Codex's project-level config (`.codex/config.toml` if available in your version).
+
+## Invoke
+
+Once loaded, just ask in natural language:
+
+> *"Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired."*
+
+Codex will recognize the deploy intent, look up the recipe in the loaded content, and follow the phased workflow.
+
+If Codex doesn't auto-trigger, prompt explicitly:
+
+> *"Follow the open-forge skill instructions to self-host OpenClaw on AWS Lightsail."*
+
+## Tool translation
+
+| open-forge concept (Claude Code term) | Codex equivalent |
+|---|---|
+| `AskUserQuestion` (structured choice) | Codex asks a multi-line question with bulleted options; user replies free-text |
+| `WebFetch` (read upstream docs) | Codex's `web_search` / `fetch_url` tool, depending on Codex variant |
+| `mcp__github__issue_write` (post feedback issue) | Codex shells out to `gh issue create` (preferred) or prints a prefilled URL for the user to open |
+| Persistent state file (`~/.open-forge/deployments/<name>.yaml`) | Same path; Codex reads/writes via filesystem tool. Resume across sessions works if the user keeps the workspace open or re-loads the file at session start. |
+
+## Limitations
+
+- **No auto-trigger.** Claude Code triggers the skill from the description-match. Codex needs an explicit prompt referencing self-hosting.
+- **State-file resume** depends on Codex retaining file context across sessions. Re-loading the YAML at the start of a new conversation is reliable; auto-discovery is not.
+- **Tool-name fidelity** varies. Codex's tool surface differs from Claude Code's (e.g. no `AskUserQuestion`); the agent improvises but may produce less consistent UX.
+- **Issue-posting via the GitHub MCP server** isn't available in Codex; fall back to `gh` CLI or prefilled-URL paths per `references/modules/feedback.md`.
+
+## Example session
+
+```
+User: Self-host Vaultwarden on a Hetzner CX22.
+
+Codex: I'll follow the open-forge recipe at references/projects/vaultwarden.md.
+
+       Combo: Hetzner Cloud CX × Docker.
+       Phases I'll run: preflight → provision → dns → tls → smtp → hardening.
+
+       For preflight, I need:
+         - Hetzner API token (file path / env var name / paste — see credential
+           handling rules in CLAUDE.md § Credential handling)
+         - Domain you want to use
+
+User: token at ~/.secrets/hcloud, domain vault.example.com
+
+Codex: [Reads ~/.secrets/hcloud via shell tool]
+       [Runs hcloud server create ...]
+       ...
+```
+
+## Reporting issues / contributing
+
+Same as for Claude Code — file a [GitHub issue](https://github.com/zhangqi444/open-forge/issues/new/choose) using the templates. The skill drafts feedback automatically; for Codex you can ask:
+
+> *"Draft a recipe-feedback issue for this deployment per references/modules/feedback.md."*
+
+Codex will produce the sanitized draft; you review + post via `gh issue create` or browser.

--- a/docs/platforms/continue.md
+++ b/docs/platforms/continue.md
@@ -1,0 +1,105 @@
+# Using open-forge with Continue.dev
+
+Continue.dev is an open-source IDE assistant (VS Code, JetBrains). It supports custom commands, context providers, and prompt libraries — open-forge plugs into all three.
+
+## Install
+
+1. Clone open-forge:
+
+   ```bash
+   git clone https://github.com/zhangqi444/open-forge ~/code/open-forge
+   ```
+
+2. Generate the Continue-flavored config:
+
+   ```bash
+   cd ~/code/open-forge
+   ./scripts/build-dist.sh continue
+   # Outputs:
+   #   dist/continue/config.snippet.yaml   (paste into your continue config)
+   #   dist/continue/prompts/*.md          (per-recipe prompt files)
+   ```
+
+3. Merge `dist/continue/config.snippet.yaml` into your `~/.continue/config.yaml`:
+
+   ```yaml
+   # ~/.continue/config.yaml
+   contextProviders:
+     - name: file
+       params:
+         baseDir: ~/code/open-forge/plugins/open-forge/skills/open-forge
+
+   prompts:
+     - name: self-host
+       description: "Deploy a self-hostable app via open-forge recipes"
+       systemMessage: |
+         You are an expert at deploying self-hostable open-source apps. Follow the
+         open-forge skill at ~/code/open-forge/plugins/open-forge/skills/open-forge/SKILL.md.
+         Use the recipe under references/projects/ that matches the user's request;
+         if no recipe exists, follow the Tier 2 (live-derived) fallback per CLAUDE.md.
+
+   slashCommands:
+     - name: deploy
+       description: "Self-host an open-source app"
+       prompt: "self-host"
+   ```
+
+4. Reload Continue (Cmd+Shift+P → **Developer: Reload Window**).
+
+## Invoke
+
+Use the slash command in Continue's chat:
+
+> `/deploy Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired.`
+
+Or invoke the prompt by name:
+
+> `@self-host Self-host Vaultwarden on a Hetzner CX22.`
+
+You can also reference specific recipes via `@file`:
+
+> `@file references/projects/openclaw.md @file references/infra/aws/lightsail.md Now follow the recipe.`
+
+## Tool translation
+
+| open-forge concept | Continue equivalent |
+|---|---|
+| `AskUserQuestion` (structured choice) | Continue's chat doesn't have first-class structured prompts; agent asks in prose with options listed |
+| `WebFetch` | Continue's `@URL` context provider — paste a URL, agent reads the content |
+| `mcp__github__issue_write` | Continue's terminal context provider can run `gh issue create`; or use the prefilled-URL fallback |
+| Persistent state file | Filesystem operations work via Continue's tool-use (when enabled in config) |
+
+## Limitations
+
+- **Tool-use (agent mode) varies by model.** Continue's tool-use is model-dependent; Claude / GPT-4 work well, smaller models may struggle with the multi-step phased workflow.
+- **No auto-trigger on description match.** Continue uses explicit slash commands or `@` mentions; the open-forge skill description is informational, not a trigger.
+- **Context provider scoping.** The `file` provider above loads the entire `references/` tree; for large catalogs consider per-recipe context providers (`@file references/projects/<name>.md`) to keep context tight.
+
+## Example session
+
+```
+User: /deploy Self-host Vaultwarden on a Hetzner CX22.
+
+Continue: Loading the recipe at references/projects/vaultwarden.md and
+          infra adapter references/infra/hetzner/cloud-cx.md from the
+          file context provider.
+
+          Combo: Hetzner Cloud CX × Docker.
+          Phases: preflight → provision → dns → tls → smtp → hardening
+          → feedback.
+
+          For preflight, I need your Hetzner API token. Three safer
+          paths (per references/modules/credentials.md):
+            1. File path (e.g. ~/.secrets/hcloud)
+            2. Env var name (e.g. HCLOUD_TOKEN)
+            3. Paste — last resort, will need to rotate after deploy
+
+User: 2, HCLOUD_TOKEN
+Continue: [reads $HCLOUD_TOKEN via terminal tool]
+          [runs hcloud server create ...]
+          ...
+```
+
+## Reporting issues / contributing
+
+Continue's terminal context provider can run `gh issue create` for posting feedback. Or use the prefilled-URL fallback per `references/modules/feedback.md` § Submission paths.

--- a/docs/platforms/cursor.md
+++ b/docs/platforms/cursor.md
@@ -1,0 +1,108 @@
+# Using open-forge with Cursor
+
+Cursor's `.cursor/rules/` directory holds Markdown rule files the IDE auto-loads into the AI context. open-forge's recipes + modules drop straight in.
+
+## Install
+
+Two paths, pick one:
+
+### Option A — drop into your project (per-project)
+
+1. Clone open-forge alongside your project:
+
+   ```bash
+   git clone https://github.com/zhangqi444/open-forge ~/code/open-forge
+   ```
+
+2. Generate the Cursor-flavored rules bundle:
+
+   ```bash
+   cd ~/code/open-forge
+   ./scripts/build-dist.sh cursor
+   # Outputs: dist/cursor/*.mdc
+   ```
+
+3. Copy the bundle into your project's Cursor rules directory:
+
+   ```bash
+   mkdir -p /path/to/your/project/.cursor/rules/
+   cp dist/cursor/*.mdc /path/to/your/project/.cursor/rules/
+   ```
+
+   Restart Cursor or run **Cmd+Shift+P** → **Reload Window**.
+
+### Option B — global rules (all projects)
+
+For Cursor's User Rules (apply to all projects):
+
+1. Open Cursor → **Settings** → **General** → **Rules for AI**.
+2. Paste the contents of `dist/cursor/00-skill.mdc` (or `dist/cursor/00-skill-slim.mdc` for a context-friendly version) into the *Rules for AI* text area.
+3. Save. Now any Cursor session in any project knows about open-forge.
+
+## File layout
+
+`dist/cursor/` contains:
+
+- `00-skill.mdc` — top-level invocation rule (always-loaded)
+- `01-credentials.mdc` — credential-handling patterns (loaded when sensitive input is involved)
+- `02-feedback.mdc` — post-deploy feedback flow
+- `10-projects-<software>.mdc` — per-software recipes (loaded contextually)
+- `20-infra-<cloud>.mdc` — per-infra adapters
+- `30-runtimes-<runtime>.mdc` — runtime modules
+
+Each `.mdc` file has Cursor's frontmatter for scoping:
+
+```yaml
+---
+description: open-forge skill — self-host any open-source app on your own infrastructure
+globs: ["**/*.md", "**/Dockerfile*", "**/docker-compose*.yml"]
+alwaysApply: true
+---
+```
+
+## Invoke
+
+Cursor auto-loads always-applied rules into context. Just ask:
+
+> *"Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired."*
+
+If you want the skill to drive an agentic flow (multi-step), use **Composer** mode (Cmd+I) and ask the deploy question — Cursor's agent will follow the phased workflow.
+
+## Tool translation
+
+| open-forge concept | Cursor equivalent |
+|---|---|
+| `AskUserQuestion` (structured choice) | Cursor prompts in chat with bulleted options; user types reply or clicks suggestion |
+| `WebFetch` | Cursor's `@Web` context provider or built-in browse tool |
+| `mcp__github__issue_write` | Cursor agent runs `gh issue create` via terminal tool (preferred) or prints prefilled URL |
+| Persistent state file | Same path (`~/.open-forge/deployments/<name>.yaml`); Cursor reads/writes via filesystem tool. Composer mode keeps state across the session. |
+
+## Limitations
+
+- **Composer mode required for autonomous multi-step deploys.** Single-question chat works for one-shot tasks but won't handle the phased workflow as cleanly.
+- **`@` mentions** for context loading work — `@Codebase` finds recipes; `@File` references specific recipe files.
+- **Always-apply vs auto-apply globs.** The `00-skill.mdc` rule sets `alwaysApply: true` so it loads everywhere. Per-recipe rules use globs to load contextually (e.g. only when working with Compose files).
+
+## Example session (Composer mode)
+
+```
+User (Cmd+I): Self-host Vaultwarden on a Hetzner CX22 with Cloudflare for DNS.
+
+Cursor: Loading recipe references/projects/vaultwarden.md and infra
+        adapter references/infra/hetzner/cloud-cx.md from open-forge.
+
+        Phases I'll run:
+          1. preflight — verify hcloud CLI is installed + authenticated
+          2. provision — create CX22 server, allocate floating IP
+          3. dns — print A-records for you to add at Cloudflare
+          4. tls — Let's Encrypt cert via the Caddy reverse proxy
+          5. smtp — Vaultwarden's email config
+          6. hardening — rotate the admin token
+
+        For preflight: do you have an hcloud API token in a file or
+        env var? (per credentials.md, paste is last-resort)
+```
+
+## Reporting issues / contributing
+
+Same as Claude Code — [GitHub issue templates](https://github.com/zhangqi444/open-forge/issues/new/choose). Cursor agents can run `gh issue create` directly via the terminal tool, so the post-deploy feedback flow works end-to-end.

--- a/docs/platforms/generic.md
+++ b/docs/platforms/generic.md
@@ -1,0 +1,126 @@
+# Using open-forge with any AI agent
+
+For platforms not covered by a dedicated guide (Anthropic API direct, OpenAI Assistants, custom LangChain / AutoGen / smolagents agents, self-built tools-using LLMs, etc.), this is the platform-neutral integration guide. open-forge is fundamentally a library of platform-agnostic markdown — any agent that can read text and execute shell commands can use it.
+
+## Install
+
+1. Clone the repo into a path your agent can read:
+
+   ```bash
+   git clone https://github.com/zhangqi444/open-forge ~/code/open-forge
+   ```
+
+2. Generate the single-file generic bundle (or use the canonical files directly):
+
+   ```bash
+   cd ~/code/open-forge
+   ./scripts/build-dist.sh generic
+   # Outputs: dist/generic/open-forge-bundle.md
+   ```
+
+   The bundle concatenates SKILL.md + CLAUDE.md + the credential & feedback modules + a recipe index. Suitable for pasting into a system prompt or feeding as a single document to any agent.
+
+3. (Alternative) Point your agent at the canonical paths:
+
+   ```
+   System prompt:
+     Follow the instructions at the following paths:
+       - ~/code/open-forge/CLAUDE.md
+       - ~/code/open-forge/plugins/open-forge/skills/open-forge/SKILL.md
+       - ~/code/open-forge/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+       - ~/code/open-forge/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+
+     For per-deploy recipes, look up:
+       ~/code/open-forge/plugins/open-forge/skills/open-forge/references/projects/<software>.md
+       ~/code/open-forge/plugins/open-forge/skills/open-forge/references/infra/<cloud>/<service>.md
+       ~/code/open-forge/plugins/open-forge/skills/open-forge/references/runtimes/<runtime>.md
+   ```
+
+## What your agent needs to support
+
+open-forge expects an agent with the following capabilities:
+
+| Capability | Required | Notes |
+|---|---|---|
+| Read local text files | ✅ Yes | Recipes are markdown; agent must be able to load them on demand |
+| Execute shell commands | ✅ Yes | Skill orchestrates `aws`, `ssh`, `docker`, `kubectl`, etc. |
+| Ask the user structured questions | ⚠️ Helpful | If your agent doesn't have first-class structured choice (Claude Code's `AskUserQuestion`), the agent asks in prose with options listed. Less polished but works. |
+| Fetch URLs | ⚠️ Recommended | For Tier 2 deploys (live-derived from upstream docs). If unavailable, user pastes upstream content into chat. |
+| Persistent file storage between sessions | ⚠️ Recommended | For state-file resume (`~/.open-forge/deployments/<name>.yaml`). If unavailable, user re-loads the YAML at the start of each session. |
+| Run `gh issue create` (or similar GitHub integration) | ⚠️ Recommended | For the post-deploy feedback flow. If unavailable, fall back to the prefilled-URL path per `references/modules/feedback.md`. |
+
+If your agent has all five, the experience matches Claude Code's. If it has only the required two (read files + run shell), open-forge still works — just more prose-heavy interaction.
+
+## Tool translation
+
+The open-forge content uses Claude Code-specific tool names in some places (mostly historical). Translate as you load:
+
+| Claude Code term | Generic capability | Your agent's tool |
+|---|---|---|
+| `AskUserQuestion` | "Ask user for one of N choices" | (your platform's structured-prompt API, if any; otherwise prose) |
+| `WebFetch` | "Fetch URL content" | (your fetch / browse tool) |
+| `mcp__github__*` | "GitHub API" | `gh` CLI shell-out, or the GitHub MCP server, or the GitHub REST API directly |
+| State file at `~/.open-forge/deployments/<name>.yaml` | Persistent JSON/YAML store | (filesystem, if available; otherwise inline in chat history) |
+
+Phase 2 of the multi-platform support effort genericizes these references in SKILL.md itself. Until then, treat Claude Code-specific tool names as descriptive of the *capability needed*, not the literal tool to call.
+
+## Invocation pattern
+
+Once the content is loaded into your agent's context, the user's prompt should look like:
+
+> *"Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired."*
+
+The agent should:
+
+1. Look up `references/projects/openclaw.md` for the recipe.
+2. Look up `references/infra/aws/lightsail.md` for the infra adapter.
+3. Note the runtime is bundled (vendor blueprint) so no separate runtime module needed.
+4. Run preflight from `references/modules/preflight.md`.
+5. Walk through phases per SKILL.md § Phased workflow, asking the user only what's genuinely needed.
+6. Apply credential-handling patterns from `references/modules/credentials.md` for any sensitive input.
+7. After `hardening`, offer the post-deploy feedback flow per `references/modules/feedback.md`.
+
+If the user's request doesn't match a verified recipe, fall back to **Tier 2** (live-derived) per CLAUDE.md § Two-tier coverage model.
+
+## Limitations
+
+- **No auto-trigger.** Generic agents don't auto-load open-forge on intent — the user explicitly invokes it. For best UX, set up a slash command or alias.
+- **Tool-name fidelity** depends entirely on what your agent supports. The skill is designed to degrade gracefully (prose questions if no structured prompts; user-pasted upstream content if no fetch tool), but the experience varies.
+- **State-file resume** depends on persistent file storage. Stateless agents (one prompt = one session) need the user to save and re-load the state file manually.
+- **Issue-posting** for the feedback loop needs *some* way to call GitHub. `gh` CLI is the most portable; a prefilled URL works as an always-available fallback.
+
+## Example session (any tools-using LLM)
+
+```
+User: I want to self-host Vaultwarden on a Hetzner CX22.
+
+Agent: I'm following the open-forge skill at
+       ~/code/open-forge/plugins/open-forge/skills/open-forge/SKILL.md.
+
+       [reads SKILL.md + references/projects/vaultwarden.md +
+        references/infra/hetzner/cloud-cx.md]
+
+       Combo: Hetzner Cloud CX × Docker.
+       I'll run preflight → provision → dns → tls → smtp → hardening →
+       feedback.
+
+       Preflight: do you have your Hetzner API token in a file or env
+       var? (Per references/modules/credentials.md, paste is last
+       resort.)
+
+User: env var HCLOUD_TOKEN
+
+Agent: [verifies $HCLOUD_TOKEN is set]
+       [runs hcloud server create ...]
+       ...
+```
+
+## Reporting issues / contributing
+
+The post-deploy feedback flow asks the user to opt into a GitHub issue. Most agents will end up using the prefilled-URL path:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...
+```
+
+The user reviews the redacted draft in chat, then opens the URL in a browser to submit. See `references/modules/feedback.md` § Submission paths for the full hierarchy.

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-forge",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, helm, podman, docker, lume, tailscale, terraform, cdk, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw, Hermes-Agent, Ollama, Open WebUI, Stable Diffusion WebUI (Automatic1111), ComfyUI, Dify, LibreChat, AnythingLLM, Aider, vLLM, Langfuse. AI stack focus: Ollama (single-user LLM inference) + vLLM (production-grade LLM inference) + Open WebUI / LibreChat (multi-user chat UIs) + Stable Diffusion WebUI / ComfyUI (image generation) + AnythingLLM (RAG-focused workspace) + Aider (terminal pair-programming CLI) + Langfuse (LLM observability + evals) compose into a complete local-AI stack; OpenClaw + Hermes-Agent are agent projects; Dify is the LLMOps platform layer. Every recipe is verified against upstream's docs index per the strict-doc policy in CLAUDE.md (community-maintained methods are explicitly flagged when upstream ships no first-party version).",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -9,6 +9,8 @@ description: Automate self-hosting of open-source apps on cloud infrastructure t
 
 Walk a user from "I have a cloud account and a domain" to "working app at `https://my.domain` with TLS and mail." Load the appropriate project recipe and infra adapter based on the user's stated intent; run phases sequentially; record state so the user can resume later.
 
+> **Platform note:** this skill is designed for Claude Code but the content is platform-agnostic. Tool names like `AskUserQuestion`, `WebFetch`, and `mcp__github__*` are Claude Code-specific — read them as *capabilities* (structured-choice prompt, URL fetch, GitHub API) and use whichever equivalent your platform exposes. See [`docs/platforms/`](../../../../docs/platforms/) in the repo for per-platform integration guides (Codex / Cursor / Aider / Continue / generic).
+
 ## Operating principle
 
 **Claude does the work; the user makes the choices.** open-forge replaces the traditional "read a README, copy-paste 30 lines of bash, debug for hours" experience with a guided chat where Claude executes everything via the user's local CLI tools (aws, ssh, jq, curl) and only stops to ask when input is genuinely required.
@@ -17,7 +19,7 @@ What this means in practice:
 
 - **Run, don't print.** When a recipe contains a bash block, *Claude executes it*. Announce it in one sentence first ("Opening port 22 in the Lightsail firewall now."), then run. Don't paste the block into chat for the user to run.
 - **Ask for choices and credentials only.** Things only the user can decide or provide: AWS profile name, domain choice, canonical www-vs-apex, SMTP API key, model provider preference. Everything else (which jq command to run, which sed pattern to apply, which IAM script URL to fetch) Claude figures out from the recipe.
-- **One question at a time when possible.** Use the `AskUserQuestion` tool for structured choices (multiple-choice, single-select). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
+- **One question at a time when possible.** Use a structured-choice prompt for multiple-choice / single-select (Claude Code: `AskUserQuestion`; on other platforms, ask in prose with options listed). Reserve free-text questions for things like API keys and domain names. Avoid wall-of-questions forms.
 - **Auto-install with confirmation, not silently.** If `jq` or `aws` is missing, propose the install command, get one-line approval, then run it. Never `sudo apt-get install` without asking.
 - **The recipe files in `references/projects/` and `references/infra/` are guidance for Claude, not pages for the user to read.** Keep that lens when extending or refactoring.
 
@@ -82,7 +84,7 @@ Before provisioning, establish three things by asking (or inferring from the use
 2. **Where** to host? → loads `references/infra/<cloud>/<service>.md` or `references/infra/{byo-vps,localhost}.md`
 3. **How** to host? → loads the matching `references/runtimes/<runtime>.md` (skipped if the infra bundles the runtime, e.g. vendor blueprints)
 
-The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Use `AskUserQuestion` only when genuinely ambiguous.
+The **how** question is *dynamically generated* from (software, where) — each project lists its "Compatible combos" table in the project recipe, and the options shown are filtered by the user's where answer. If the user's initial prompt already names a clear infra ("deploy to Lightsail" → AWS), announce the inferred choice and continue — don't re-ask. Ask a structured-choice question only when genuinely ambiguous.
 
 Then **immediately load `references/modules/preflight.md`** and run its steps. Preflight is combo-aware — it only installs / validates what the chosen tuple actually needs (AWS CLI only when infra ∈ AWS, Docker only when runtime = docker, nothing extra on localhost).
 
@@ -100,7 +102,7 @@ If no recipe matches, **don't refuse — fall back to Tier 2**:
 
 1. **Announce in one sentence**: *"This software isn't in our verified recipe set — I'll fetch upstream docs live and reuse the runtime / infra modules. Treat my output as best-effort, not authoritative."*
 2. **Fetch upstream the same way Tier 1 does**:
-   - `WebFetch` the upstream README first. If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
+   - Fetch the upstream README first via the platform's URL-fetch capability (Claude Code: `WebFetch`; Cursor: `@Web`; Aider/generic: `curl` via shell). If 403/404, fall back to `raw.githubusercontent.com/<org>/<repo>/<branch>/README.md`, or `git clone` the docs repo locally if the docs site is Cloudflare-protected.
    - Locate the upstream install-method index (docs site, repo `docs/install/` tree, wiki).
    - Enumerate every method documented under that index. **Do not invent methods upstream doesn't ship** — if fetches fail, stop and tell the user, don't speculate.
    - Read canonical install artifacts in the repo (`Dockerfile`, `docker-compose.yml`, `helm/`, `flake.nix`, primary config example).
@@ -184,7 +186,7 @@ Inputs split across three layers:
 - **Infra-specific** — handled by the loaded infra adapter (e.g. `references/infra/lightsail.md`): bundle/blueprint choice, SSH key path defaults.
 - **Project-specific** — handled by the loaded project recipe (e.g. `references/projects/ghost.md`): domain, canonical preference, Let's Encrypt email, SMTP provider + API key, model provider, etc.
 
-Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use `AskUserQuestion` for structured choices.
+Each recipe and adapter has its own **"Inputs to collect"** section listing exactly what it needs and at which phase. Collect just-in-time per phase, not all upfront. Use a structured-choice prompt where the platform supports one (Claude Code: `AskUserQuestion`; otherwise prose with options listed).
 
 ## Asking for credentials
 
@@ -256,7 +258,7 @@ Load `references/modules/feedback.md` for the full sanitization rules + draft te
 6. **Confirm post?** — explicit "yes" required. If user edits the draft, re-show + re-confirm.
 7. **Submit via the first available path**:
    - `gh issue create --title "..." --body "..." --label recipe-feedback,recipe:<name>` if the user has `gh` authenticated.
-   - GitHub MCP `mcp__github__issue_write` if available.
+   - Platform-native GitHub integration if available (Claude Code: `mcp__github__issue_write`; Cursor / generic: GitHub MCP server if installed).
    - Fallback: print a prefilled URL (`https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=...&body=...`) and ask the user to open + submit in browser.
 
 ### Sanitization is mandatory

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# build-dist.sh — generate platform-specific distribution bundles from canonical sources.
+#
+# Usage:
+#   ./scripts/build-dist.sh <platform>
+#
+# Platforms:
+#   codex      — system-prompt for ChatGPT Codex / Codex CLI
+#   cursor     — .mdc rule files for .cursor/rules/
+#   aider      — CONVENTIONS.md + read-files.txt + .aider.conf.yml
+#   continue   — config snippet + per-recipe prompt files for Continue.dev
+#   generic    — single-file concatenated bundle for any tools-using LLM
+#   all        — run all of the above
+#
+# Output: dist/<platform>/* (gitignored except the build script itself)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILL_DIR="$REPO_ROOT/plugins/open-forge/skills/open-forge"
+REFS_DIR="$SKILL_DIR/references"
+DIST_DIR="$REPO_ROOT/dist"
+
+usage() {
+  grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+[[ $# -lt 1 ]] && usage
+
+PLATFORM="$1"
+
+build_codex() {
+  echo "→ Building Codex bundle…"
+  mkdir -p "$DIST_DIR/codex"
+
+  cat > "$DIST_DIR/codex/system-prompt.md" <<EOF
+# open-forge skill (Codex system prompt)
+
+You are an expert at deploying self-hostable open-source apps. You operate as the open-forge skill — see the canonical content below.
+
+When the user asks to self-host a service, follow the phased workflow (preflight → provision → dns → tls → smtp → inbound → hardening → feedback) defined in SKILL.md. Look up the matching recipe in references/projects/<software>.md and the matching infra adapter in references/infra/<cloud>/<service>.md.
+
+If no recipe matches, fall back to Tier 2 (live-derived) per CLAUDE.md § Two-tier coverage model.
+
+Tool names like AskUserQuestion / WebFetch / mcp__github__* are Claude Code-specific — use Codex's equivalents (prose questions with options listed; web_search / fetch_url; gh CLI shell-out).
+
+For credential collection, follow references/modules/credentials.md — five patterns prioritized from "secret never enters chat" to "last-resort paste with risk acknowledgement."
+
+After hardening, offer the post-deploy feedback flow per references/modules/feedback.md.
+
+---
+
+EOF
+  cat "$REPO_ROOT/CLAUDE.md" >> "$DIST_DIR/codex/system-prompt.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/codex/system-prompt.md"
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/codex/system-prompt.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/codex/system-prompt.md"
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/codex/system-prompt.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/codex/system-prompt.md"
+  cat "$REFS_DIR/modules/feedback.md" >> "$DIST_DIR/codex/system-prompt.md"
+
+  # Slim version: just SKILL.md + credentials, no per-recipe content
+  cat > "$DIST_DIR/codex/system-prompt-slim.md" <<EOF
+# open-forge skill (slim Codex system prompt)
+
+When the user asks to self-host a service, look up the matching recipe at:
+  https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects/<software>.md
+
+Follow the phased workflow + credential-handling patterns below. Tool names are Claude Code's; use Codex equivalents.
+
+---
+
+EOF
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/codex/system-prompt-slim.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/codex/system-prompt-slim.md"
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/codex/system-prompt-slim.md"
+
+  echo "  ✓ dist/codex/system-prompt.md ($(wc -l < "$DIST_DIR/codex/system-prompt.md") lines)"
+  echo "  ✓ dist/codex/system-prompt-slim.md ($(wc -l < "$DIST_DIR/codex/system-prompt-slim.md") lines)"
+}
+
+build_cursor() {
+  echo "→ Building Cursor bundle…"
+  mkdir -p "$DIST_DIR/cursor"
+
+  # Top-level skill rule (always-applied)
+  cat > "$DIST_DIR/cursor/00-skill.mdc" <<EOF
+---
+description: open-forge skill — self-host any open-source app on your own infrastructure
+alwaysApply: true
+---
+
+EOF
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/cursor/00-skill.mdc"
+
+  # Slim version of skill rule
+  cat > "$DIST_DIR/cursor/00-skill-slim.mdc" <<EOF
+---
+description: open-forge skill (slim) — self-host open-source apps; full content at github.com/zhangqi444/open-forge
+alwaysApply: true
+---
+
+When the user asks to self-host a service, follow the open-forge phased workflow:
+preflight → provision → dns → tls → smtp → inbound → hardening → feedback.
+
+Look up the matching recipe at github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects/<software>.md.
+
+Apply credential-handling patterns from references/modules/credentials.md (five patterns; paste is last-resort).
+
+After hardening, offer the post-deploy feedback flow per references/modules/feedback.md.
+
+Tool names in the canonical content (AskUserQuestion, WebFetch, mcp__github__*) are Claude Code-specific — use Cursor equivalents (prose prompts with options; @Web; gh CLI via terminal tool).
+EOF
+
+  # Credentials rule (loads when sensitive context detected)
+  cat > "$DIST_DIR/cursor/01-credentials.mdc" <<EOF
+---
+description: Credential-handling patterns for open-forge — five patterns prioritizing safer alternatives over chat paste
+globs: ["**/*.env*", "**/secrets/**", "**/credentials/**"]
+---
+
+EOF
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/cursor/01-credentials.mdc"
+
+  # Feedback rule (loads when post-deploy / drafting issue)
+  cat > "$DIST_DIR/cursor/02-feedback.mdc" <<EOF
+---
+description: open-forge post-deploy feedback flow — sanitization + multi-step consent + GitHub issue submission
+---
+
+EOF
+  cat "$REFS_DIR/modules/feedback.md" >> "$DIST_DIR/cursor/02-feedback.mdc"
+
+  echo "  ✓ dist/cursor/00-skill.mdc"
+  echo "  ✓ dist/cursor/00-skill-slim.mdc"
+  echo "  ✓ dist/cursor/01-credentials.mdc"
+  echo "  ✓ dist/cursor/02-feedback.mdc"
+}
+
+build_aider() {
+  echo "→ Building Aider bundle…"
+  mkdir -p "$DIST_DIR/aider"
+
+  # CONVENTIONS.md — auto-loaded by Aider from project root
+  cat > "$DIST_DIR/aider/CONVENTIONS.md" <<EOF
+# Aider conventions — open-forge skill
+
+When the user asks to self-host a service, follow the open-forge phased workflow + recipe content below.
+
+Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specific — use Aider equivalents:
+- Structured choice → ask in chat with bulleted options; user replies in terminal
+- WebFetch → /run curl <url> via Aider's shell capability, or user pastes upstream content
+- GitHub issue posting → /run gh issue create (preferred), or prefilled URL fallback
+
+State file at ~/.open-forge/deployments/<name>.yaml — Aider operates on it via filesystem ops.
+
+---
+
+EOF
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/aider/CONVENTIONS.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/aider/CONVENTIONS.md"
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/aider/CONVENTIONS.md"
+
+  # read-files.txt — list of files to --read
+  cat > "$DIST_DIR/aider/read-files.txt" <<EOF
+$REPO_ROOT/CLAUDE.md
+$SKILL_DIR/SKILL.md
+$REFS_DIR/modules/credentials.md
+$REFS_DIR/modules/feedback.md
+$REFS_DIR/modules/preflight.md
+EOF
+
+  # .aider.conf.yml — drop-in config
+  cat > "$DIST_DIR/aider/.aider.conf.yml" <<EOF
+# Drop this file into your project root (or merge with existing config) to load
+# open-forge as default context for every Aider session in the project.
+
+read:
+  - $REPO_ROOT/CLAUDE.md
+  - $SKILL_DIR/SKILL.md
+  - $REFS_DIR/modules/credentials.md
+  - $REFS_DIR/modules/feedback.md
+
+auto-commits: false   # open-forge state files at ~/.open-forge/ shouldn't be auto-committed
+EOF
+
+  echo "  ✓ dist/aider/CONVENTIONS.md"
+  echo "  ✓ dist/aider/read-files.txt"
+  echo "  ✓ dist/aider/.aider.conf.yml"
+}
+
+build_continue() {
+  echo "→ Building Continue.dev bundle…"
+  mkdir -p "$DIST_DIR/continue"
+
+  # config.snippet.yaml — to merge into ~/.continue/config.yaml
+  cat > "$DIST_DIR/continue/config.snippet.yaml" <<EOF
+# Add to ~/.continue/config.yaml. Merge into existing top-level keys.
+
+contextProviders:
+  - name: file
+    params:
+      baseDir: $SKILL_DIR
+
+prompts:
+  - name: self-host
+    description: "Deploy a self-hostable app via open-forge recipes"
+    systemMessage: |
+      You are the open-forge skill. When the user asks to self-host a service,
+      look up the matching recipe at $REFS_DIR/projects/<software>.md and
+      follow the phased workflow defined in $SKILL_DIR/SKILL.md.
+
+      Apply credential-handling patterns from references/modules/credentials.md
+      (five patterns; paste is last-resort).
+
+      Tool names like AskUserQuestion / WebFetch / mcp__github__* are Claude
+      Code-specific — use Continue equivalents (prose with options listed,
+      @Web context provider, gh CLI via terminal).
+
+slashCommands:
+  - name: deploy
+    description: "Self-host an open-source app via open-forge"
+    prompt: "self-host"
+EOF
+
+  echo "  ✓ dist/continue/config.snippet.yaml"
+}
+
+build_generic() {
+  echo "→ Building generic bundle…"
+  mkdir -p "$DIST_DIR/generic"
+
+  # Single-file concatenated bundle
+  cat > "$DIST_DIR/generic/open-forge-bundle.md" <<EOF
+# open-forge — single-file bundle for any tools-using LLM agent
+
+This is a concatenation of the canonical open-forge skill content. Feed it as a system prompt or a long-context document to any LLM agent that supports tool use. The agent acts as a deployment runbook for self-hostable open-source apps.
+
+For per-recipe content (~180 individual recipes under references/projects/), browse:
+  https://deepwiki.com/zhangqi444/open-forge
+
+Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specific — read as capabilities (structured-choice prompt; URL fetch; GitHub API) and use your platform's equivalents.
+
+---
+
+EOF
+  cat "$REPO_ROOT/CLAUDE.md" >> "$DIST_DIR/generic/open-forge-bundle.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/generic/open-forge-bundle.md"
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/generic/open-forge-bundle.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/generic/open-forge-bundle.md"
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/generic/open-forge-bundle.md"
+  echo -e "\n\n---\n" >> "$DIST_DIR/generic/open-forge-bundle.md"
+  cat "$REFS_DIR/modules/feedback.md" >> "$DIST_DIR/generic/open-forge-bundle.md"
+
+  echo "  ✓ dist/generic/open-forge-bundle.md ($(wc -l < "$DIST_DIR/generic/open-forge-bundle.md") lines)"
+}
+
+case "$PLATFORM" in
+  codex)    build_codex ;;
+  cursor)   build_cursor ;;
+  aider)    build_aider ;;
+  continue) build_continue ;;
+  generic)  build_generic ;;
+  all)
+    build_codex
+    build_cursor
+    build_aider
+    build_continue
+    build_generic
+    ;;
+  *) usage ;;
+esac
+
+echo
+echo "Done. Bundles in: $DIST_DIR/"


### PR DESCRIPTION
## Summary

Brings open-forge to **5 AI coding platforms** beyond Claude Code: Codex (ChatGPT / CLI), Cursor, Aider, Continue.dev, and any tools-using LLM agent. Bumps plugin to **v0.21.0** (multi-platform is a notable feature, minor bump).

This is delivered in three phases as requested:

| Phase | Commit | What |
|---|---|---|
| **1** | `dbc6e12` | Per-platform usage docs in `docs/platforms/` (5 files, ~550 lines) |
| **2** | `a62cd9b` | Genericize SKILL.md tool references — Claude Code names + per-platform equivalents in parentheses |
| **3** | `e02f1a2` | Build script + committed distribution bundles in `dist/` for all 5 platforms |

## Phase 1 — `docs/platforms/`

| Platform | Doc | How users load open-forge |
|---|---|---|
| **Codex** | `docs/platforms/codex.md` | System-prompt embedding (ChatGPT custom instructions) or workspace-file include (Codex CLI) |
| **Cursor** | `docs/platforms/cursor.md` | Drop `dist/cursor/*.mdc` into `.cursor/rules/`, or paste into User Rules globally |
| **Aider** | `docs/platforms/aider.md` | `--read` flags at invocation, or `.aider.conf.yml` at project root, or drop `CONVENTIONS.md` |
| **Continue.dev** | `docs/platforms/continue.md` | Merge `config.snippet.yaml` into `~/.continue/config.yaml`; invoke via `/deploy` slash command |
| **Generic** | `docs/platforms/generic.md` | Five capabilities the platform needs; tool-name translation; example invocation pattern for any tools-using LLM |

Each doc includes: install steps, invocation pattern, tool-translation table, limitations, sample session.

## Phase 2 — `SKILL.md` genericization

Five surgical edits replace Claude Code-specific tool names with capability descriptions + platform names in parentheses:

- `AskUserQuestion` → "structured-choice prompt (Claude Code: AskUserQuestion; otherwise prose with options)"
- `WebFetch` → "URL-fetch capability (Claude Code: WebFetch; Cursor: @Web; Aider/generic: curl)"
- `mcp__github__issue_write` → "Platform-native GitHub integration (Claude Code: MCP; otherwise gh CLI)"

Plus a "Platform note" at the top of Overview pointing the reading agent at `docs/platforms/` and stating that tool names should be read as capabilities.

CLAUDE.md was already agent-shape-agnostic from earlier work; only SKILL.md needed touch-up.

## Phase 3 — `dist/` bundles + `scripts/build-dist.sh`

`scripts/build-dist.sh` generates platform-specific bundles by concatenating canonical sources (CLAUDE.md + SKILL.md + credentials.md + feedback.md) into the format each platform expects:

```bash
./scripts/build-dist.sh <platform>     # codex / cursor / aider / continue / generic
./scripts/build-dist.sh all
```

Bundles **committed as snapshots** so casual users grab them without cloning + running the script:

| Bundle | Size |
|---|---|
| `dist/codex/system-prompt.md` | 1243 lines (full) |
| `dist/codex/system-prompt-slim.md` | 523 lines |
| `dist/cursor/00-skill.mdc` + 3 others | Cursor frontmatter (description / alwaysApply / globs) |
| `dist/aider/CONVENTIONS.md` + `read-files.txt` + `.aider.conf.yml` | Drop-in for Aider |
| `dist/continue/config.snippet.yaml` | Merge into Continue config |
| `dist/generic/open-forge-bundle.md` | 1238 lines (single-file for any LLM) |

`dist/README.md` explains the layout + regeneration command.

## README

Install section now leads with Claude Code (canonical), followed by a section linking to the five `docs/platforms/*` guides.

## Test plan

- [ ] `./scripts/build-dist.sh all` runs cleanly and produces all bundles.
- [ ] Each `docs/platforms/*` guide is followable end-to-end on its target platform.
- [ ] Live test: load `dist/cursor/00-skill.mdc` into a Cursor project's `.cursor/rules/` and ask Cursor to "self-host Vaultwarden on a Hetzner CX22" — confirm Cursor follows the phased workflow.
- [ ] Live test: paste `dist/codex/system-prompt-slim.md` into ChatGPT custom instructions and ask the same — confirm Codex follows the workflow.
- [ ] After the next CLAUDE.md / SKILL.md / module change in main, regenerate bundles and confirm they pick up the changes.

## Out of scope

- **CI auto-publish** of bundles to GitHub Releases. The build script makes regeneration easy; CI publishing can come later if there's demand.
- **Tool-name fidelity** in the ~200 individual recipes. They mostly don't reference Claude Code-specific tools (it's mostly bash commands). The cross-cutting layer (SKILL.md + modules) handles the bulk.
- **Per-platform feedback-flow validation.** The credential and feedback flows degrade gracefully on platforms with fewer capabilities (per `docs/platforms/generic.md`); first end-to-end tests will surface platform-specific issues.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_