### PR TITLE
fix: make dist/aider + dist/continue paths portable across machines

### DIFF
--- a/dist/aider/.aider.conf.yml
+++ b/dist/aider/.aider.conf.yml
@@ -1,10 +1,13 @@
 # Drop this file into your project root (or merge with existing config) to load
 # open-forge as default context for every Aider session in the project.
+#
+# Substitute ${OPEN_FORGE_REPO} with your clone path before use. Example:
+#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" .aider.conf.yml
 
 read:
-  - /home/user/open-forge/CLAUDE.md
-  - /home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md
-  - /home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/credentials.md
-  - /home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+  - ${OPEN_FORGE_REPO}/CLAUDE.md
+  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md
+  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/feedback.md
 
 auto-commits: false   # open-forge state files at ~/.open-forge/ shouldn't be auto-committed

--- a/dist/aider/read-files.txt
+++ b/dist/aider/read-files.txt
@@ -1,5 +1,7 @@
-/home/user/open-forge/CLAUDE.md
-/home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md
-/home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/credentials.md
-/home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/feedback.md
-/home/user/open-forge/plugins/open-forge/skills/open-forge/references/modules/preflight.md
+# Substitute ${OPEN_FORGE_REPO} with your clone path, e.g.:
+#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" read-files.txt
+${OPEN_FORGE_REPO}/CLAUDE.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/preflight.md

--- a/dist/continue/config.snippet.yaml
+++ b/dist/continue/config.snippet.yaml
@@ -1,17 +1,22 @@
 # Add to ~/.continue/config.yaml. Merge into existing top-level keys.
+#
+# Substitute ${OPEN_FORGE_REPO} with your clone path before use. Example:
+#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" config.snippet.yaml
 
 contextProviders:
   - name: file
     params:
-      baseDir: /home/user/open-forge/plugins/open-forge/skills/open-forge
+      baseDir: ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge
 
 prompts:
   - name: self-host
     description: "Deploy a self-hostable app via open-forge recipes"
     systemMessage: |
       You are the open-forge skill. When the user asks to self-host a service,
-      look up the matching recipe at /home/user/open-forge/plugins/open-forge/skills/open-forge/references/projects/<software>.md and
-      follow the phased workflow defined in /home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md.
+      look up the matching recipe at
+      ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/projects/<software>.md
+      and follow the phased workflow defined in
+      ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md.
 
       Apply credential-handling patterns from references/modules/credentials.md
       (five patterns; paste is last-resort).

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -164,25 +164,31 @@ EOF
   echo -e "\n\n---\n" >> "$DIST_DIR/aider/CONVENTIONS.md"
   cat "$REFS_DIR/modules/credentials.md" >> "$DIST_DIR/aider/CONVENTIONS.md"
 
-  # read-files.txt — list of files to --read
-  cat > "$DIST_DIR/aider/read-files.txt" <<EOF
-$REPO_ROOT/CLAUDE.md
-$SKILL_DIR/SKILL.md
-$REFS_DIR/modules/credentials.md
-$REFS_DIR/modules/feedback.md
-$REFS_DIR/modules/preflight.md
+  # read-files.txt — list of files to --read.
+  # Uses ${OPEN_FORGE_REPO} placeholder — users substitute with their actual clone path.
+  cat > "$DIST_DIR/aider/read-files.txt" <<'EOF'
+# Substitute ${OPEN_FORGE_REPO} with your clone path, e.g.:
+#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" read-files.txt
+${OPEN_FORGE_REPO}/CLAUDE.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/feedback.md
+${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/preflight.md
 EOF
 
-  # .aider.conf.yml — drop-in config
-  cat > "$DIST_DIR/aider/.aider.conf.yml" <<EOF
+  # .aider.conf.yml — drop-in config (uses ${OPEN_FORGE_REPO} placeholder)
+  cat > "$DIST_DIR/aider/.aider.conf.yml" <<'EOF'
 # Drop this file into your project root (or merge with existing config) to load
 # open-forge as default context for every Aider session in the project.
+#
+# Substitute ${OPEN_FORGE_REPO} with your clone path before use. Example:
+#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" .aider.conf.yml
 
 read:
-  - $REPO_ROOT/CLAUDE.md
-  - $SKILL_DIR/SKILL.md
-  - $REFS_DIR/modules/credentials.md
-  - $REFS_DIR/modules/feedback.md
+  - ${OPEN_FORGE_REPO}/CLAUDE.md
+  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md
+  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/credentials.md
+  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/modules/feedback.md
 
 auto-commits: false   # open-forge state files at ~/.open-forge/ shouldn't be auto-committed
 EOF
@@ -196,22 +202,28 @@ build_continue() {
   echo "→ Building Continue.dev bundle…"
   mkdir -p "$DIST_DIR/continue"
 
-  # config.snippet.yaml — to merge into ~/.continue/config.yaml
-  cat > "$DIST_DIR/continue/config.snippet.yaml" <<EOF
+  # config.snippet.yaml — uses ${OPEN_FORGE_REPO} placeholder so the file is
+  # portable across machines (CI / local / users' clones).
+  cat > "$DIST_DIR/continue/config.snippet.yaml" <<'EOF'
 # Add to ~/.continue/config.yaml. Merge into existing top-level keys.
+#
+# Substitute ${OPEN_FORGE_REPO} with your clone path before use. Example:
+#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" config.snippet.yaml
 
 contextProviders:
   - name: file
     params:
-      baseDir: $SKILL_DIR
+      baseDir: ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge
 
 prompts:
   - name: self-host
     description: "Deploy a self-hostable app via open-forge recipes"
     systemMessage: |
       You are the open-forge skill. When the user asks to self-host a service,
-      look up the matching recipe at $REFS_DIR/projects/<software>.md and
-      follow the phased workflow defined in $SKILL_DIR/SKILL.md.
+      look up the matching recipe at
+      ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/references/projects/<software>.md
+      and follow the phased workflow defined in
+      ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md.
 
       Apply credential-handling patterns from references/modules/credentials.md
       (five patterns; paste is last-resort).


### PR DESCRIPTION
## Summary

CI on PR #36 ([run 25146869467](https://github.com/zhangqi444/open-forge/actions/runs/25146869467/job/73708521703)) caught a path portability bug in the build script — but the PR was merged before this fix landed, so main currently has bundles with absolute paths embedded (pointing at the contributor's home directory).

This PR fixes the underlying script and regenerates the affected bundles with portable placeholders.

## Root cause

`scripts/build-dist.sh` resolved `$REPO_ROOT` from `$BASH_SOURCE` and embedded that absolute path into:

- `dist/aider/.aider.conf.yml`
- `dist/aider/read-files.txt`
- `dist/continue/config.snippet.yaml`

Locally my path was `/home/user/open-forge/`; on CI it'd resolve to `/home/runner/work/open-forge/open-forge/`. Whichever machine ran the build last "won" the file content; CI's `dist-bundles-up-to-date` regen check then saw drift on every run from a different machine.

## Fix

Replaced absolute `$REPO_ROOT`-derived paths with a literal `${OPEN_FORGE_REPO}` placeholder + an inline `sed` example for users to substitute their actual clone path before use. Generated files are now machine-independent.

```yaml
# Before
read:
  - /home/user/open-forge/CLAUDE.md
  - /home/user/open-forge/plugins/open-forge/skills/open-forge/SKILL.md

# After
# Substitute ${OPEN_FORGE_REPO} with your clone path before use:
#   sed -i "s|\${OPEN_FORGE_REPO}|$HOME/code/open-forge|g" .aider.conf.yml
read:
  - ${OPEN_FORGE_REPO}/CLAUDE.md
  - ${OPEN_FORGE_REPO}/plugins/open-forge/skills/open-forge/SKILL.md
```

This is also a stronger contract — users shouldn't be installing aider configs that reference a particular contributor's home directory.

## Files changed

| File | Change |
|---|---|
| `scripts/build-dist.sh` | `build_aider()` and `build_continue()` use `${OPEN_FORGE_REPO}` placeholder instead of `$REPO_ROOT`/`$SKILL_DIR`/`$REFS_DIR`. Bash heredocs switched to `<<'EOF'` (literal) so the placeholder is preserved verbatim. |
| `dist/aider/.aider.conf.yml` | Regenerated with placeholders + sed-example header comment |
| `dist/aider/read-files.txt` | Regenerated with placeholders + sed-example header comment |
| `dist/continue/config.snippet.yaml` | Regenerated with placeholders + sed-example header comment |

No version bump (build-script bug fix; not user-visible behavior change).

## Test plan

- [ ] CI's `dist-bundles-up-to-date` check passes (the actual proof — running on CI confirms the bundles are now machine-independent).
- [ ] Smoke test: `./scripts/build-dist.sh aider continue` on a different working directory should produce byte-identical files.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_