### PR TITLE
Update recipe count to 951+ and auto-count in build script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## What this project is
 
-`open-forge` is a guided self-hosting **skill** distributed via Claude Code's plugin marketplace and adapted for 6+ other AI platforms. It walks users from *"I have a cloud account and a domain"* to *"working app at https://my.domain"* via a phased workflow (preflight → provision → dns → tls → smtp → inbound → hardening → feedback) using ~180 verified recipes plus a live-derived fallback for the long tail.
+`open-forge` is a guided self-hosting **skill** distributed via Claude Code's plugin marketplace and adapted for 6+ other AI platforms. It walks users from *"I have a cloud account and a domain"* to *"working app at https://my.domain"* via a phased workflow (preflight → provision → dns → tls → smtp → inbound → hardening → feedback) using 950+ verified recipes plus a live-derived fallback for the long tail.
 
 This **isn't a typical software repo** — it's a library of platform-agnostic markdown recipes + a thin Bash build script. There's no compiled artifact, no test suite, no lint config. The "build" is regenerating distribution bundles from canonical sources.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/plugin-v0.20.1-F97316?style=flat-square&labelColor=0F172A" alt="Plugin version" /></a>
   <a href="https://deepwiki.com/zhangqi444/open-forge"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
-  <a href="https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects"><img src="https://img.shields.io/badge/verified%20recipes-180+-EA580C?style=flat-square&labelColor=0F172A" alt="Verified recipes" /></a>
+  <a href="https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects"><img src="https://img.shields.io/github/directory-file-count/zhangqi444/open-forge/plugins/open-forge/skills/open-forge/references/projects?type=file&extension=md&style=flat-square&labelColor=0F172A&color=EA580C&label=verified%20recipes" alt="Verified recipes" /></a>
   <a href="#install"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-D77756?style=flat-square&labelColor=0F172A" alt="Built for Claude Code" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=22D3EE" alt="MIT License" /></a>
   <a href="https://github.com/zhangqi444/open-forge/stargazers"><img src="https://img.shields.io/github/stars/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=FACC15" alt="GitHub stars" /></a>
@@ -26,7 +26,7 @@
   AWS profile name?
 ```
 
-> *(OpenClaw — the self-hosted personal AI agent at [openclaw.ai](https://openclaw.ai) — is the project's signature use case; works the same way for any of the [~180 verified recipes](#coverage).)*
+> *(OpenClaw — the self-hosted personal AI agent at [openclaw.ai](https://openclaw.ai) — is the project's signature use case; works the same way for any of the [950+ verified recipes](#coverage).)*
 
 ## Install
 
@@ -92,7 +92,7 @@ That's why captured tribal knowledge already includes things like *"OpenClaw's t
 
 ## Coverage
 
-- **Software**: ~180 verified recipes for popular self-hostable apps — AI stack (Ollama · vLLM · Open WebUI · …), publishing (Ghost · WordPress · …), productivity (Nextcloud · Joplin · …), photos & media (Immich · Jellyfin · …), monitoring, security, networking, communication, automation. Plus **live-derived fallback** for anything else with public docs (best-effort; you'll see a banner before it starts).
+- **Software**: 950+ verified recipes for popular self-hostable apps — AI stack (Ollama · vLLM · Open WebUI · …), publishing (Ghost · WordPress · …), productivity (Nextcloud · Joplin · …), photos & media (Immich · Jellyfin · …), monitoring, security, networking, communication, automation. Plus **live-derived fallback** for anything else with public docs (best-effort; you'll see a banner before it starts).
 - **Where**: any cloud VM (AWS · Azure · GCP · Hetzner · DigitalOcean · Oracle Always-Free ARM · Hostinger), your own machine, Raspberry Pi, macOS VM (Lume), any Kubernetes cluster (EKS · GKE · AKS · DOKS · k3s · kind), or PaaS (Fly.io · Render · Railway · Northflank · exe.dev).
 - **How**: Docker · Podman · Native · Kubernetes (Kustomize-first; Helm where upstream ships one).
 

--- a/dist/generic/open-forge-bundle.md
+++ b/dist/generic/open-forge-bundle.md
@@ -2,7 +2,7 @@
 
 This is a concatenation of the canonical open-forge skill content. Feed it as a system prompt or a long-context document to any LLM agent that supports tool use. The agent acts as a deployment runbook for self-hostable open-source apps.
 
-For per-recipe content (~180 individual recipes under references/projects/), browse:
+For per-recipe content (951+ individual recipes under references/projects/), browse:
   https://deepwiki.com/zhangqi444/open-forge
 
 Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specific — read as capabilities (structured-choice prompt; URL fetch; GitHub API) and use your platform's equivalents.

--- a/dist/hermes/SKILL.md
+++ b/dist/hermes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-forge
-description: Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail. Agent-mode rules apply (no chat-paste credentials, no group-channel deploys).
+description: Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. 951+ verified recipes plus live-derived fallback for the long tail. Agent-mode rules apply (no chat-paste credentials, no group-channel deploys).
 ---
 
 # open-forge — self-host any open-source app

--- a/dist/openclaw/SKILL.md
+++ b/dist/openclaw/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-forge
-description: "Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail."
+description: "Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. 951+ verified recipes plus live-derived fallback for the long tail."
 metadata:
   {
     "openclaw":

--- a/scripts/build-dist.sh
+++ b/scripts/build-dist.sh
@@ -23,6 +23,10 @@ SKILL_DIR="$REPO_ROOT/plugins/open-forge/skills/open-forge"
 REFS_DIR="$SKILL_DIR/references"
 DIST_DIR="$REPO_ROOT/dist"
 
+# Live recipe count — embedded in generated descriptions so they don't go stale
+# as the catalog grows. Counts .md files under references/projects/.
+RECIPE_COUNT=$(find "$REFS_DIR/projects" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')
+
 usage() {
   grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'
   exit 1
@@ -246,10 +250,10 @@ build_openclaw() {
   mkdir -p "$DIST_DIR/openclaw"
 
   # OpenClaw skill SKILL.md — drop into ~/.openclaw/workspace/skills/open-forge/SKILL.md
-  cat > "$DIST_DIR/openclaw/SKILL.md" <<'EOF'
+  cat > "$DIST_DIR/openclaw/SKILL.md" <<EOF
 ---
 name: open-forge
-description: "Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail."
+description: "Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ${RECIPE_COUNT}+ verified recipes plus live-derived fallback for the long tail."
 metadata:
   {
     "openclaw":
@@ -281,10 +285,10 @@ build_hermes() {
   mkdir -p "$DIST_DIR/hermes"
 
   # Hermes uses agentskills.io 'open standard' frontmatter — simpler, no metadata block
-  cat > "$DIST_DIR/hermes/SKILL.md" <<'EOF'
+  cat > "$DIST_DIR/hermes/SKILL.md" <<EOF
 ---
 name: open-forge
-description: Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ~180 verified recipes plus live-derived fallback for the long tail. Agent-mode rules apply (no chat-paste credentials, no group-channel deploys).
+description: Self-host any open-source app on the user's own infrastructure (cloud VM, VPS, Raspberry Pi, localhost, k8s, PaaS). Walks the user through provisioning, DNS, TLS, SMTP, and hardening in phased + resumable workflows. ${RECIPE_COUNT}+ verified recipes plus live-derived fallback for the long tail. Agent-mode rules apply (no chat-paste credentials, no group-channel deploys).
 ---
 
 # open-forge — self-host any open-source app
@@ -311,7 +315,7 @@ build_generic() {
 
 This is a concatenation of the canonical open-forge skill content. Feed it as a system prompt or a long-context document to any LLM agent that supports tool use. The agent acts as a deployment runbook for self-hostable open-source apps.
 
-For per-recipe content (~180 individual recipes under references/projects/), browse:
+For per-recipe content (${RECIPE_COUNT}+ individual recipes under references/projects/), browse:
   https://deepwiki.com/zhangqi444/open-forge
 
 Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specific — read as capabilities (structured-choice prompt; URL fetch; GitHub API) and use your platform's equivalents.


### PR DESCRIPTION
## Summary

Catalog has grown from ~180 to **951 recipes** since the badges + docs were last updated (the bot has shipped 183+ batches). This PR fixes the static count references and **wires up live counting** so this doesn't drift again.

No version bump (description / count update only).

## What changed

| File | Change |
|---|---|
| `README.md` badge | Hard-coded `verified recipes 180+` shields.io static → **dynamic** `github/directory-file-count` badge that pulls the live count from the GitHub API. Always shows current number. |
| `README.md` inline | Two `~180` → `950+` substitutions (sample-chat caption + Coverage bullet) |
| `AGENTS.md` | Same `~180` → `950+` substitution |
| `scripts/build-dist.sh` | New `RECIPE_COUNT` shell variable that counts `.md` files under `references/projects/` at build time. OpenClaw / Hermes / generic dist bundles now embed `${RECIPE_COUNT}+` instead of `~180`. OpenClaw and Hermes heredocs switched from `<<'EOF'` to `<<EOF` so the variable expands. |
| `dist/openclaw/SKILL.md` + `dist/hermes/SKILL.md` + `dist/generic/open-forge-bundle.md` | Regenerated; now read **"951+ verified recipes"** (live count at this build time). |

## Live vs static after this PR

- **README badge** — fully dynamic (GitHub API). Always current, zero maintenance.
- **dist bundles** — current at every build; CI regen keeps them fresh.
- **README + AGENTS.md prose** — still static (`950+`). Worth manually bumping when the catalog crosses the next round number (e.g. `1000+`); not worth wiring dynamically since these are read by humans, not parsed.

## Test plan

- [ ] CI's `dist-bundles-up-to-date` check passes (the regen output matches what's committed).
- [ ] Live test: render the README on github.com — confirm the dynamic badge resolves to the current count (`951` at PR open time).
- [ ] Build script smoke-test: `./scripts/build-dist.sh all` on a fresh clone — confirm `RECIPE_COUNT` resolves correctly via `find`.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_