### PR TITLE
Operationalize dist/ bundle regeneration — CLAUDE.md policy + CI safety net

### DIFF
--- a/.github/workflows/dist-bundles.yml
+++ b/.github/workflows/dist-bundles.yml
@@ -1,0 +1,34 @@
+name: dist-bundles-up-to-date
+
+# Fail PRs/commits whose dist/ bundles drift from canonical sources
+# (CLAUDE.md, SKILL.md, references/modules/credentials.md, references/modules/feedback.md).
+#
+# When this fails: run ./scripts/build-dist.sh all from the repo root, commit, push.
+# See CLAUDE.md § Processing incoming issues → 3. Author the patch for the policy.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Regenerate dist/ from canonical sources
+        run: ./scripts/build-dist.sh all
+
+      - name: Fail if dist/ drifted
+        run: |
+          if ! git diff --quiet dist/; then
+            echo "::error::dist/ bundles are out of date relative to CLAUDE.md / SKILL.md / references/modules/."
+            echo "::error::Run './scripts/build-dist.sh all' from the repo root, commit the changes, and push."
+            echo
+            echo "--- Diff (first 100 lines) ---"
+            git diff dist/ | head -100
+            exit 1
+          fi
+          echo "✓ dist/ bundles are up to date."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,7 @@ If validation fails (upstream URL 404s, software is out of scope, methodology is
 - Cite the upstream URL at the top of every section per *Strict doc-verification policy*.
 - Flag community-maintained methods with the required ⚠️ blockquote.
 - Re-scan against the *Sanitization principles* strip-list — if any identifier slipped through user-supplied content, redact before drafting.
+- **If your patch touches `CLAUDE.md`, `plugins/open-forge/skills/open-forge/SKILL.md`, or any file under `plugins/open-forge/skills/open-forge/references/modules/`, regenerate the multi-platform distribution bundles**: `./scripts/build-dist.sh all`. Include the regenerated `dist/` files in the same PR. The bundles concatenate canonical sources for non-Claude-Code platforms (Codex / Cursor / Aider / Continue / generic); they drift if not regenerated, which silently breaks those platforms. CI enforces this — see `.github/workflows/dist-bundles.yml`.
 - Bump `plugin.json` `version` per *Versioning + publish flow*.
 - If multiple feedback issues for the same recipe are pending, batch them into a single PR.
 
@@ -409,6 +410,13 @@ open-forge/
 ├── README.md                              ← user-facing, lives on GitHub
 ├── LICENSE                                ← MIT
 ├── .claude-plugin/marketplace.json        ← marketplace manifest
+├── .github/
+│   ├── ISSUE_TEMPLATE/                    ← three issue channels (recipe-feedback, software-nomination, method-proposal)
+│   └── workflows/dist-bundles.yml         ← CI: fail PRs whose dist/ bundles are stale vs canonical sources
+├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / generic)
+├── dist/                                  ← regenerated multi-platform distribution bundles (see scripts/build-dist.sh)
+├── scripts/
+│   └── build-dist.sh                      ← regenerates dist/ from canonical sources; run when CLAUDE.md / SKILL.md / modules change
 └── plugins/open-forge/
     ├── .claude-plugin/plugin.json         ← plugin manifest (version!)
     └── skills/open-forge/
@@ -417,11 +425,11 @@ open-forge/
         │   ├── projects/<name>.md         ← software layer
         │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
-        └── scripts/                       ← reused operational scripts; empty by default
+        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring, credentials, feedback)
+        └── scripts/                       ← deployment-time operational scripts (per-recipe); empty by default
 ```
 
-`scripts/` stays empty unless something is reused 3+ times across deployments. Inline commands in recipes are clearer for one-off use.
+The skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time) stays empty unless something is reused 3+ times across deployments — inline commands in recipes are clearer for one-off use. Distinct from the top-level `scripts/` (build-time tooling for dist/ bundles).
 
 ## Versioning + publish flow
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -21,6 +21,16 @@ The bundles are concatenations of the canonical content (`CLAUDE.md`, `plugins/o
 
 Run from the repo root.
 
+### Who runs this?
+
+| Actor | When |
+|---|---|
+| **AI coding session processing an issue** (per [CLAUDE.md § Processing incoming issues](../CLAUDE.md#processing-incoming-issues)) | Whenever a patch touches `CLAUDE.md` / `SKILL.md` / `references/modules/{credentials,feedback}.md`. Required step in `### 3. Author the patch`. |
+| **Maintainer** (manual edits) | Same trigger — if you hand-edit a canonical source, regenerate before opening the PR. |
+| **CI** (safety net) | [`.github/workflows/dist-bundles.yml`](../.github/workflows/dist-bundles.yml) runs the build script on every PR and fails if `dist/` is stale. Catches both bot- and human-authored PRs that forgot to regenerate. |
+
+If you see a CI failure on `dist-bundles-up-to-date`, the fix is always: run `./scripts/build-dist.sh all` from the repo root, commit the changes, push.
+
 ## Per-platform usage
 
 See [`docs/platforms/`](../docs/platforms/) — one guide per platform with install instructions, tool translations, limitations, and example sessions.


### PR DESCRIPTION
## Summary

After multi-platform support landed in v0.21.0, the `dist/` bundles became a maintenance surface — they concatenate canonical content (`CLAUDE.md` / `SKILL.md` / `references/modules/credentials.md` / `references/modules/feedback.md`), so any change to those files leaves the bundles stale until someone re-runs `./scripts/build-dist.sh`. Until now, **no one was clearly responsible** for that step.

This PR pins down who runs it and adds CI to catch drift.

No version bump — operational policy + CI workflow, not user-visible behavior change.

## What changed

### `CLAUDE.md` — the policy

| Section | Change |
|---|---|
| **§ Processing incoming issues, "3. Author the patch"** | New bullet: *"If your patch touches `CLAUDE.md`, `SKILL.md`, or any file under `references/modules/`, regenerate `dist/` bundles via `./scripts/build-dist.sh all` and include the regenerated files in the same PR."* CI enforces this. |
| **§ File layout** | Revised tree includes `.github/`, `docs/platforms/`, `dist/`, and the top-level `scripts/` (previously documented as empty per policy but now holds `build-dist.sh`). Distinction preserved between top-level `scripts/` (build-time tooling) and skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time per-recipe; still empty by default). |

### `dist/README.md` — explicit "who runs this?"

Three actors:
- **AI coding session processing an issue** — required step, per CLAUDE.md
- **Maintainer doing manual edits** — same trigger
- **CI** — safety net via the new workflow

### `.github/workflows/dist-bundles.yml` (new)

```yaml
name: dist-bundles-up-to-date
on: [push, pull_request to main]
```

Runs `./scripts/build-dist.sh all` on every PR + push to main. Fails the build if `dist/` drifted vs canonical sources, with a helpful error message + first 100 lines of the diff so the contributor sees exactly what's missing.

## Test plan

- [ ] CI workflow runs on this PR (it's a self-test — the workflow file is being added in this PR but should run on the next push).
- [ ] After this lands: open a probe PR that edits `CLAUDE.md` without regenerating bundles → confirm CI fails with the expected error.
- [ ] After this lands: open a probe PR that edits `CLAUDE.md` AND regenerates bundles → confirm CI passes.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_