### PR TITLE
v0.22.0 — Phase 4: agent-platform support (OpenClaw + Hermes-Agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,19 @@ In **Claude Code**:
 /plugin install open-forge@open-forge
 ```
 
-**Other AI coding tools** — Codex (ChatGPT / CLI), Cursor, Aider, Continue.dev, or any tools-using LLM — see [`docs/platforms/`](docs/platforms/):
+**Other AI coding tools and agent platforms** — see [`docs/platforms/`](docs/platforms/):
 
-- [Codex](docs/platforms/codex.md) — system-prompt embedding or workspace files
-- [Cursor](docs/platforms/cursor.md) — `.cursor/rules/` bundle
-- [Aider](docs/platforms/aider.md) — `--read` files + `CONVENTIONS.md`
-- [Continue.dev](docs/platforms/continue.md) — context provider + slash command
-- [Generic agents](docs/platforms/generic.md) — any LLM that can read files + run shell commands
+| Platform | How |
+|---|---|
+| [Codex](docs/platforms/codex.md) (ChatGPT / CLI) | System-prompt embedding or workspace files |
+| [Cursor](docs/platforms/cursor.md) | `.cursor/rules/` bundle |
+| [Aider](docs/platforms/aider.md) | `--read` files + `CONVENTIONS.md` |
+| [Continue.dev](docs/platforms/continue.md) | Context provider + slash command |
+| [OpenClaw](docs/platforms/openclaw.md) (personal AI agent at openclaw.ai) | Workspace skill at `~/.openclaw/workspace/skills/open-forge/` |
+| [Hermes-Agent](docs/platforms/hermes.md) (Nous Research) | User skill at `~/.hermes/skills/open-forge/` |
+| [Generic agents](docs/platforms/generic.md) | Any LLM that can read files + run shell |
+
+**Agent-mode caveat:** When running inside an autonomous agent (OpenClaw / Hermes / messaging-channel agents), credential **paste is disabled** — the skill only accepts file paths, env vars, cloud-CLI sessions, or secrets-manager refs. Pasting credentials into messaging channels (WhatsApp / Telegram / etc.) is meaningfully riskier than into coding-tool chat. Group-channel deploy conversations are also refused.
 
 Then say what you want to deploy:
 

--- a/dist/README.md
+++ b/dist/README.md
@@ -8,6 +8,8 @@ Auto-generated bundles for AI coding tools other than Claude Code. Each subdirec
 | `cursor/` | `.mdc` rule files with Cursor frontmatter | Cursor's `.cursor/rules/` |
 | `aider/` | `CONVENTIONS.md` + `read-files.txt` + `.aider.conf.yml` | Aider |
 | `continue/` | `config.snippet.yaml` | Continue.dev's `~/.continue/config.yaml` |
+| `openclaw/` | `SKILL.md` with OpenClaw frontmatter (name + description + metadata) | OpenClaw — drop into `~/.openclaw/workspace/skills/open-forge/` |
+| `hermes/` | `SKILL.md` with agentskills.io open-standard frontmatter | Hermes-Agent — drop into `~/.hermes/skills/open-forge/` |
 | `generic/` | `open-forge-bundle.md` (single-file concatenation) | Any LLM agent with tool use |
 
 ## Regenerate after upstream changes

--- a/dist/aider/CONVENTIONS.md
+++ b/dist/aider/CONVENTIONS.md
@@ -226,6 +226,17 @@ Whenever the skill needs sensitive input — API keys, DB passwords, OAuth clien
 4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
 5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
 
+### Agent-mode rules (OpenClaw / Hermes / any messaging-channel agent)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks to the user via WhatsApp / Telegram / Slack / iMessage / email / etc.), apply these stricter rules **on top of** the base five-pattern flow above:
+
+- **Pattern 5 (direct paste) is DISABLED.** Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat — chat history syncs to the user's phone, may be backed up to cloud (iCloud / Google Drive), and often persists indefinitely. Refuse a paste with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead. See [credentials.md](references/modules/credentials.md) for options."* If the user insists, refuse again — don't compromise.
+- **Reject deploy conversations from group channels.** Group chats leak everything to all members (credentials, IPs, admin URLs). When invoked from a group context, respond: *"Self-host deploys involve sensitive info. Switch to a 1:1 DM and ask again."* Then stop.
+- **Use async polling for time-elapsed waits**, not blocking prompts. `dns` propagation, `tls` cert issuance, `provision` instance-boot — all become *"I'll poll and ping you when ready"* rather than *"press enter when DNS propagates."* Agents have a daemon; use it.
+- **Channel-aware response routing.** Long-form content (DNS records to add at registrar, full recipe explanations, admin-bootstrap URLs) should go via secure / structured channels (email, signed note, secure-share link) when the agent supports them, not the chat. Quick decisions (yes/no, pick from list) stay in chat. Final hand-off (admin URL, rotation reminders) → secure 1:1 only.
+
+See [`docs/platforms/openclaw.md`](../../../../docs/platforms/openclaw.md) and [`docs/platforms/hermes.md`](../../../../docs/platforms/hermes.md) for the full agent-mode integration guides.
+
 See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
 
 ## Verification after each phase
@@ -517,9 +528,19 @@ If the user picked patterns 1-4 for everything, no rotation reminder is needed (
 
 ---
 
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
 ## Failure modes
 
-- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
 - **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
 - **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
 - **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.

--- a/dist/codex/system-prompt-slim.md
+++ b/dist/codex/system-prompt-slim.md
@@ -222,6 +222,17 @@ Whenever the skill needs sensitive input — API keys, DB passwords, OAuth clien
 4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
 5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
 
+### Agent-mode rules (OpenClaw / Hermes / any messaging-channel agent)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks to the user via WhatsApp / Telegram / Slack / iMessage / email / etc.), apply these stricter rules **on top of** the base five-pattern flow above:
+
+- **Pattern 5 (direct paste) is DISABLED.** Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat — chat history syncs to the user's phone, may be backed up to cloud (iCloud / Google Drive), and often persists indefinitely. Refuse a paste with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead. See [credentials.md](references/modules/credentials.md) for options."* If the user insists, refuse again — don't compromise.
+- **Reject deploy conversations from group channels.** Group chats leak everything to all members (credentials, IPs, admin URLs). When invoked from a group context, respond: *"Self-host deploys involve sensitive info. Switch to a 1:1 DM and ask again."* Then stop.
+- **Use async polling for time-elapsed waits**, not blocking prompts. `dns` propagation, `tls` cert issuance, `provision` instance-boot — all become *"I'll poll and ping you when ready"* rather than *"press enter when DNS propagates."* Agents have a daemon; use it.
+- **Channel-aware response routing.** Long-form content (DNS records to add at registrar, full recipe explanations, admin-bootstrap URLs) should go via secure / structured channels (email, signed note, secure-share link) when the agent supports them, not the chat. Quick decisions (yes/no, pick from list) stay in chat. Final hand-off (admin URL, rotation reminders) → secure 1:1 only.
+
+See [`docs/platforms/openclaw.md`](../../../../docs/platforms/openclaw.md) and [`docs/platforms/hermes.md`](../../../../docs/platforms/hermes.md) for the full agent-mode integration guides.
+
 See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
 
 ## Verification after each phase
@@ -513,9 +524,19 @@ If the user picked patterns 1-4 for everything, no rotation reminder is needed (
 
 ---
 
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
 ## Failure modes
 
-- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
 - **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
 - **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
 - **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.

--- a/dist/codex/system-prompt.md
+++ b/dist/codex/system-prompt.md
@@ -330,6 +330,7 @@ If validation fails (upstream URL 404s, software is out of scope, methodology is
 - Cite the upstream URL at the top of every section per *Strict doc-verification policy*.
 - Flag community-maintained methods with the required ⚠️ blockquote.
 - Re-scan against the *Sanitization principles* strip-list — if any identifier slipped through user-supplied content, redact before drafting.
+- **If your patch touches `CLAUDE.md`, `plugins/open-forge/skills/open-forge/SKILL.md`, or any file under `plugins/open-forge/skills/open-forge/references/modules/`, regenerate the multi-platform distribution bundles**: `./scripts/build-dist.sh all`. Include the regenerated `dist/` files in the same PR. The bundles concatenate canonical sources for non-Claude-Code platforms (Codex / Cursor / Aider / Continue / generic); they drift if not regenerated, which silently breaks those platforms. CI enforces this — see `.github/workflows/dist-bundles.yml`.
 - Bump `plugin.json` `version` per *Versioning + publish flow*.
 - If multiple feedback issues for the same recipe are pending, batch them into a single PR.
 
@@ -425,6 +426,13 @@ open-forge/
 ├── README.md                              ← user-facing, lives on GitHub
 ├── LICENSE                                ← MIT
 ├── .claude-plugin/marketplace.json        ← marketplace manifest
+├── .github/
+│   ├── ISSUE_TEMPLATE/                    ← three issue channels (recipe-feedback, software-nomination, method-proposal)
+│   └── workflows/dist-bundles.yml         ← CI: fail PRs whose dist/ bundles are stale vs canonical sources
+├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / generic)
+├── dist/                                  ← regenerated multi-platform distribution bundles (see scripts/build-dist.sh)
+├── scripts/
+│   └── build-dist.sh                      ← regenerates dist/ from canonical sources; run when CLAUDE.md / SKILL.md / modules change
 └── plugins/open-forge/
     ├── .claude-plugin/plugin.json         ← plugin manifest (version!)
     └── skills/open-forge/
@@ -433,11 +441,11 @@ open-forge/
         │   ├── projects/<name>.md         ← software layer
         │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
-        └── scripts/                       ← reused operational scripts; empty by default
+        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring, credentials, feedback)
+        └── scripts/                       ← deployment-time operational scripts (per-recipe); empty by default
 ```
 
-`scripts/` stays empty unless something is reused 3+ times across deployments. Inline commands in recipes are clearer for one-off use.
+The skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time) stays empty unless something is reused 3+ times across deployments — inline commands in recipes are clearer for one-off use. Distinct from the top-level `scripts/` (build-time tooling for dist/ bundles).
 
 ## Versioning + publish flow
 

--- a/dist/codex/system-prompt.md
+++ b/dist/codex/system-prompt.md
@@ -706,6 +706,17 @@ Whenever the skill needs sensitive input — API keys, DB passwords, OAuth clien
 4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
 5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
 
+### Agent-mode rules (OpenClaw / Hermes / any messaging-channel agent)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks to the user via WhatsApp / Telegram / Slack / iMessage / email / etc.), apply these stricter rules **on top of** the base five-pattern flow above:
+
+- **Pattern 5 (direct paste) is DISABLED.** Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat — chat history syncs to the user's phone, may be backed up to cloud (iCloud / Google Drive), and often persists indefinitely. Refuse a paste with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead. See [credentials.md](references/modules/credentials.md) for options."* If the user insists, refuse again — don't compromise.
+- **Reject deploy conversations from group channels.** Group chats leak everything to all members (credentials, IPs, admin URLs). When invoked from a group context, respond: *"Self-host deploys involve sensitive info. Switch to a 1:1 DM and ask again."* Then stop.
+- **Use async polling for time-elapsed waits**, not blocking prompts. `dns` propagation, `tls` cert issuance, `provision` instance-boot — all become *"I'll poll and ping you when ready"* rather than *"press enter when DNS propagates."* Agents have a daemon; use it.
+- **Channel-aware response routing.** Long-form content (DNS records to add at registrar, full recipe explanations, admin-bootstrap URLs) should go via secure / structured channels (email, signed note, secure-share link) when the agent supports them, not the chat. Quick decisions (yes/no, pick from list) stay in chat. Final hand-off (admin URL, rotation reminders) → secure 1:1 only.
+
+See [`docs/platforms/openclaw.md`](../../../../docs/platforms/openclaw.md) and [`docs/platforms/hermes.md`](../../../../docs/platforms/hermes.md) for the full agent-mode integration guides.
+
 See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
 
 ## Verification after each phase
@@ -997,9 +1008,19 @@ If the user picked patterns 1-4 for everything, no rotation reminder is needed (
 
 ---
 
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
 ## Failure modes
 
-- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
 - **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
 - **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
 - **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.

--- a/dist/cursor/01-credentials.mdc
+++ b/dist/cursor/01-credentials.mdc
@@ -216,9 +216,19 @@ If the user picked patterns 1-4 for everything, no rotation reminder is needed (
 
 ---
 
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
 ## Failure modes
 
-- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
 - **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
 - **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
 - **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.

--- a/dist/generic/open-forge-bundle.md
+++ b/dist/generic/open-forge-bundle.md
@@ -701,6 +701,17 @@ Whenever the skill needs sensitive input — API keys, DB passwords, OAuth clien
 4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
 5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
 
+### Agent-mode rules (OpenClaw / Hermes / any messaging-channel agent)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks to the user via WhatsApp / Telegram / Slack / iMessage / email / etc.), apply these stricter rules **on top of** the base five-pattern flow above:
+
+- **Pattern 5 (direct paste) is DISABLED.** Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat — chat history syncs to the user's phone, may be backed up to cloud (iCloud / Google Drive), and often persists indefinitely. Refuse a paste with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead. See [credentials.md](references/modules/credentials.md) for options."* If the user insists, refuse again — don't compromise.
+- **Reject deploy conversations from group channels.** Group chats leak everything to all members (credentials, IPs, admin URLs). When invoked from a group context, respond: *"Self-host deploys involve sensitive info. Switch to a 1:1 DM and ask again."* Then stop.
+- **Use async polling for time-elapsed waits**, not blocking prompts. `dns` propagation, `tls` cert issuance, `provision` instance-boot — all become *"I'll poll and ping you when ready"* rather than *"press enter when DNS propagates."* Agents have a daemon; use it.
+- **Channel-aware response routing.** Long-form content (DNS records to add at registrar, full recipe explanations, admin-bootstrap URLs) should go via secure / structured channels (email, signed note, secure-share link) when the agent supports them, not the chat. Quick decisions (yes/no, pick from list) stay in chat. Final hand-off (admin URL, rotation reminders) → secure 1:1 only.
+
+See [`docs/platforms/openclaw.md`](../../../../docs/platforms/openclaw.md) and [`docs/platforms/hermes.md`](../../../../docs/platforms/hermes.md) for the full agent-mode integration guides.
+
 See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
 
 ## Verification after each phase
@@ -992,9 +1003,19 @@ If the user picked patterns 1-4 for everything, no rotation reminder is needed (
 
 ---
 
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
 ## Failure modes
 
-- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
 - **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
 - **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
 - **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.

--- a/dist/generic/open-forge-bundle.md
+++ b/dist/generic/open-forge-bundle.md
@@ -325,6 +325,7 @@ If validation fails (upstream URL 404s, software is out of scope, methodology is
 - Cite the upstream URL at the top of every section per *Strict doc-verification policy*.
 - Flag community-maintained methods with the required ⚠️ blockquote.
 - Re-scan against the *Sanitization principles* strip-list — if any identifier slipped through user-supplied content, redact before drafting.
+- **If your patch touches `CLAUDE.md`, `plugins/open-forge/skills/open-forge/SKILL.md`, or any file under `plugins/open-forge/skills/open-forge/references/modules/`, regenerate the multi-platform distribution bundles**: `./scripts/build-dist.sh all`. Include the regenerated `dist/` files in the same PR. The bundles concatenate canonical sources for non-Claude-Code platforms (Codex / Cursor / Aider / Continue / generic); they drift if not regenerated, which silently breaks those platforms. CI enforces this — see `.github/workflows/dist-bundles.yml`.
 - Bump `plugin.json` `version` per *Versioning + publish flow*.
 - If multiple feedback issues for the same recipe are pending, batch them into a single PR.
 
@@ -420,6 +421,13 @@ open-forge/
 ├── README.md                              ← user-facing, lives on GitHub
 ├── LICENSE                                ← MIT
 ├── .claude-plugin/marketplace.json        ← marketplace manifest
+├── .github/
+│   ├── ISSUE_TEMPLATE/                    ← three issue channels (recipe-feedback, software-nomination, method-proposal)
+│   └── workflows/dist-bundles.yml         ← CI: fail PRs whose dist/ bundles are stale vs canonical sources
+├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / generic)
+├── dist/                                  ← regenerated multi-platform distribution bundles (see scripts/build-dist.sh)
+├── scripts/
+│   └── build-dist.sh                      ← regenerates dist/ from canonical sources; run when CLAUDE.md / SKILL.md / modules change
 └── plugins/open-forge/
     ├── .claude-plugin/plugin.json         ← plugin manifest (version!)
     └── skills/open-forge/
@@ -428,11 +436,11 @@ open-forge/
         │   ├── projects/<name>.md         ← software layer
         │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring)
-        └── scripts/                       ← reused operational scripts; empty by default
+        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring, credentials, feedback)
+        └── scripts/                       ← deployment-time operational scripts (per-recipe); empty by default
 ```
 
-`scripts/` stays empty unless something is reused 3+ times across deployments. Inline commands in recipes are clearer for one-off use.
+The skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time) stays empty unless something is reused 3+ times across deployments — inline commands in recipes are clearer for one-off use. Distinct from the top-level `scripts/` (build-time tooling for dist/ bundles).
 
 ## Versioning + publish flow
 

--- a/dist/hermes/SKILL.md
+++ b/dist/hermes/SKILL.md
@@ -1,7 +1,11 @@
 ---
-description: open-forge skill — self-host any open-source app on your own infrastructure
-alwaysApply: true
+name: open-forge
+description: Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail. Agent-mode rules apply (no chat-paste credentials, no group-channel deploys).
 ---
+
+# open-forge — self-host any open-source app
+
+> **Agent-mode rules in effect.** Pattern 5 (direct credential paste) is disabled. Group-channel deploy conversations are refused. See § *Asking for credentials → Agent-mode rules* below.
 
 ---
 name: open-forge
@@ -303,3 +307,486 @@ A new project: add `references/projects/<name>.md` covering required services, c
 A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
 
 Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.
+
+
+---
+
+# Credentials handling (agent-mode rules apply)
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.
+
+
+---
+
+# Post-deploy feedback flow
+
+---
+name: feedback
+description: Post-deploy feedback module — sanitization rules + draft templates + submission paths for the three GitHub-issue input channels (recipe-feedback / software-nomination / method-proposal). Loaded by SKILL.md § Post-deploy feedback.
+---
+
+# Feedback module — drafting + submitting GitHub issues
+
+This module is loaded after a deploy completes (or is abandoned) when the user opts in to share what they learned. Implements the multi-step consent flow described in CLAUDE.md § *Sanitization principles* and SKILL.md § *Post-deploy feedback*.
+
+**Hard rule:** never post without showing the redacted draft + getting explicit "yes" from the user. The skill is the user's submitter; consent gates everything.
+
+---
+
+## Sanitization checklist
+
+Apply BEFORE drafting. Scan the deployment session — including chat transcript, any tool outputs Claude has in context, any state-file references — and replace identifiers per the table.
+
+### Strip-list (regex patterns + replacements)
+
+| Class | Detection | Replacement |
+|---|---|---|
+| **Domains** (apex, www, admin) | Anything matching the user's `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` collected during inputs, plus generic FQDNs in URL paths the user typed | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| **Public IPv4** | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (excluding RFC-1918 ranges if you want to allow them as `${PRIVATE_IP}`) | `${PUBLIC_IP}` |
+| **Private IPv4** | `\b(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)[0-9.]+\b` | `${PRIVATE_IP}` (or strip if it leaks network topology) |
+| **IPv6** | Standard IPv6 patterns | `${PUBLIC_IPV6}` / `${PRIVATE_IPV6}` |
+| **SSH key paths** | Anything matching `~/.ssh/[^ ]+`, `/home/[^/]+/\.ssh/[^ ]+`, `*.pem`, `*.priv`, `id_(rsa|ed25519|ecdsa)` | `${KEY_PATH}` |
+| **SSH key contents** | `-----BEGIN [A-Z ]+ KEY-----` blocks | `<REDACTED-SSH-KEY>` |
+| **Resend API key** | `re_[A-Za-z0-9_]+` | `<REDACTED-RESEND-KEY>` |
+| **SendGrid API key** | `SG\.[A-Za-z0-9._-]+` | `<REDACTED-SENDGRID-KEY>` |
+| **OpenAI API key** | `sk-[A-Za-z0-9]{20,}` | `<REDACTED-OPENAI-KEY>` |
+| **Anthropic API key** | `sk-ant-[A-Za-z0-9_-]{20,}` | `<REDACTED-ANTHROPIC-KEY>` |
+| **Slack tokens** | `xox[bp]-[A-Za-z0-9-]+` | `<REDACTED-SLACK-TOKEN>` |
+| **GitHub PAT** | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]+` | `<REDACTED-GH-PAT>` |
+| **AWS access key ID** | `AKIA[0-9A-Z]{16}` | `<REDACTED-AWS-KEY>` |
+| **AWS secret key** | After `aws_secret_access_key`, 40-char base64 | `<REDACTED-AWS-SECRET>` |
+| **AWS account ID** | 12 consecutive digits in AWS context (ARN, account-id field) | `${AWS_ACCOUNT}` |
+| **AWS profile name** | Whatever the user collected as `aws_profile` during inputs | `${AWS_PROFILE}` |
+| **GCP service-account JSON** | `"type": "service_account"` blocks | `<REDACTED-GCP-SA>` |
+| **Generic Bearer token** | `Bearer [A-Za-z0-9._~+/=-]{20,}` | `<REDACTED-BEARER>` |
+| **Email addresses** | RFC-822 pattern; especially the LE email + SMTP from-address + any user identity email | `${EMAIL}` |
+| **State-file contents** | Anything from `~/.open-forge/deployments/<name>.yaml` raw | Reference by deployment name only, never paste contents |
+| **MySQL/Postgres password** | After `password=` / `--password ` / `IDENTIFIED BY ` | `<REDACTED-DB-PASSWORD>` |
+| **OAuth client secrets** | After `client_secret` / `CLIENT_SECRET` | `<REDACTED-CLIENT-SECRET>` |
+| **Random bytes from `openssl rand -hex N`** that the user generated as a secret | Long hex strings used as secrets | `<REDACTED-RANDOM-SECRET>` |
+
+### Manual review pass (after regex)
+
+After regex-based sanitization, do a final read-through looking for:
+
+- **Hostnames in URL paths** that contain the user's domain (sed/regex may have missed embedded URLs).
+- **Username conventions** that are personally identifiable (e.g. `qi-experiment` as an AWS profile).
+- **Stack-trace lines** containing absolute filesystem paths (`/home/<user>/...`).
+- **Anything pasted from the user's clipboard or env vars** that wasn't covered by the strip-list.
+
+If you can't confidently classify something as safe, **redact it** — the user's final review is a safety net, not the only line of defense.
+
+### What you may keep
+
+| Class | OK to keep | Why |
+|---|---|---|
+| Recipe filenames (`ghost.md`, `openclaw.md`) | ✅ | Public; needed for context |
+| Plugin version (`0.20.0`) | ✅ | Public; needed for triage |
+| Combo names (`Ghost-CLI on Ubuntu`, `DigitalOcean droplet`) | ✅ | Public; needed for context |
+| Generic error messages quoted from upstream tools | ⚠️ | OK if no identifiers; redact paths and IPs from stack traces |
+| `${VAR}` placeholders | ✅ | These are the redactions; they're fine |
+| Public repo URLs (upstream docs you're proposing to add) | ✅ | Public |
+
+---
+
+## Draft templates
+
+Each template renders into the matching `.github/ISSUE_TEMPLATE/*.yml` form. The structure mirrors the form fields so the user pastes the body and the form auto-validates the sanitization checkboxes.
+
+### Channel 1 — recipe feedback (default at end of deploy)
+
+```markdown
+**Recipe**: <recipe-filename>
+**Combo**: <infra adapter> / <runtime>
+**Plugin version**: <version-from-plugin.json>
+**Outcome**: <one-of: Deploy succeeded with notes / Deploy succeeded after retries / Deploy failed; recovered manually / Deploy failed; abandoned / Recipe was outdated>
+
+## What the recipe missed
+
+<Concrete description: what surprised you, what failed, what required manual intervention. Sanitized.>
+
+## Suggested edit (optional — diff format preferred)
+
+```diff
+@@ <section header from the recipe> @@
+- <line that was wrong / missing>
++ <line that should be there>
+```
+
+## Sanitization confirmation
+- [x] All domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses stripped from this issue body.
+- [x] I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+```
+
+### Channel 2 — software nomination (Tier 2 → Tier 1)
+
+```markdown
+**Software name**: <project>
+**Upstream repo**: <github URL>
+**Upstream install-method index**: <docs / repo path / wiki URL>
+**Intended deploy combo**: <infra> / <runtime>
+
+## Why Tier 1?
+
+<What's painful about this software's install that compounds across deploys?
+Per the demand-driven graduation criteria in CLAUDE.md, a Tier 1 recipe earns
+its keep when the captured tribal knowledge saves the next user real pain.>
+
+## In-scope check (per CLAUDE.md § Is this software in scope?)
+
+This software is: <one-of: deployable service / static-site generator / AI inference server / CI runner / storage backend / not sure>
+
+## Confirmation
+- [x] I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+- [x] This software has at least one upstream-documented install method or canonical install artifact in-repo.
+```
+
+### Channel 3 — method proposal
+
+```markdown
+**Recipe to extend**: <recipe-filename>
+**Method name**: <e.g. "Snap package", "Helm chart">
+**Upstream URL documenting this method**: <URL>
+**Source type**: <First-party — published by upstream / Community-maintained>
+
+## Canonical install command(s)
+
+```bash
+<paste verbatim from upstream>
+```
+
+## Why this method matters
+
+<When would a user pick this method over the existing options in the recipe?>
+
+## Confirmation
+- [x] I have verified the upstream URL above shows this install method on the current upstream version.
+- [x] No credentials, IPs, or other identifiers in this issue.
+```
+
+---
+
+## Submission paths (try in order)
+
+The skill never opens a browser silently or POSTs without explicit user confirmation. Three submission paths in priority order:
+
+### 1. `gh` CLI (preferred when available)
+
+```bash
+# Check if gh is authenticated for the right account
+gh auth status
+
+# If yes, submit
+gh issue create \
+  --repo zhangqi444/open-forge \
+  --title "<title from template>" \
+  --body-file /tmp/feedback-draft.md \
+  --label recipe-feedback,recipe:<name>
+```
+
+Strengths: works headlessly in chat; respects user's existing GitHub auth.
+
+Caveats: user must have `gh` installed + authenticated. If `gh auth status` errors, fall through to path 2.
+
+### 2. GitHub MCP server (if available)
+
+If `mcp__github__issue_write` is available in the tool list, use it:
+
+```
+mcp__github__issue_write({
+  method: "create",
+  owner: "zhangqi444",
+  repo: "open-forge",
+  title: "<title>",
+  body: "<full body>",
+  labels: ["recipe-feedback", "recipe:<name>"]
+})
+```
+
+Strengths: no `gh` install needed; uses the MCP server's auth.
+
+Caveats: only works if the MCP server is configured with appropriate scopes.
+
+### 3. Prefilled URL (always-available fallback)
+
+When neither `gh` nor the GitHub MCP works, generate a URL the user opens in a browser:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=<URL-encoded-title>&body=<URL-encoded-body>
+```
+
+Print the URL in chat with the instruction:
+
+> *"I can't post for you in this environment. Open this URL in a browser, review one more time, and click Submit:*
+>
+> *<URL>*
+>
+> *The form has the same sanitization checkboxes from the template — they'll be checked based on what you've already confirmed in chat."*
+
+URL-encode the title + body. GitHub URL length limit is ~8 KB total; if the body is longer, truncate the body and put the rest in a `<details>` block (or warn the user to paste it manually).
+
+---
+
+## Liability + license boilerplate (paste at end of every issue body)
+
+Append this exact block as the final paragraph of every issue body before submission:
+
+```markdown
+---
+
+> By submitting this issue, I grant a non-revocable license to the open-forge project to use this content in recipes and documentation. The open-forge project bears no liability for my choice to share. I have reviewed the issue body for credentials and personal information per CLAUDE.md § *Sanitization principles*.
+```
+
+This is in addition to the checkboxes in the issue-template form — it's an extra paper trail in the issue body itself.
+
+---
+
+## When the deploy aborted before completion
+
+If the user wants to file feedback about a deploy that failed mid-phase (e.g. preflight passed, provisioning failed at the security-group step), the `Outcome` field should be *"Deploy failed; abandoned"* and the body should include:
+
+- Which phase failed.
+- What the error was (sanitized — strip stack traces of paths/IPs).
+- What workaround the user attempted (if any).
+- Whether the user wants the recipe edited to handle this case, or whether they think it was an upstream / cloud-account issue (out of recipe scope).
+
+These are often the highest-value feedback issues — they catch recipes that succeed in the maintainer's environment but fail in others.
+
+---
+
+## Failure modes to watch for
+
+- **User says "post it" too quickly.** Respect their consent, but flag any line you weren't 100% sure about: *"Posting now. One last thing — line 14 mentions a username `qi-experiment` that might be your AWS profile name. Was that intentional?"*
+- **Drafts that quote upstream error messages with embedded user data.** Common with Bitnami's `bncert-tool` output, AWS CLI errors quoting account IDs in ARNs.
+- **State-file leaks.** If the user asks Claude to read `~/.open-forge/deployments/<name>.yaml` while drafting, do **not** paste contents — reference by deployment name only.
+- **Multiple rapid yes-clicks.** If the user says "yes, yes, yes, post" to skip the review, slow down: re-show the draft once, get confirmation, then submit. Speed is not a user safety feature.

--- a/dist/openclaw/SKILL.md
+++ b/dist/openclaw/SKILL.md
@@ -1,7 +1,21 @@
 ---
-description: open-forge skill — self-host any open-source app on your own infrastructure
-alwaysApply: true
+name: open-forge
+description: "Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛠️",
+        "requires": { "bins": ["bash", "curl", "ssh"] },
+        "agent_mode": true,
+        "credentials_paste_disabled": true,
+        "source": "https://github.com/zhangqi444/open-forge",
+        "docs": "https://deepwiki.com/zhangqi444/open-forge"
+      }
+  }
 ---
+
+# open-forge — self-host any open-source app
 
 ---
 name: open-forge
@@ -303,3 +317,486 @@ A new project: add `references/projects/<name>.md` covering required services, c
 A new infra: add `references/infra/<name>.md` covering provisioning (create instance, static IP, SSH key), firewall defaults, user/paths conventions. Follow lightsail.md.
 
 Cross-cutting modules (new SMTP provider, new forwarder): add under `references/modules/`. Keep them project- and infra-agnostic.
+
+
+---
+
+# Credentials handling (agent-mode rules apply)
+
+---
+name: credentials
+description: How the skill asks for credentials safely — five patterns prioritized from "secret never enters chat" to "last-resort paste with explicit risk acknowledgement." Loaded by SKILL.md § Asking for credentials. Applies to API keys, SSH keys, DB passwords, OAuth client secrets, cloud account creds, anything sensitive.
+---
+
+# Credentials module — five patterns, prioritized
+
+Pasting raw credentials into Claude Code is risky:
+
+- The secret enters the session history (visible to other tools loaded in the same session, may persist in logs).
+- May be relayed via MCP servers depending on the user's setup.
+- Shows up in transcripts the user might later share for support.
+- Some terminals / IDEs persist input across restarts.
+
+The skill defaults to safer patterns. Direct chat paste is **last resort** and only after explicit risk acknowledgement.
+
+**Hard rule:** every time the skill needs a sensitive input, it offers the user the five patterns below — letting them pick — and surfaces the risk if they pick paste. Don't silently accept a paste; don't pretend Claude Code is a vault.
+
+---
+
+## The five patterns (priority order)
+
+### 1. Local file path (recommended for personal use)
+
+User stores the secret in a file under their home directory; tells the skill the path; skill reads via `cat`.
+
+**When to suggest first:** for one-off API keys (Resend, SendGrid, Mailgun, OpenAI, Anthropic, etc.) that the user already has in a `.env`, `.secrets`, or password-manager export.
+
+**Skill prompt:**
+
+> *"Path to a file containing the key (e.g. `~/.secrets/resend`)? I'll read it via `cat`."*
+
+**Skill execution:**
+
+```bash
+RESEND_KEY=$(cat ~/.secrets/resend)   # or however the user names it
+# Use $RESEND_KEY in subsequent commands; never echo it back to the user
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- File survives across Claude Code sessions; user can use the same path next time.
+- User is responsible for the file's permissions (`chmod 600` recommended; mention if the file's mode is `644` or wider).
+
+---
+
+### 2. Environment variable name (recommended for shell users)
+
+User exports the secret as an env var **before** starting Claude Code (or in their shell `rc`); tells the skill the var name.
+
+**When to suggest first:** when the user already has secrets in a `.envrc` / `.bashrc` / `~/.config/fish/config.fish` they `source` regularly.
+
+**Skill prompt:**
+
+> *"Name of an env var holding the key (e.g. `RESEND_API_KEY`)? I'll read `$RESEND_API_KEY` from my shell."*
+
+**Skill execution:**
+
+```bash
+# Verify the var exists in Claude's shell
+test -n "$RESEND_API_KEY" || { echo "RESEND_API_KEY not set; export it before continuing"; exit 1; }
+# Use it
+curl ... -H "Authorization: Bearer $RESEND_API_KEY" ...
+```
+
+**Properties:**
+
+- Secret never enters chat.
+- Session-scoped if exported in the current shell only; persistent if in `rc` files.
+- The env var **must** exist in the shell Claude Code launched from. If the user `export`s after Claude Code starts, Claude won't see it (you'll need them to restart Claude Code or pass it inline).
+
+---
+
+### 3. Cloud-CLI session auth (default for AWS / GCP / Azure / GitHub)
+
+User authenticates the cloud CLI ahead of time (e.g. `aws sso login`, `gcloud auth application-default login`, `az login`, `gh auth login`); skill uses the resulting profile / session.
+
+**When to suggest first:** any time the credential is for a cloud account that ships its own CLI auth flow. Don't ask for raw cloud access keys if SSO / browser auth is available.
+
+| Provider | Pre-skill setup | What skill uses |
+|---|---|---|
+| AWS | `aws sso login --profile <name>` (or `aws configure` for static keys) | `aws --profile <name> ...` |
+| GCP | `gcloud auth application-default login` + `gcloud config set project <id>` | `gcloud` / `gsutil` / Terraform default-application-credentials |
+| Azure | `az login` | `az ...` (uses cached session) |
+| GitHub | `gh auth login` | `gh ...` (uses stored token, scoped) |
+| DigitalOcean | `doctl auth init` | `doctl ...` |
+| Hetzner | `hcloud context create` | `hcloud --context <name> ...` |
+| Cloudflare | `wrangler login` | `wrangler ...` |
+
+**Skill prompt:**
+
+> *"Have you run `aws sso login` for the profile you want to use? If yes, what's the profile name?"*
+
+**Properties:**
+
+- No secret material in chat or in any file the skill reads.
+- Auth is browser-mediated, MFA-friendly.
+- Sessions expire (good — bounded blast radius); skill handles re-auth gracefully if the session lapses mid-deploy.
+
+---
+
+### 4. Secrets-manager reference (advanced)
+
+User stores secrets in 1Password / Bitwarden / Vault / AWS Secrets Manager / GCP Secret Manager; gives the skill a CLI-resolvable reference; skill calls the secret-manager CLI to fetch only when needed.
+
+**When to suggest first:** when the user mentions they "have it in 1Password" or similar; or for users with proper secret-management practices.
+
+| Secret manager | Reference shape | Skill execution |
+|---|---|---|
+| 1Password | `op://Personal/Resend/api-key` | `op read 'op://Personal/Resend/api-key'` |
+| Bitwarden | item name + field | `bw get password '<item-name>'` |
+| HashiCorp Vault | `secret/data/<path>#<field>` | `vault kv get -field=<field> secret/<path>` |
+| AWS Secrets Manager | secret name + JSON key | `aws secretsmanager get-secret-value --secret-id <name> --query SecretString --output text \| jq -r .<key>` |
+| GCP Secret Manager | resource name | `gcloud secrets versions access latest --secret=<name>` |
+| `pass` (Linux) | path | `pass <path>` |
+
+**Skill prompt:**
+
+> *"1Password / Bitwarden / Vault reference? I'll fetch via the matching CLI when I need it."*
+
+**Properties:**
+
+- Secret never enters chat or any persistent file.
+- Resolved just-in-time; not cached in shell vars longer than necessary.
+- User must have the matching CLI installed + authenticated.
+
+---
+
+### 5. Direct chat paste (last resort — risk acknowledgement required)
+
+User types the secret directly into chat. Skill **must** surface the risks before accepting.
+
+**When this happens:** user explicitly says they want to paste, or none of patterns 1-4 work for their situation (e.g. they're trying out the skill with a one-shot key and don't want to set up file storage).
+
+**Required risk acknowledgement (paraphrase, don't elide):**
+
+> *"⚠️ If you paste the key here, it will live in this Claude Code session's history. It may also be visible to other tools loaded in the session and could appear in any transcripts you share later for support. After this deploy completes, I'll remind you to rotate the key in the provider's dashboard. Still want to paste? (yes / pick a safer path)"*
+
+**If user confirms:**
+
+- Accept the paste.
+- Use the value immediately; don't echo it back.
+- At the end of the deploy, surface a reminder: *"You pasted `<provider>` API key into chat earlier. Rotate it in `<provider's dashboard URL>` now that the deploy is complete."*
+
+**Properties:**
+
+- Convenient but contaminates session history.
+- The rotation reminder is mandatory — without it, the user may forget the key is exposed.
+
+---
+
+## Per-credential-class recommendations
+
+Different credential types pair best with different patterns. Surface the recommendation when the credential class is known.
+
+| Credential class | Default suggestion | Alternative |
+|---|---|---|
+| **API keys** (Resend, SendGrid, OpenAI, etc.) | Pattern 1 (file path) or 2 (env var) | Pattern 4 (secrets manager) |
+| **AWS / GCP / Azure / GH cloud auth** | Pattern 3 (CLI session) | Pattern 4 if user prefers explicit secret refs |
+| **SSH keys** (cloud instance auth) | The path itself is what skill needs (not the contents — never the contents). Pattern 1, but specifically the file is the key file (`~/.ssh/id_ed25519`); skill uses `ssh -i <path>` | n/a — never accept SSH key contents pasted into chat |
+| **DB passwords** | Pattern 1, 2, or 4 | Pattern 5 only if it's a one-shot generated password the user is about to throw away anyway |
+| **OAuth client secrets** | Pattern 4 (long-lived; should be vaulted) | Pattern 1 with `chmod 600` |
+| **Random secrets generated for the deploy** (`openssl rand -hex 32` etc.) | Generate inline; never echo to user; store in the state file or pass directly to the upstream tool | n/a |
+
+---
+
+## Skill prompt template
+
+When the skill reaches a phase that needs a credential, use this template:
+
+```
+[Phase: <smtp / provision / etc.>] I need <credential class>.
+
+Pick how to provide it:
+
+  1. **File path** — paste the path to a file containing the secret (e.g. `~/.secrets/resend`)
+  2. **Env var name** — paste the name of an env var I should read (e.g. `RESEND_API_KEY`)
+  3. **Cloud-CLI session** — say which profile / context if you've already done `<provider> login`
+  4. **Secrets-manager ref** — paste a `op://`, `vault://`, `bw://`, etc. reference
+  5. **Paste directly** — least safe; key enters chat history; you'll be reminded to rotate after
+
+Which? (default: 1 if you have a file, 2 if you exported an env var)
+```
+
+After the user picks, validate before proceeding:
+
+- File path → `test -r <path>` first; refuse if mode is wider than 600 (offer to `chmod 600`).
+- Env var → `test -n "$<NAME>"`; refuse if empty.
+- Cloud-CLI session → run a smoke command (`aws sts get-caller-identity --profile <name>`); refuse if it errors.
+- Secrets-manager ref → run a smoke command (`op read --no-newline <ref>` etc.); refuse if it errors or empty.
+- Paste → require the risk acknowledgement before accepting.
+
+---
+
+## End-of-deploy: rotation reminders
+
+If the user picked pattern 5 (direct paste) for any credential during the deploy, surface a rotation reminder during the `hardening` phase:
+
+```
+[Hardening] Rotation reminder — you pasted these keys into chat during this deploy:
+
+  • Resend API key (used in smtp phase)  → rotate at https://resend.com/api-keys
+  • <other-provider> key                 → rotate at <provider's dashboard URL>
+
+Pasted secrets remain in this Claude Code session's history. Rotating now means
+even if the session leaks later, the keys are already invalid.
+```
+
+If the user picked patterns 1-4 for everything, no rotation reminder is needed (the secrets never entered chat).
+
+---
+
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
+## Failure modes
+
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
+- **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
+- **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
+- **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.
+- **Secrets-manager CLI not installed.** Detect via `command -v op` etc.; if missing, fall back to a different pattern, don't try to install a secret manager mid-deploy.
+- **CLI session expired mid-deploy.** Common with AWS SSO. Skill detects the expiry, says *"AWS session expired; please re-run `aws sso login --profile <name>` and tell me when ready."*, then resumes from the failed phase.
+
+
+---
+
+# Post-deploy feedback flow
+
+---
+name: feedback
+description: Post-deploy feedback module — sanitization rules + draft templates + submission paths for the three GitHub-issue input channels (recipe-feedback / software-nomination / method-proposal). Loaded by SKILL.md § Post-deploy feedback.
+---
+
+# Feedback module — drafting + submitting GitHub issues
+
+This module is loaded after a deploy completes (or is abandoned) when the user opts in to share what they learned. Implements the multi-step consent flow described in CLAUDE.md § *Sanitization principles* and SKILL.md § *Post-deploy feedback*.
+
+**Hard rule:** never post without showing the redacted draft + getting explicit "yes" from the user. The skill is the user's submitter; consent gates everything.
+
+---
+
+## Sanitization checklist
+
+Apply BEFORE drafting. Scan the deployment session — including chat transcript, any tool outputs Claude has in context, any state-file references — and replace identifiers per the table.
+
+### Strip-list (regex patterns + replacements)
+
+| Class | Detection | Replacement |
+|---|---|---|
+| **Domains** (apex, www, admin) | Anything matching the user's `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` collected during inputs, plus generic FQDNs in URL paths the user typed | `${CANONICAL_HOST}` / `${APEX}` / `${ADMIN_DOMAIN}` |
+| **Public IPv4** | `\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b` (excluding RFC-1918 ranges if you want to allow them as `${PRIVATE_IP}`) | `${PUBLIC_IP}` |
+| **Private IPv4** | `\b(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.)[0-9.]+\b` | `${PRIVATE_IP}` (or strip if it leaks network topology) |
+| **IPv6** | Standard IPv6 patterns | `${PUBLIC_IPV6}` / `${PRIVATE_IPV6}` |
+| **SSH key paths** | Anything matching `~/.ssh/[^ ]+`, `/home/[^/]+/\.ssh/[^ ]+`, `*.pem`, `*.priv`, `id_(rsa|ed25519|ecdsa)` | `${KEY_PATH}` |
+| **SSH key contents** | `-----BEGIN [A-Z ]+ KEY-----` blocks | `<REDACTED-SSH-KEY>` |
+| **Resend API key** | `re_[A-Za-z0-9_]+` | `<REDACTED-RESEND-KEY>` |
+| **SendGrid API key** | `SG\.[A-Za-z0-9._-]+` | `<REDACTED-SENDGRID-KEY>` |
+| **OpenAI API key** | `sk-[A-Za-z0-9]{20,}` | `<REDACTED-OPENAI-KEY>` |
+| **Anthropic API key** | `sk-ant-[A-Za-z0-9_-]{20,}` | `<REDACTED-ANTHROPIC-KEY>` |
+| **Slack tokens** | `xox[bp]-[A-Za-z0-9-]+` | `<REDACTED-SLACK-TOKEN>` |
+| **GitHub PAT** | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]+` | `<REDACTED-GH-PAT>` |
+| **AWS access key ID** | `AKIA[0-9A-Z]{16}` | `<REDACTED-AWS-KEY>` |
+| **AWS secret key** | After `aws_secret_access_key`, 40-char base64 | `<REDACTED-AWS-SECRET>` |
+| **AWS account ID** | 12 consecutive digits in AWS context (ARN, account-id field) | `${AWS_ACCOUNT}` |
+| **AWS profile name** | Whatever the user collected as `aws_profile` during inputs | `${AWS_PROFILE}` |
+| **GCP service-account JSON** | `"type": "service_account"` blocks | `<REDACTED-GCP-SA>` |
+| **Generic Bearer token** | `Bearer [A-Za-z0-9._~+/=-]{20,}` | `<REDACTED-BEARER>` |
+| **Email addresses** | RFC-822 pattern; especially the LE email + SMTP from-address + any user identity email | `${EMAIL}` |
+| **State-file contents** | Anything from `~/.open-forge/deployments/<name>.yaml` raw | Reference by deployment name only, never paste contents |
+| **MySQL/Postgres password** | After `password=` / `--password ` / `IDENTIFIED BY ` | `<REDACTED-DB-PASSWORD>` |
+| **OAuth client secrets** | After `client_secret` / `CLIENT_SECRET` | `<REDACTED-CLIENT-SECRET>` |
+| **Random bytes from `openssl rand -hex N`** that the user generated as a secret | Long hex strings used as secrets | `<REDACTED-RANDOM-SECRET>` |
+
+### Manual review pass (after regex)
+
+After regex-based sanitization, do a final read-through looking for:
+
+- **Hostnames in URL paths** that contain the user's domain (sed/regex may have missed embedded URLs).
+- **Username conventions** that are personally identifiable (e.g. `qi-experiment` as an AWS profile).
+- **Stack-trace lines** containing absolute filesystem paths (`/home/<user>/...`).
+- **Anything pasted from the user's clipboard or env vars** that wasn't covered by the strip-list.
+
+If you can't confidently classify something as safe, **redact it** — the user's final review is a safety net, not the only line of defense.
+
+### What you may keep
+
+| Class | OK to keep | Why |
+|---|---|---|
+| Recipe filenames (`ghost.md`, `openclaw.md`) | ✅ | Public; needed for context |
+| Plugin version (`0.20.0`) | ✅ | Public; needed for triage |
+| Combo names (`Ghost-CLI on Ubuntu`, `DigitalOcean droplet`) | ✅ | Public; needed for context |
+| Generic error messages quoted from upstream tools | ⚠️ | OK if no identifiers; redact paths and IPs from stack traces |
+| `${VAR}` placeholders | ✅ | These are the redactions; they're fine |
+| Public repo URLs (upstream docs you're proposing to add) | ✅ | Public |
+
+---
+
+## Draft templates
+
+Each template renders into the matching `.github/ISSUE_TEMPLATE/*.yml` form. The structure mirrors the form fields so the user pastes the body and the form auto-validates the sanitization checkboxes.
+
+### Channel 1 — recipe feedback (default at end of deploy)
+
+```markdown
+**Recipe**: <recipe-filename>
+**Combo**: <infra adapter> / <runtime>
+**Plugin version**: <version-from-plugin.json>
+**Outcome**: <one-of: Deploy succeeded with notes / Deploy succeeded after retries / Deploy failed; recovered manually / Deploy failed; abandoned / Recipe was outdated>
+
+## What the recipe missed
+
+<Concrete description: what surprised you, what failed, what required manual intervention. Sanitized.>
+
+## Suggested edit (optional — diff format preferred)
+
+```diff
+@@ <section header from the recipe> @@
+- <line that was wrong / missing>
++ <line that should be there>
+```
+
+## Sanitization confirmation
+- [x] All domains, IP addresses, SSH key paths, API keys, AWS account IDs, and email addresses stripped from this issue body.
+- [x] I understand this issue is public and permanent. I grant a non-revocable license to use this content in the open-forge recipe.
+```
+
+### Channel 2 — software nomination (Tier 2 → Tier 1)
+
+```markdown
+**Software name**: <project>
+**Upstream repo**: <github URL>
+**Upstream install-method index**: <docs / repo path / wiki URL>
+**Intended deploy combo**: <infra> / <runtime>
+
+## Why Tier 1?
+
+<What's painful about this software's install that compounds across deploys?
+Per the demand-driven graduation criteria in CLAUDE.md, a Tier 1 recipe earns
+its keep when the captured tribal knowledge saves the next user real pain.>
+
+## In-scope check (per CLAUDE.md § Is this software in scope?)
+
+This software is: <one-of: deployable service / static-site generator / AI inference server / CI runner / storage backend / not sure>
+
+## Confirmation
+- [x] I have read the *Is this software in scope?* and *Demand-driven graduation criteria* sections in CLAUDE.md.
+- [x] This software has at least one upstream-documented install method or canonical install artifact in-repo.
+```
+
+### Channel 3 — method proposal
+
+```markdown
+**Recipe to extend**: <recipe-filename>
+**Method name**: <e.g. "Snap package", "Helm chart">
+**Upstream URL documenting this method**: <URL>
+**Source type**: <First-party — published by upstream / Community-maintained>
+
+## Canonical install command(s)
+
+```bash
+<paste verbatim from upstream>
+```
+
+## Why this method matters
+
+<When would a user pick this method over the existing options in the recipe?>
+
+## Confirmation
+- [x] I have verified the upstream URL above shows this install method on the current upstream version.
+- [x] No credentials, IPs, or other identifiers in this issue.
+```
+
+---
+
+## Submission paths (try in order)
+
+The skill never opens a browser silently or POSTs without explicit user confirmation. Three submission paths in priority order:
+
+### 1. `gh` CLI (preferred when available)
+
+```bash
+# Check if gh is authenticated for the right account
+gh auth status
+
+# If yes, submit
+gh issue create \
+  --repo zhangqi444/open-forge \
+  --title "<title from template>" \
+  --body-file /tmp/feedback-draft.md \
+  --label recipe-feedback,recipe:<name>
+```
+
+Strengths: works headlessly in chat; respects user's existing GitHub auth.
+
+Caveats: user must have `gh` installed + authenticated. If `gh auth status` errors, fall through to path 2.
+
+### 2. GitHub MCP server (if available)
+
+If `mcp__github__issue_write` is available in the tool list, use it:
+
+```
+mcp__github__issue_write({
+  method: "create",
+  owner: "zhangqi444",
+  repo: "open-forge",
+  title: "<title>",
+  body: "<full body>",
+  labels: ["recipe-feedback", "recipe:<name>"]
+})
+```
+
+Strengths: no `gh` install needed; uses the MCP server's auth.
+
+Caveats: only works if the MCP server is configured with appropriate scopes.
+
+### 3. Prefilled URL (always-available fallback)
+
+When neither `gh` nor the GitHub MCP works, generate a URL the user opens in a browser:
+
+```
+https://github.com/zhangqi444/open-forge/issues/new?template=recipe-feedback.yml&title=<URL-encoded-title>&body=<URL-encoded-body>
+```
+
+Print the URL in chat with the instruction:
+
+> *"I can't post for you in this environment. Open this URL in a browser, review one more time, and click Submit:*
+>
+> *<URL>*
+>
+> *The form has the same sanitization checkboxes from the template — they'll be checked based on what you've already confirmed in chat."*
+
+URL-encode the title + body. GitHub URL length limit is ~8 KB total; if the body is longer, truncate the body and put the rest in a `<details>` block (or warn the user to paste it manually).
+
+---
+
+## Liability + license boilerplate (paste at end of every issue body)
+
+Append this exact block as the final paragraph of every issue body before submission:
+
+```markdown
+---
+
+> By submitting this issue, I grant a non-revocable license to the open-forge project to use this content in recipes and documentation. The open-forge project bears no liability for my choice to share. I have reviewed the issue body for credentials and personal information per CLAUDE.md § *Sanitization principles*.
+```
+
+This is in addition to the checkboxes in the issue-template form — it's an extra paper trail in the issue body itself.
+
+---
+
+## When the deploy aborted before completion
+
+If the user wants to file feedback about a deploy that failed mid-phase (e.g. preflight passed, provisioning failed at the security-group step), the `Outcome` field should be *"Deploy failed; abandoned"* and the body should include:
+
+- Which phase failed.
+- What the error was (sanitized — strip stack traces of paths/IPs).
+- What workaround the user attempted (if any).
+- Whether the user wants the recipe edited to handle this case, or whether they think it was an upstream / cloud-account issue (out of recipe scope).
+
+These are often the highest-value feedback issues — they catch recipes that succeed in the maintainer's environment but fail in others.
+
+---
+
+## Failure modes to watch for
+
+- **User says "post it" too quickly.** Respect their consent, but flag any line you weren't 100% sure about: *"Posting now. One last thing — line 14 mentions a username `qi-experiment` that might be your AWS profile name. Was that intentional?"*
+- **Drafts that quote upstream error messages with embedded user data.** Common with Bitnami's `bncert-tool` output, AWS CLI errors quoting account IDs in ARNs.
+- **State-file leaks.** If the user asks Claude to read `~/.open-forge/deployments/<name>.yaml` while drafting, do **not** paste contents — reference by deployment name only.
+- **Multiple rapid yes-clicks.** If the user says "yes, yes, yes, post" to skip the review, slow down: re-show the draft once, get confirmation, then submit. Speed is not a user safety feature.

--- a/docs/platforms/hermes.md
+++ b/docs/platforms/hermes.md
@@ -1,0 +1,144 @@
+# Using open-forge with Hermes-Agent
+
+Hermes-Agent ([github.com/NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent)) is a self-improving personal AI agent from Nous Research, structurally similar to OpenClaw but Python-based with autonomous skill creation. Skills follow the same SKILL.md frontmatter convention OpenClaw uses (the [agentskills.io](https://agentskills.io) "open standard"), so open-forge ships as a single skill bundle that drops into either ecosystem.
+
+> **Agent-mode caveat:** Same as OpenClaw — **direct credential paste (Pattern 5) is disabled** when open-forge runs inside Hermes. Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat. The skill only accepts file path / env var / cloud-CLI session / secrets-manager reference. See SKILL.md § *Asking for credentials* for the full agent-mode rules.
+
+## Install
+
+Hermes user skills live at `~/.hermes/skills/`. Imports from OpenClaw go to `~/.hermes/skills/openclaw-imports/`. open-forge ships compatible with both paths:
+
+```bash
+# 1. Generate the Hermes skill bundle
+git clone https://github.com/zhangqi444/open-forge ~/code/open-forge
+cd ~/code/open-forge
+./scripts/build-dist.sh hermes
+# Outputs: dist/hermes/SKILL.md (with Hermes-flavored frontmatter)
+
+# 2. Drop into your Hermes skills directory
+mkdir -p ~/.hermes/skills/open-forge/
+cp dist/hermes/SKILL.md ~/.hermes/skills/open-forge/
+
+# 3. Restart Hermes so the skill discovers
+hermes gateway restart
+```
+
+Verify:
+
+```bash
+hermes skills list | grep open-forge
+# or via slash command in any channel:
+#   /skills
+```
+
+## Invoke
+
+From any channel Hermes is paired with:
+
+> *"Self-host OpenClaw on a Hetzner CX22 with the local Ollama provider."*
+
+Hermes recognizes the deploy intent (matches the skill description) and follows the phased workflow.
+
+You can also invoke explicitly via slash command:
+
+> `/open-forge Self-host Mastodon on my Oracle Cloud ARM.`
+
+## Tool translation
+
+| open-forge concept | Hermes equivalent |
+|---|---|
+| `AskUserQuestion` (structured choice) | Hermes sends a message with numbered options; user replies inline |
+| `WebFetch` | Hermes's `fetch` tool (or `curl` via shell) |
+| `mcp__github__issue_write` | Hermes's MCP integration with the GitHub MCP server (preferred), or `gh` CLI shell-out |
+| Persistent state file | Native fit — Hermes is a long-running daemon |
+| OpenClaw migration | If user previously used open-forge on OpenClaw, the state file at `~/.open-forge/deployments/` is portable; `hermes claw migrate` (per Hermes upstream) helps with cross-agent state transfer for general state, but open-forge's per-deployment YAMLs work as-is on Hermes |
+
+## Async-friendly phases
+
+Same as OpenClaw — long-running daemon = natural fit for the phased workflow's time-elapsed waits:
+
+| Phase | Sync mode (Claude Code) | Agent mode (Hermes) |
+|---|---|---|
+| `dns` propagation wait | User watches `dig` | Hermes polls `dig` and pings user when resolved |
+| `tls` cert issuance | User watches certbot | Hermes monitors the certbot log, notifies on completion |
+| `provision` instance-boot wait | User retries `ssh` | Hermes auto-retries SSH on a backoff |
+
+## Channel-aware UX
+
+Hermes can route message types to different channels (similar to OpenClaw). Same recommendations:
+
+- Long-form (DNS records, recipe explanations) → email / note
+- Quick decisions → primary chat
+- Async waits → channel notifications on state change
+- Final hand-off (admin URL, rotation reminders) → secure 1:1 channel only
+
+## Self-improvement integration
+
+Hermes has an autonomous skill-creation system that learns from successful task completion. open-forge's [feedback loop](../../plugins/open-forge/skills/open-forge/references/modules/feedback.md) is complementary:
+
+- **Hermes's autonomous skill creation** — captures *agent-side* patterns (which tools the agent invoked, in what order)
+- **open-forge's feedback loop** — captures *deployment-side* patterns (which gotchas surfaced, what surprised the user)
+
+After a successful deploy, both can capture data — Hermes learns from the agent's procedural memory; open-forge proposes recipe edits via a sanitized GitHub issue. Don't conflate them.
+
+## Limitations
+
+- **Pattern 5 (direct paste) is disabled** — same hard rule as OpenClaw. File / env / cloud-CLI / secrets-manager only.
+- **Hermes's skill-import path** at `~/.hermes/skills/openclaw-imports/` is for skills migrated FROM OpenClaw; new Hermes-native installs of open-forge should go to `~/.hermes/skills/open-forge/` directly.
+- **Group channels** unsafe for deploy conversations — same caveat as OpenClaw.
+- **Hermes's MCP integration** can use the GitHub MCP server for issue posting; if the user hasn't set this up, fall back to `gh` CLI or prefilled URL.
+- **The `hermes claw migrate` command** is for migrating users from OpenClaw to Hermes broadly (memory, settings); it does NOT migrate the open-forge state file specifically. The state file at `~/.open-forge/deployments/` is portable across both agents because open-forge owns its own state storage.
+
+## Example session (Telegram)
+
+```
+User (Telegram 14:02):  Self-host Vaultwarden on Hetzner.
+
+Hermes (14:02):         I'll use the open-forge skill. Combo: Hetzner Cloud CX
+                        × Docker. I need three things:
+                          1. Hetzner API token (file path / env var name /
+                             1Password ref — paste is disabled in agent mode)
+                          2. Domain you want to use
+                          3. Any preference on CX server size (default: cx22)
+
+User (14:03):           Token at HCLOUD_TOKEN env var, domain
+                        vault.aria.dev, default size
+
+Hermes (14:03):         [reads $HCLOUD_TOKEN, runs hcloud server create]
+                        Server up at <PUBLIC_IP>. Add this DNS record at
+                        your registrar:
+                          A vault.aria.dev → <PUBLIC_IP>
+                        I'll poll every 60s. Will ping you when DNS resolves.
+
+Hermes (14:31):         DNS resolved. Issuing TLS cert via certbot…
+
+Hermes (14:33):         Vaultwarden running at https://vault.aria.dev.
+                        Admin token sent via secure note. Rotate after
+                        first login.
+
+User (15:45):           That worked. Anything to add to the recipe?
+
+Hermes (15:45):         I observed the DNS-propagation wait took ~28 min for
+                        your registrar. The current vaultwarden.md recipe
+                        doesn't note Hetzner Robot users may see longer
+                        propagation. Want me to draft a recipe-feedback
+                        issue with that gotcha? (sanitized — domain, IP,
+                        token all redacted; you review before posting)
+
+User (15:46):           Yes
+
+Hermes (15:46):         [drafts redacted issue body in chat for review]
+                        ...
+```
+
+## Reporting issues / contributing
+
+Hermes's MCP integration (or `gh` CLI shell-out) handles GitHub issue posting. Same flow as on Claude Code — sanitized draft → user review → post. See [`references/modules/feedback.md`](../../plugins/open-forge/skills/open-forge/references/modules/feedback.md).
+
+## Submitting open-forge to agentskills.io
+
+[agentskills.io](https://agentskills.io) is the open-standard skills registry that both Hermes and OpenClaw consume. To publish open-forge:
+
+1. Build the bundle: `./scripts/build-dist.sh hermes` (the file is also valid for OpenClaw — same frontmatter conventions).
+2. Submit to agentskills.io via their publishing flow (see their docs at first publication).
+3. Both Hermes and OpenClaw users install via their respective `skills install open-forge` command.

--- a/docs/platforms/openclaw.md
+++ b/docs/platforms/openclaw.md
@@ -1,0 +1,124 @@
+# Using open-forge with OpenClaw
+
+OpenClaw ([openclaw.ai](https://openclaw.ai)) is a self-hosted personal AI agent — a long-running daemon that talks to you via WhatsApp / Telegram / Slack / iMessage / etc. open-forge can run as an OpenClaw **skill**, letting users say *"self-host Vaultwarden on my Hetzner box"* from any messaging channel and have OpenClaw orchestrate the deploy on whatever host it's running on.
+
+> **Agent-mode caveat:** When open-forge runs inside an autonomous agent like OpenClaw, **direct credential paste (Pattern 5)** is disabled. Pasting an API key into WhatsApp / Telegram / Slack is meaningfully riskier than pasting into a coding-tool chat (chat history syncs to phones, may be cloud-backed up, often persists indefinitely). The agent will only accept credentials via file path / env var / cloud-CLI session / secrets-manager reference. See SKILL.md § *Asking for credentials* for the full agent-mode rules.
+
+## Install
+
+OpenClaw skills live at `~/.openclaw/workspace/skills/<skill>/SKILL.md` per [docs.openclaw.ai/skills](https://docs.openclaw.ai/skills/) (Workspace skill type). open-forge ships a pre-built skill bundle:
+
+```bash
+# 1. Generate the OpenClaw skill bundle from canonical sources
+git clone https://github.com/zhangqi444/open-forge ~/code/open-forge
+cd ~/code/open-forge
+./scripts/build-dist.sh openclaw
+# Outputs: dist/openclaw/SKILL.md (with OpenClaw frontmatter)
+
+# 2. Drop into your OpenClaw workspace
+mkdir -p ~/.openclaw/workspace/skills/open-forge/
+cp dist/openclaw/SKILL.md ~/.openclaw/workspace/skills/open-forge/
+
+# 3. Restart the OpenClaw gateway so the skill loads
+openclaw gateway restart
+```
+
+OpenClaw auto-discovers the new skill on next message. Verify:
+
+```bash
+openclaw skills list | grep open-forge
+```
+
+## Invoke
+
+From any channel OpenClaw is paired with:
+
+> *"Self-host Vaultwarden on my Hetzner CX22."*
+
+OpenClaw recognizes the deploy intent (the skill description matches), loads `~/.openclaw/workspace/skills/open-forge/SKILL.md` into context, and follows the phased workflow.
+
+For more explicit triggering:
+
+> *"Use the open-forge skill to deploy Mastodon on my Oracle Cloud ARM."*
+
+## Tool translation
+
+| open-forge concept | OpenClaw equivalent |
+|---|---|
+| `AskUserQuestion` (structured choice) | OpenClaw sends a message via the active channel listing options as a numbered list; user replies with the number or the text |
+| `WebFetch` | OpenClaw's built-in fetch capability (or `curl` via the `bash` tool) |
+| `mcp__github__issue_write` | OpenClaw's `gh-issues` skill (one of the bundled skills) — composes via `gh` CLI under the hood |
+| Persistent state file (`~/.open-forge/deployments/<name>.yaml`) | Native fit — OpenClaw is a long-running daemon; resume across days/weeks works automatically |
+
+## Async-friendly phases
+
+Agent mode actually fits open-forge's phased workflow *better* than coding-tool mode in places — because the agent runs as a daemon, time-elapsed waits become natural:
+
+| Phase | Sync mode (Claude Code) | Agent mode (OpenClaw) |
+|---|---|---|
+| `dns` "wait for propagation" | User watches `dig` until it resolves | OpenClaw polls `dig` on a 30-second loop and pings user when ready: *"DNS resolved! Continuing to TLS phase."* |
+| `tls` "wait for cert issuance" | User watches Let's Encrypt | OpenClaw monitors via the `acme.sh` / `certbot` log and notifies on success/failure |
+| `provision` "wait for instance to boot" | User polls `ssh` | OpenClaw retries SSH every 10s and proceeds when reachable |
+
+## Channel-aware UX
+
+OpenClaw can route different message types to different channels (WhatsApp for chat, email for "screenshot the DNS records you added at your registrar," voice for confirmations). The skill respects channel preferences:
+
+- **Long-form output** (DNS records to add at registrar, recipe explanations) → email or note
+- **Quick decisions** (yes/no, pick from list) → primary chat channel
+- **Async waits** (DNS propagation, TLS issuance) → channel notification when state changes
+- **Final hand-off** (admin URL, rotation reminders) → secure channel (not public group chats)
+
+## Limitations
+
+- **Pattern 5 (direct paste) is disabled** in agent mode. Period. Forces the user to provide credentials via file / env / cloud-CLI / secrets-manager. Adds friction; reduces leak risk.
+- **Multi-user OpenClaw deployments** (rare, but possible) need extra care — the skill's state file is per-deployment-name, but OpenClaw doesn't natively partition state by user. If multiple users share an OpenClaw instance, namespacing is the user's responsibility.
+- **Public group chats** are not safe contexts for deploy conversations — credentials, IPs, admin URLs all leak to the room. open-forge in OpenClaw should refuse to operate from group channels and ask the user to switch to a 1:1 DM.
+- **OpenClaw's onboard wizard runs once at install time**; the skill's per-deploy inputs are collected via the channel as messages, not via `openclaw onboard`.
+
+## Example session (WhatsApp)
+
+```
+User (WhatsApp 9:14am):  Self-host Vaultwarden on my Hetzner CX22.
+
+OpenClaw (9:14am):       I'll use the open-forge skill. Combo: Hetzner Cloud
+                         CX × Docker. I need:
+                           1. Hetzner API token (file path / env var / 1Password
+                              ref — paste is disabled in agent mode)
+                           2. Domain you want to use
+
+User (9:15am):           Token at ~/.config/hcloud/token, domain vault.aria.dev
+
+OpenClaw (9:15am):       Reading token from ~/.config/hcloud/token… got it.
+                         Provisioning CX22 server now (this takes 30-60 seconds)…
+
+OpenClaw (9:16am):       Server up at <PUBLIC_IP>. DNS records to add at your
+                         registrar:
+                           A vault.aria.dev → <PUBLIC_IP>
+                         I'll poll DNS every 60s and ping you when it resolves.
+
+OpenClaw (9:42am):       DNS resolved (took 27 minutes). Continuing TLS phase…
+
+OpenClaw (9:44am):       TLS cert issued. Vaultwarden running at
+                         https://vault.aria.dev. Bootstrap admin at
+                         https://vault.aria.dev/admin (token at <link sent
+                         via email>; rotate after first login).
+
+User (10:30am):          Done.
+
+OpenClaw (10:30am):      Want to share what you learned? I can draft a recipe-
+                         feedback issue for vaultwarden.md (sanitized; you
+                         review before posting).
+```
+
+## Reporting issues / contributing
+
+OpenClaw can run `gh issue create` directly (via the `gh-issues` skill or the `bash` tool). The post-deploy feedback flow at the end of every deploy works the same way as on Claude Code — sanitized draft → user review → post. See [`references/modules/feedback.md`](../../plugins/open-forge/skills/open-forge/references/modules/feedback.md).
+
+## Submitting open-forge to ClawHub
+
+[ClawHub](https://docs.openclaw.ai/skills/clawhub) is OpenClaw's skill registry. To publish open-forge there:
+
+1. Build the skill bundle: `./scripts/build-dist.sh openclaw`.
+2. Follow ClawHub's submission flow (see ClawHub docs at first publication time — out of scope for this guide).
+3. Once published, users install via `openclaw skill install open-forge` instead of the manual workspace copy.

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-forge",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, helm, podman, docker, lume, tailscale, terraform, cdk, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw, Hermes-Agent, Ollama, Open WebUI, Stable Diffusion WebUI (Automatic1111), ComfyUI, Dify, LibreChat, AnythingLLM, Aider, vLLM, Langfuse. AI stack focus: Ollama (single-user LLM inference) + vLLM (production-grade LLM inference) + Open WebUI / LibreChat (multi-user chat UIs) + Stable Diffusion WebUI / ComfyUI (image generation) + AnythingLLM (RAG-focused workspace) + Aider (terminal pair-programming CLI) + Langfuse (LLM observability + evals) compose into a complete local-AI stack; OpenClaw + Hermes-Agent are agent projects; Dify is the LLMOps platform layer. Every recipe is verified against upstream's docs index per the strict-doc policy in CLAUDE.md (community-maintained methods are explicitly flagged when upstream ships no first-party version).",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",

--- a/plugins/open-forge/skills/open-forge/SKILL.md
+++ b/plugins/open-forge/skills/open-forge/SKILL.md
@@ -213,6 +213,17 @@ Whenever the skill needs sensitive input — API keys, DB passwords, OAuth clien
 4. **Never accept SSH key contents.** Always ask for the path; skill uses `ssh -i <path>`.
 5. **End-of-deploy rotation reminder** if the user pasted any secret during the deploy: surface during the `hardening` phase with a list of (credential, dashboard URL) pairs. Pasted secrets remain in session history; rotating now bounds the exposure.
 
+### Agent-mode rules (OpenClaw / Hermes / any messaging-channel agent)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks to the user via WhatsApp / Telegram / Slack / iMessage / email / etc.), apply these stricter rules **on top of** the base five-pattern flow above:
+
+- **Pattern 5 (direct paste) is DISABLED.** Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat — chat history syncs to the user's phone, may be backed up to cloud (iCloud / Google Drive), and often persists indefinitely. Refuse a paste with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead. See [credentials.md](references/modules/credentials.md) for options."* If the user insists, refuse again — don't compromise.
+- **Reject deploy conversations from group channels.** Group chats leak everything to all members (credentials, IPs, admin URLs). When invoked from a group context, respond: *"Self-host deploys involve sensitive info. Switch to a 1:1 DM and ask again."* Then stop.
+- **Use async polling for time-elapsed waits**, not blocking prompts. `dns` propagation, `tls` cert issuance, `provision` instance-boot — all become *"I'll poll and ping you when ready"* rather than *"press enter when DNS propagates."* Agents have a daemon; use it.
+- **Channel-aware response routing.** Long-form content (DNS records to add at registrar, full recipe explanations, admin-bootstrap URLs) should go via secure / structured channels (email, signed note, secure-share link) when the agent supports them, not the chat. Quick decisions (yes/no, pick from list) stay in chat. Final hand-off (admin URL, rotation reminders) → secure 1:1 only.
+
+See [`docs/platforms/openclaw.md`](../../../../docs/platforms/openclaw.md) and [`docs/platforms/hermes.md`](../../../../docs/platforms/hermes.md) for the full agent-mode integration guides.
+
 See [`references/modules/credentials.md`](references/modules/credentials.md) for the full pattern details, per-credential-class recommendations, and failure-mode handling.
 
 ## Verification after each phase

--- a/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+++ b/plugins/open-forge/skills/open-forge/references/modules/credentials.md
@@ -211,9 +211,19 @@ If the user picked patterns 1-4 for everything, no rotation reminder is needed (
 
 ---
 
+## Agent-mode rules (OpenClaw / Hermes / messaging-channel agents)
+
+When this skill runs inside a long-running personal AI agent (OpenClaw, Hermes-Agent, or any agent that talks via WhatsApp / Telegram / Slack / iMessage / email), the rules tighten:
+
+- **Pattern 5 (direct paste) is DISABLED.** Messaging channels persist chat history far longer than coding-tool sessions, sync to phones, often back up to cloud — pasting credentials there is meaningfully riskier. Refuse with: *"I can't accept credentials pasted into a messaging channel. Use a file path, env var, cloud-CLI session, or secrets-manager reference instead."* If the user insists, refuse again. No exceptions.
+- **Reject deploy conversations from group channels** entirely. Group chats leak to all members. Respond once: *"Self-host deploys involve sensitive info — switch to a 1:1 DM."* Then stop until the user re-asks from a private channel.
+- **Final hand-off content** (admin bootstrap URLs, generated passwords, rotation reminders) → secure 1:1 channel only, never group / public / shared.
+
+The base five-pattern flow above still applies; agent-mode just removes Pattern 5 from the offered options and adds the group-channel guard.
+
 ## Failure modes
 
-- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening).
+- **User insists on pasting "to keep it simple."** Respect their consent after risk acknowledgement, but surface the rotation reminder twice (once mid-deploy, once at hardening). **In agent mode, refuse instead** — don't accept paste regardless of insistence.
 - **User pastes by accident** (meant to paste a path, pasted the key itself). Detect via key-shape regex (`re_[A-Za-z0-9_]+`, `sk-ant-`, `AKIA[0-9A-Z]{16}`, etc.); if a paste looks like a key when the prompt expected a path, stop and ask: *"That looks like the key itself, not a path. Did you mean to paste the key directly? (if so, see risks above; if not, paste the path)."*
 - **Env var not present in Claude's shell.** User exported it after starting Claude Code. Ask them to restart Claude Code with the var set, or fall back to a different pattern.
 - **File mode is too permissive** (e.g. `0644`). Refuse to read; offer to run `chmod 600 <path>` first.

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -9,6 +9,8 @@
 #   cursor     — .mdc rule files for .cursor/rules/
 #   aider      — CONVENTIONS.md + read-files.txt + .aider.conf.yml
 #   continue   — config snippet + per-recipe prompt files for Continue.dev
+#   openclaw   — SKILL.md for ~/.openclaw/workspace/skills/open-forge/
+#   hermes     — SKILL.md for ~/.hermes/skills/open-forge/
 #   generic    — single-file concatenated bundle for any tools-using LLM
 #   all        — run all of the above
 #
@@ -227,6 +229,66 @@ EOF
   echo "  ✓ dist/continue/config.snippet.yaml"
 }
 
+build_openclaw() {
+  echo "→ Building OpenClaw skill bundle…"
+  mkdir -p "$DIST_DIR/openclaw"
+
+  # OpenClaw skill SKILL.md — drop into ~/.openclaw/workspace/skills/open-forge/SKILL.md
+  cat > "$DIST_DIR/openclaw/SKILL.md" <<'EOF'
+---
+name: open-forge
+description: "Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail."
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🛠️",
+        "requires": { "bins": ["bash", "curl", "ssh"] },
+        "agent_mode": true,
+        "credentials_paste_disabled": true,
+        "source": "https://github.com/zhangqi444/open-forge",
+        "docs": "https://deepwiki.com/zhangqi444/open-forge"
+      }
+  }
+---
+
+# open-forge — self-host any open-source app
+
+EOF
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/openclaw/SKILL.md"
+  echo -e "\n\n---\n\n# Credentials handling (agent-mode rules apply)\n" >> "$DIST_DIR/openclaw/SKILL.md"
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/openclaw/SKILL.md"
+  echo -e "\n\n---\n\n# Post-deploy feedback flow\n" >> "$DIST_DIR/openclaw/SKILL.md"
+  cat "$REFS_DIR/modules/feedback.md" >> "$DIST_DIR/openclaw/SKILL.md"
+
+  echo "  ✓ dist/openclaw/SKILL.md ($(wc -l < "$DIST_DIR/openclaw/SKILL.md") lines)"
+}
+
+build_hermes() {
+  echo "→ Building Hermes-Agent skill bundle…"
+  mkdir -p "$DIST_DIR/hermes"
+
+  # Hermes uses agentskills.io 'open standard' frontmatter — simpler, no metadata block
+  cat > "$DIST_DIR/hermes/SKILL.md" <<'EOF'
+---
+name: open-forge
+description: Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail. Agent-mode rules apply (no chat-paste credentials, no group-channel deploys).
+---
+
+# open-forge — self-host any open-source app
+
+> **Agent-mode rules in effect.** Pattern 5 (direct credential paste) is disabled. Group-channel deploy conversations are refused. See § *Asking for credentials → Agent-mode rules* below.
+
+EOF
+  cat "$SKILL_DIR/SKILL.md" >> "$DIST_DIR/hermes/SKILL.md"
+  echo -e "\n\n---\n\n# Credentials handling (agent-mode rules apply)\n" >> "$DIST_DIR/hermes/SKILL.md"
+  cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/hermes/SKILL.md"
+  echo -e "\n\n---\n\n# Post-deploy feedback flow\n" >> "$DIST_DIR/hermes/SKILL.md"
+  cat "$REFS_DIR/modules/feedback.md" >> "$DIST_DIR/hermes/SKILL.md"
+
+  echo "  ✓ dist/hermes/SKILL.md ($(wc -l < "$DIST_DIR/hermes/SKILL.md") lines)"
+}
+
 build_generic() {
   echo "→ Building generic bundle…"
   mkdir -p "$DIST_DIR/generic"
@@ -261,12 +323,16 @@ case "$PLATFORM" in
   cursor)   build_cursor ;;
   aider)    build_aider ;;
   continue) build_continue ;;
+  openclaw) build_openclaw ;;
+  hermes)   build_hermes ;;
   generic)  build_generic ;;
   all)
     build_codex
     build_cursor
     build_aider
     build_continue
+    build_openclaw
+    build_hermes
     build_generic
     ;;
   *) usage ;;


### PR DESCRIPTION
## Summary

Extends multi-platform support to **autonomous agent platforms** — OpenClaw and Hermes-Agent. Users can now ask their personal AI agent (via WhatsApp / Telegram / Slack / iMessage / etc.) to *"self-host Vaultwarden on my Hetzner box"* and have the agent orchestrate the deploy on whatever host it's running on.

Bumps plugin to **v0.22.0**.

## Research summary

Both platforms have skills systems following the [agentskills.io](https://agentskills.io) "open standard" — `SKILL.md` with `name` + `description` frontmatter. Verified by:

- Cloning [`NousResearch/hermes-agent`](https://github.com/NousResearch/hermes-agent) locally and reading `skills/note-taking/obsidian/SKILL.md`.
- Reading [`openclaw/openclaw/skills/github/SKILL.md`](https://github.com/openclaw/openclaw/tree/main/skills) via raw.github.

(Both projects' docs sites — `docs.openclaw.ai`, `nousresearch.github.io/hermes-agent` — returned 403 on WebFetch; fell back to repo content per CLAUDE.md fetch-failure clause.)

| Platform | Frontmatter shape | Skill location |
|---|---|---|
| **OpenClaw** | `name` + `description` + `metadata` block (emoji / `requires.bins` / install methods) | `~/.openclaw/workspace/skills/<skill>/SKILL.md` |
| **Hermes** | `name` + `description` (simpler — no metadata) | `~/.hermes/skills/<skill>/SKILL.md` |

## Agent-mode rules (new in this PR)

Per the design discussion, **direct credential paste (Pattern 5) is disabled** in agent mode. Pasting credentials into messaging channels is meaningfully riskier than into coding-tool chat — chat history syncs to phones, may be cloud-backed up, often persists indefinitely. Three additional hard rules apply when open-forge runs inside OpenClaw / Hermes / any messaging-channel agent:

1. **Pattern 5 (direct paste) disabled.** Refuse with: *"I can't accept credentials pasted into a messaging channel. Use file path / env var / cloud-CLI session / secrets-manager reference."* No exceptions even on user insistence.
2. **Group-channel deploys refused.** Group chats leak everything to all members. Respond once: *"Switch to a 1:1 DM."* Then stop.
3. **Async polling for time-elapsed waits.** DNS propagation, TLS issuance, SSH boot — all become poll-and-ping rather than blocking prompts. Agents have a daemon; use it.
4. **Channel-aware response routing.** Long-form content (DNS records, recipe explanations) → email / structured note. Quick decisions → primary chat. Final hand-off (admin URL, rotation reminders) → secure 1:1.

Codified in both `SKILL.md § Asking for credentials → Agent-mode rules` and `references/modules/credentials.md § Agent-mode rules`.

## What changed

| File | Change | Size |
|---|---|---|
| `docs/platforms/openclaw.md` (new) | Install + invoke + tool translation + async-phases table + channel-aware UX + WhatsApp example session + ClawHub submission note | ~150 lines |
| `docs/platforms/hermes.md` (new) | Same shape as OpenClaw guide. Notes Hermes's autonomous skill-creation is complementary to (not redundant with) open-forge's feedback loop. agentskills.io submission note. | ~150 lines |
| `SKILL.md` | New § *Agent-mode rules* under *Asking for credentials* | +14 lines |
| `references/modules/credentials.md` | New § *Agent-mode rules* before *Failure modes*; "Failure modes" first bullet updated to refuse paste in agent mode | +12 lines |
| `scripts/build-dist.sh` | New `build_openclaw()` and `build_hermes()` functions; wired into `all` | +66 lines |
| `dist/openclaw/SKILL.md` (new, generated) | OpenClaw-flavored bundle with name + description + metadata block | ~802 lines |
| `dist/hermes/SKILL.md` (new, generated) | Hermes-flavored bundle with agentskills.io open-standard frontmatter | ~792 lines |
| `dist/README.md` | Two new rows in the platform table | +2 lines |
| `README.md` | "Other AI coding tools" → "Other AI coding tools and agent platforms" (7-row table including OpenClaw + Hermes); "Agent-mode caveat" callout | +20 / -10 |
| `plugin.json` | 0.21.0 → 0.22.0 | — |

Plus: regenerated all 5 existing platform bundles since the SKILL.md and credentials.md updates flow through into them. CI's `dist-bundles-up-to-date` check should pass.

## Test plan

- [ ] CI's `dist-bundles-up-to-date` check passes (all bundles regenerated).
- [ ] `./scripts/build-dist.sh openclaw` and `./scripts/build-dist.sh hermes` produce bundles with the expected frontmatter.
- [ ] Live test on OpenClaw: drop `dist/openclaw/SKILL.md` into `~/.openclaw/workspace/skills/open-forge/`, restart gateway, ask via WhatsApp *"self-host Vaultwarden on Hetzner CX22"* — confirm skill loads and Pattern 5 is blocked.
- [ ] Live test on Hermes: drop `dist/hermes/SKILL.md` into `~/.hermes/skills/open-forge/`, restart, ask via Telegram — same flow.
- [ ] Group-channel test: ask the deploy question from an OpenClaw group chat — confirm refusal.

## Out of scope

- **ClawHub / agentskills.io publication.** Building a publishable bundle is in scope; submitting to upstream registries is a maintainer action that needs an account at each. Once published, install simplifies to `openclaw skill install open-forge` / `hermes skills install open-forge`.
- **Multi-user agent deployments.** Rare; namespacing is the user's responsibility per the openclaw.md doc.
- **Channel-routing implementation details.** The skill specifies *which* channel content should go to (long-form → email, hand-off → DM); the agent itself implements the actual routing (depends on channel adapters configured per-installation).

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_