### PR TITLE
v0.23.1 — add ARCHITECTURE.md + cross-doc refresh (count, bundles, pointers)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ## What this project is
 
-`open-forge` is a guided self-hosting **skill** distributed via Claude Code's plugin marketplace and adapted for 6+ other AI platforms. It walks users from *"I have a cloud account and a domain"* to *"working app at https://my.domain"* via a phased workflow (preflight → provision → dns → tls → smtp → inbound → hardening → feedback) using 950+ verified recipes plus a live-derived fallback for the long tail.
+`open-forge` is a guided self-hosting **skill** distributed via Claude Code's plugin marketplace and adapted for 6+ other AI platforms. It walks users from *"I have a cloud account and a domain"* to *"working app at https://my.domain"* via a phased workflow (preflight → provision → dns → tls → smtp → inbound → hardening → feedback) using 1,100+ verified recipes plus curated bundles for goal-shaped requests (AI homelab, privacy stack) plus a live-derived fallback for the long tail.
 
 This **isn't a typical software repo** — it's a library of platform-agnostic markdown recipes + a thin Bash build script. There's no compiled artifact, no test suite, no lint config. The "build" is regenerating distribution bundles from canonical sources.
 
@@ -62,6 +62,6 @@ Cross-platform behavior changes (e.g. credential handling) live in `references/m
 
 ## Reference
 
-For everything not covered above, **read [CLAUDE.md](CLAUDE.md)**. It's the canonical reference for working on open-forge.
+For everything not covered above, **read [CLAUDE.md](CLAUDE.md)** — the canonical reference for *policy* (what's in scope, strict-doc rules, sanitization, processing workflow) — and **[ARCHITECTURE.md](ARCHITECTURE.md)** for *system shape* (actors, data flow, state stores, quality gates, cadence).
 
 User-facing project documentation lives in [README.md](README.md). End-user-skill content lives in [plugins/open-forge/skills/open-forge/SKILL.md](plugins/open-forge/skills/open-forge/SKILL.md).

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,198 @@
+# ARCHITECTURE.md
+
+How open-forge actually works as a system — the actors, the data flow, where state lives, what keeps quality up. Different audience from [CLAUDE.md](CLAUDE.md) (which is the *policy* — strict-doc rules, sanitization principles, processing workflow): ARCHITECTURE is *system shape*.
+
+> **Pointers**: For policy details (what's in scope, how to verify against upstream, sanitization rules) see [CLAUDE.md](CLAUDE.md). For end-user usage see [README.md](README.md). For the skill content the end-user's agent reads see [SKILL.md](plugins/open-forge/skills/open-forge/SKILL.md).
+
+## System overview
+
+```
+                                 (input pipe)
+   end users  ─┐                                              ┌─►  marketplace
+  (skill-      │     ┌────────────────┐                       │   (Claude Code
+   assisted    ├──►  │ GitHub issues  │  ←──── batch ───────  │    + 6 other
+   feedback)   │     │ ┌────────────┐ │      newsletter       │    platforms)
+               │     │ │ recipe-fb  │ │      crawls           │
+   maintainer  ├──►  │ │ nominate   │ │                       │
+  (manual)     │     │ │ method     │ │                       │
+               │     │ └────────────┘ │                       │
+               │     └────────┬───────┘                       │
+               │              │                               │
+               │              ▼                               │
+               │     ┌────────────────┐    ┌────────────┐     │
+               │     │  AI session    │───►│   PR on    │────►│ merge → main
+               │     │   (the bot     │    │   main     │     │
+               │     │   on schedule  │    │            │     │
+               │     │   OR ad-hoc)   │    └─────┬──────┘     │
+               │     └────────────────┘          │            │
+               │              ▲                  ▼            │
+               │              │             ┌─────────┐       │
+               │              │             │   CI    │ ──────┘
+               │              │             │ guards  │
+               │              │             └─────────┘
+               │              │
+               │       (strict-doc-policy verification:
+               │        re-fetch upstream → diff → patch)
+               │              │
+   public      │              │
+   newsletters ┴──────────────┘
+   (selfh.st,
+    other RSS)
+```
+
+The catalog grows continuously — at the time of this writing, the catalog has 1,100+ verified recipes; main is updated via a stream of small bot-authored PRs (recently `batch 183 — owntracks-frontend, paaster, …`) plus occasional maintainer / AI-session PRs. The exact count is a [shields.io live badge](https://img.shields.io/github/directory-file-count/zhangqi444/open-forge/plugins/open-forge/skills/open-forge/references/projects?type=file&extension=md) in the README.
+
+## The four actors
+
+| Actor | What they do | Files they touch |
+|---|---|---|
+| **The bot** (scheduled AI session) | Polls public newsletters (selfh.st, others) + GitHub issues. Triages by template type. Verifies against upstream per strict-doc-policy. Authors patches in batches. Bumps `plugin.json` version. Updates `progress/heartbeat-log.md` and `progress/selfhst-progress.json`. | `references/projects/*.md`, `progress/*`, `plugin.json`, occasional `dist/` regen |
+| **Maintainer (zhangqi444)** | Strategic decisions, PR merges, repo-settings (About / topics / website / social preview), high-judgment edits | Repo settings (web UI), occasional manual PRs |
+| **AI sessions like Claude Code / Codex / Cursor / Aider / Continue / OpenClaw / Hermes / generic** | Maintainer-prompted: file issues, author specific PRs, audit catalog quality, generate distribution bundles for non-Claude-Code platforms | Anything except repo settings |
+| **End users** | File issues via the three templates: recipe-feedback / software-nomination / method-proposal. The skill drafts these automatically with sanitization at the end of each deploy. | GitHub issue templates only — no direct repo write access |
+
+End users do **not** open PRs. Per CLAUDE.md § *Issue-driven contribution model*, issues are the universal contribution channel; AI sessions process them centrally so the strict-doc-policy stays enforced and credentials don't leak into commit history.
+
+## Data flow — how an issue becomes a recipe edit
+
+```
+  1. END USER files issue        ──►   uses one of three templates:
+     (skill-drafted or manual)         recipe-feedback / software-nomination /
+                                       method-proposal
+                                       
+                                       OR — bot picks up signal directly from
+                                       public newsletters (skips the issue step)
+                                       
+  2. BOT or AI SESSION triages   ──►   labels: triaged / in-progress / applied /
+                                       needs-info / out-of-scope (per CLAUDE.md
+                                       § Processing incoming issues, state-
+                                       machine via labels)
+                                       
+  3. UPSTREAM VERIFICATION       ──►   re-fetch the recipe's cited upstream URLs
+                                       (or for nominations, locate upstream's
+                                       install-method index); apply strict-doc-
+                                       policy; if fetch fails, stop and label
+                                       'needs-info'
+                                       
+  4. PATCH AUTHORSHIP            ──►   apply per Recipe structure (must-have
+                                       sections); cite upstream URL at top of
+                                       every section; flag community-maintained
+                                       methods with the ⚠️ blockquote;
+                                       sanitize user-shared content
+                                       
+  5. dist/ REGENERATION          ──►   if patch touches CLAUDE.md / SKILL.md /
+                                       references/modules/, run
+                                       ./scripts/build-dist.sh all
+                                       (CI's dist-bundles-up-to-date check
+                                       enforces this)
+                                       
+  6. PR open on main             ──►   branch: bot/issue-<N>-<slug>;
+                                       PR body cites originating issue + every
+                                       upstream URL re-verified + version-bump
+                                       rationale
+                                       
+  7. CI guards                   ──►   .github/workflows/dist-bundles.yml
+                                       fails the build if dist/ drifted from
+                                       canonical sources
+                                       
+  8. Merge to main               ──►   marketplace publishes on next
+                                       /plugin marketplace update
+                                       (controlled by plugin.json version)
+                                       
+  9. Issue label flips to        ──►   bot triage closes the loop;
+     'applied'                         label-state-machine documents what's done
+```
+
+## State stores
+
+| Where | What | Owned by |
+|---|---|---|
+| **GitHub issues** | The input queue. Three templates encode the structured signals. State tracked via labels. | End users (drafts) + bot/maintainer (triage) |
+| **`progress/heartbeat-log.md`** + **`progress/selfhst-progress.json`** + **`progress/issues-log.json`** | Bot's run log. What batches ran, what was processed, what's pending. | Bot |
+| **`plugins/open-forge/skills/open-forge/references/projects/*.md`** | The catalog itself. ~1,100+ Tier 1 verified recipes. | Bot (mostly) + maintainer (strategic recipes like ghost.md) |
+| **`plugins/open-forge/skills/open-forge/references/{infra,runtimes,modules}/`** | Reusable orchestration layers — infra adapters, runtime modules, cross-cutting modules (preflight, dns, tls, smtp, inbound, tunnels, credentials, feedback, backups) | Maintainer mostly; bot adds modules when first-deploy-discipline surfaces gaps |
+| **`plugins/open-forge/skills/open-forge/references/bundles/*.md`** | Curated multi-software deployment bundles (AI homelab, privacy stack). Recipe-of-recipes that orchestrate existing Tier 1 recipes for goal-shaped requests. | Maintainer-direct authoring (per CLAUDE.md graduation criteria, bundles aren't speculative authoring — they pair existing recipes) |
+| **`dist/`** | Auto-generated multi-platform distribution bundles (codex / cursor / aider / continue / openclaw / hermes / generic). Concatenated from canonical sources via `scripts/build-dist.sh`. | Build script; CI enforces freshness |
+| **`docs/platforms/`** | Per-platform integration guides for the 7 supported platforms. | Maintainer; updated when a new platform is added |
+| **`.github/ISSUE_TEMPLATE/`** | The three input-channel forms (recipe-feedback / software-nomination / method-proposal) plus `config.yml` (disables blank issues) | Maintainer |
+| **`.github/workflows/dist-bundles.yml`** | CI gate: regenerates `dist/` and fails the build if it drifted from canonical sources | Maintainer |
+| **`~/.open-forge/deployments/<name>.yaml`** (on user machines) | End-user deployment state. Phased-workflow checkpoints, inputs, outputs. Resume across sessions. | End user; never enters the repo |
+
+## Quality gates
+
+What keeps the catalog from rotting:
+
+| Gate | Where it runs | What it catches |
+|---|---|---|
+| **Strict doc-verification policy** | At patch-authorship time (per CLAUDE.md) | Recipe content cited from training data / blog posts / search snippets — not upstream docs. Past failures (v0.7.0 Helm hallucination, v0.6.0 OpenClaw "every blessed path" 4-of-17 claim) traced back here. |
+| **Sanitization principles** | At issue-submission time (skill-side) AND at patch-acceptance time (issue-processing AI session re-checks) | User identifiers (domains, IPs, SSH keys, API keys, AWS account IDs, emails) leaking into the public repo. |
+| **CI: dist-bundles-up-to-date** | Every PR + push to main | Stale `dist/` bundles after CLAUDE.md / SKILL.md / module changes. Forces build-script regen. |
+| **Community-maintained flagging** | At patch-authorship time | Third-party install methods presented as upstream-blessed. ⚠️ blockquote required for community-maintained methods. |
+| **First-run discipline** | At deploy time (per CLAUDE.md) | Recipes that "look right" but fail in the wild. End-of-deploy feedback flow drafts a sanitized issue capturing the gotcha. |
+| **Versioning rules** | At commit time (in PR review) | User-visible behavior changes shipped without a version bump (breaks marketplace cache invalidation). |
+
+## Cadence — what actually happens in main
+
+Observed from the commit log (2026-04 to 2026-05):
+
+- **Bot batches** — the bot ships small batches (3-5 recipes per commit), tagged `batch <N>` in the commit message. Catalog grew from ~180 to 1,100+ recipes over the observation window.
+- **AI-session PRs** (this Claude Code session) — periodic batches authored on demand: catalog audits, architectural additions (issue-driven contribution model, multi-platform support, agent-platform support, backups module, bundles), bug fixes (#40 broken in-bundle links).
+- **End-user issues** — sparse but valuable; recent issues #24-27 (Windows setup gotchas), #40 (broken links), #41 (BookStack URL).
+- **Version bumps** — driven by user-visible changes. Recent: `0.17.1 → 0.17.2 → 0.19.x → 0.20.x → 0.21.0 (multi-platform) → 0.22.0 (agent platforms) → 0.23.0 (backups + bundles)`.
+
+## Three layers, one orchestration layer above
+
+The deployment model is a tuple of three independent axes (per CLAUDE.md § Architecture):
+
+1. **What** to host — software → `references/projects/<sw>.md`
+2. **Where** to host — infra → `references/infra/<cloud>/<service>.md`
+3. **How** to host — runtime → `references/runtimes/<runtime>.md`
+
+Cross-cutting concerns (preflight / dns / tls / smtp / inbound / tunnels / credentials / feedback / backups) live as reusable modules under `references/modules/`.
+
+**A fourth orchestration layer** sits above these: **bundles** (`references/bundles/`). A bundle is a *recipe-of-recipes* — it pairs commonly-co-deployed software for goal-shaped user requests (*"set up an AI homelab"*) and ships the cross-software wiring (env vars / DNS / ports between the constituent recipes). Bundles don't replace single-recipe routing; they're an additional entry point for goal-shaped intents.
+
+## Two-tier coverage
+
+Per CLAUDE.md § *Two-tier coverage model*:
+
+- **Tier 1** — verified recipes in `references/projects/`. Authored ahead of time, audited against upstream docs, kept current via first-run discipline + version bumps. Quality bar: every install method cites upstream URL; community methods flagged with blockquote.
+- **Tier 2** — derived live from upstream docs at request time. When the user names software not in the catalog, the skill announces the fallback, fetches upstream live, applies the strict-doc-policy on the fly, and reuses the runtime/infra/module layers. Best-effort, not authoritative.
+
+Tier 2 → Tier 1 graduation is **demand-driven**: 3+ feedback issues for the same software, repeat user, captured non-obvious gotcha, or maintainer-driven deploy.
+
+## Multi-platform shape
+
+The skill is content-agnostic markdown that runs on 7+ AI platforms via per-platform integration:
+
+| Platform | Integration |
+|---|---|
+| Claude Code | Plugin marketplace (`/plugin marketplace add`); auto-loads via SKILL.md description match |
+| Codex | System-prompt embedding (ChatGPT custom instructions) or workspace files (Codex CLI) |
+| Cursor | `.cursor/rules/` bundle from `dist/cursor/` |
+| Aider | `--read` files + `CONVENTIONS.md` from `dist/aider/` |
+| Continue.dev | Context provider + slash command from `dist/continue/config.snippet.yaml` |
+| OpenClaw | Workspace skill at `~/.openclaw/workspace/skills/open-forge/SKILL.md` |
+| Hermes-Agent | User skill at `~/.hermes/skills/open-forge/SKILL.md` |
+| Generic | Single-file bundle from `dist/generic/open-forge-bundle.md` |
+
+The build script (`scripts/build-dist.sh`) generates each platform's bundle by concatenating canonical sources (CLAUDE.md + SKILL.md + the `credentials` and `feedback` modules) into the format that platform expects, plus a sed post-process step that rewrites in-bundle hyperlinks to point at the inlined sections (the original cross-references are valid for the Claude Code plugin install where files coexist, but break in single-file bundles — see issue #40).
+
+## Where each subsystem's docs live
+
+| Subsystem | Doc | Purpose |
+|---|---|---|
+| Project policy | [CLAUDE.md](CLAUDE.md) | What's in scope; strict-doc rules; sanitization; issue-processing workflow |
+| AI-agent landing page | [AGENTS.md](AGENTS.md) | agents.md-standard pointer file for non-Claude-Code agents working on the repo |
+| User-facing project doc | [README.md](README.md) | Value prop, install, coverage |
+| End-user skill content | [SKILL.md](plugins/open-forge/skills/open-forge/SKILL.md) | Phased workflow, credential handling, post-deploy feedback |
+| Per-platform usage | [docs/platforms/*.md](docs/platforms/) | How to use open-forge on Codex / Cursor / Aider / Continue / OpenClaw / Hermes / generic agents |
+| Build tooling | [scripts/build-dist.sh](scripts/build-dist.sh) | Regenerates `dist/` bundles; documents itself with usage comment |
+| **System architecture** | **this file** | Actors, flow, state stores, quality gates — how it all fits together |
+
+## What this doc deliberately doesn't cover
+
+- **Per-recipe content** — that's the catalog itself; browse `references/projects/` or [DeepWiki](https://deepwiki.com/zhangqi444/open-forge).
+- **Policy detail** — strict-doc-policy regex patterns, sanitization strip-list, recipe-structure must-haves are in [CLAUDE.md](CLAUDE.md).
+- **Per-platform integration nuance** — those live in [docs/platforms/](docs/platforms/) for Codex / Cursor / Aider / Continue / OpenClaw / Hermes / generic.
+- **End-user deployment instructions** — README.md and SKILL.md cover that; this doc is for contributors, maintainers, and AI sessions trying to understand the maintenance system.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,8 @@
 Instructions for any AI coding session working *on* the open-forge plugin (not running it). Different audience from `plugins/open-forge/skills/open-forge/SKILL.md`, which is what an end-user's agent reads to *use* the plugin.
 
 > **Also accessible as [`AGENTS.md`](AGENTS.md)** per the [agents.md](https://agents.md) convention. AGENTS.md is a thin landing page that points here; this file is the canonical reference. Tools that look for either filename find their way in.
+>
+> **For *system shape* (actors, data flow, state stores, quality gates, cadence) see [`ARCHITECTURE.md`](ARCHITECTURE.md).** This file is the *policy* (what's in scope, strict-doc rules, sanitization principles, processing workflow); ARCHITECTURE.md is how the policy is operationalized as a maintenance system.
 
 ## What is open-forge
 
@@ -49,6 +51,12 @@ references/
 ```
 
 `localhost.md` is a first-class infra — for many projects (especially OpenClaw), running locally is the default upstream path. Same conversational UX as a cloud deploy; differences are: no SSH (Claude runs commands directly), no provisioning, public reach via tunnel (`references/modules/tunnels.md`).
+
+### A fourth orchestration layer — bundles
+
+Above software / infra / runtime sits an optional **bundle** layer (`references/bundles/`). A bundle is a *recipe-of-recipes* — it pairs commonly-co-deployed software for goal-shaped user requests (*"set up an AI homelab"*) and ships the cross-software wiring (env vars / DNS / ports between constituents). Bundles don't replace single-recipe routing; they're an additional entry point for goal-shaped intents.
+
+Per *Tier 2 → Tier 1 graduation criteria* below, bundles aren't speculative authoring — they orchestrate **existing Tier 1 recipes** only. If a constituent recipe gets demoted, the bundle goes with it. New bundles get added when 3+ users (or one repeat user) ask for the same combination. Current bundles: `bundles/ai-homelab.md` (Ollama + Open WebUI + AnythingLLM + Aider) and `bundles/privacy-stack.md` (Pi-hole + Vaultwarden + Headscale OR wg-easy).
 
 ## Is this software in scope?
 
@@ -413,11 +421,14 @@ open-forge/
 ├── README.md                              ← user-facing, lives on GitHub
 ├── LICENSE                                ← MIT
 ├── .claude-plugin/marketplace.json        ← marketplace manifest
+├── ARCHITECTURE.md                        ← system shape (actors, data flow, state stores, quality gates) — complement to this file
 ├── .github/
 │   ├── ISSUE_TEMPLATE/                    ← three issue channels (recipe-feedback, software-nomination, method-proposal)
 │   └── workflows/dist-bundles.yml         ← CI: fail PRs whose dist/ bundles are stale vs canonical sources
-├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / generic)
+├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / OpenClaw / Hermes / generic)
 ├── dist/                                  ← regenerated multi-platform distribution bundles (see scripts/build-dist.sh)
+├── progress/                              ← bot's run log: heartbeat-log.md + selfhst-progress.json + issues-log.json (bot-owned)
+├── assets/                                ← icon.svg + social-preview.svg
 ├── scripts/
 │   └── build-dist.sh                      ← regenerates dist/ from canonical sources; run when CLAUDE.md / SKILL.md / modules change
 └── plugins/open-forge/
@@ -425,14 +436,17 @@ open-forge/
     └── skills/open-forge/
         ├── SKILL.md                       ← end-user-Claude entrypoint
         ├── references/
-        │   ├── projects/<name>.md         ← software layer
+        │   ├── projects/<name>.md         ← software layer (1,100+ Tier 1 verified recipes)
         │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring, credentials, feedback)
+        │   ├── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, credentials, feedback, backups, monitoring)
+        │   └── bundles/<name>.md          ← curated multi-software bundles (recipe-of-recipes; ai-homelab, privacy-stack)
         └── scripts/                       ← deployment-time operational scripts (per-recipe); empty by default
 ```
 
 The skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time) stays empty unless something is reused 3+ times across deployments — inline commands in recipes are clearer for one-off use. Distinct from the top-level `scripts/` (build-time tooling for dist/ bundles).
+
+For the **system architecture** (how the catalog grows, who maintains what, how an issue becomes a recipe edit, where state lives), see [`ARCHITECTURE.md`](ARCHITECTURE.md). This file is *policy*; ARCHITECTURE.md is *system shape*.
 
 ## Versioning + publish flow
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   AWS profile name?
 ```
 
-> *(OpenClaw — the self-hosted personal AI agent at [openclaw.ai](https://openclaw.ai) — is the project's signature use case; works the same way for any of the [950+ verified recipes](#coverage).)*
+> *(OpenClaw — the self-hosted personal AI agent at [openclaw.ai](https://openclaw.ai) — is the project's signature use case; works the same way for any of the [1,100+ verified recipes](#coverage).)*
 
 ## Install
 
@@ -92,7 +92,7 @@ That's why captured tribal knowledge already includes things like *"OpenClaw's t
 
 ## Coverage
 
-- **Software**: 950+ verified recipes for popular self-hostable apps — AI stack (Ollama · vLLM · Open WebUI · …), publishing (Ghost · WordPress · …), productivity (Nextcloud · Joplin · …), photos & media (Immich · Jellyfin · …), monitoring, security, networking, communication, automation. Plus **live-derived fallback** for anything else with public docs (best-effort; you'll see a banner before it starts).
+- **Software**: 1,100+ verified recipes for popular self-hostable apps — AI stack (Ollama · vLLM · Open WebUI · …), publishing (Ghost · WordPress · …), productivity (Nextcloud · Joplin · …), photos & media (Immich · Jellyfin · …), monitoring, security, networking, communication, automation. Plus **curated bundles** ([AI homelab](plugins/open-forge/skills/open-forge/references/bundles/ai-homelab.md), [privacy stack](plugins/open-forge/skills/open-forge/references/bundles/privacy-stack.md)) for goal-shaped requests, and **live-derived fallback** for anything else with public docs (best-effort; you'll see a banner before it starts).
 - **Where**: any cloud VM (AWS · Azure · GCP · Hetzner · DigitalOcean · Oracle Always-Free ARM · Hostinger), your own machine, Raspberry Pi, macOS VM (Lume), any Kubernetes cluster (EKS · GKE · AKS · DOKS · k3s · kind), or PaaS (Fly.io · Render · Railway · Northflank · exe.dev).
 - **How**: Docker · Podman · Native · Kubernetes (Kustomize-first; Helm where upstream ships one).
 
@@ -110,7 +110,7 @@ Or just ask Claude — *"self-host X on Y"* — and it'll match.
 
 An AI agent reads [`CLAUDE.md`](CLAUDE.md) as its runbook, re-verifies every change against upstream docs, and patches the catalog. Why issues, not PRs? Central verification keeps the catalog consistent, and the skill sanitizes drafts before posting so credentials don't leak into commit history.
 
-For the architectural details (3-axis model, strict-doc-verification policy, two-tier coverage, sanitization rules), see [`CLAUDE.md`](CLAUDE.md).
+For how the catalog is maintained as a system (actors, data flow, state stores, quality gates), see [`ARCHITECTURE.md`](ARCHITECTURE.md). For policy details (3-axis model, strict-doc-verification policy, two-tier coverage, sanitization rules), see [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 

--- a/dist/codex/system-prompt.md
+++ b/dist/codex/system-prompt.md
@@ -19,6 +19,8 @@ After hardening, offer the post-deploy feedback flow per the *Post-deploy feedba
 Instructions for any AI coding session working *on* the open-forge plugin (not running it). Different audience from `plugins/open-forge/skills/open-forge/SKILL.md`, which is what an end-user's agent reads to *use* the plugin.
 
 > **Also accessible as [`AGENTS.md`](AGENTS.md)** per the [agents.md](https://agents.md) convention. AGENTS.md is a thin landing page that points here; this file is the canonical reference. Tools that look for either filename find their way in.
+>
+> **For *system shape* (actors, data flow, state stores, quality gates, cadence) see [`ARCHITECTURE.md`](ARCHITECTURE.md).** This file is the *policy* (what's in scope, strict-doc rules, sanitization principles, processing workflow); ARCHITECTURE.md is how the policy is operationalized as a maintenance system.
 
 ## What is open-forge
 
@@ -65,6 +67,12 @@ references/
 ```
 
 `localhost.md` is a first-class infra — for many projects (especially OpenClaw), running locally is the default upstream path. Same conversational UX as a cloud deploy; differences are: no SSH (Claude runs commands directly), no provisioning, public reach via tunnel (`references/modules/tunnels.md`).
+
+### A fourth orchestration layer — bundles
+
+Above software / infra / runtime sits an optional **bundle** layer (`references/bundles/`). A bundle is a *recipe-of-recipes* — it pairs commonly-co-deployed software for goal-shaped user requests (*"set up an AI homelab"*) and ships the cross-software wiring (env vars / DNS / ports between constituents). Bundles don't replace single-recipe routing; they're an additional entry point for goal-shaped intents.
+
+Per *Tier 2 → Tier 1 graduation criteria* below, bundles aren't speculative authoring — they orchestrate **existing Tier 1 recipes** only. If a constituent recipe gets demoted, the bundle goes with it. New bundles get added when 3+ users (or one repeat user) ask for the same combination. Current bundles: `bundles/ai-homelab.md` (Ollama + Open WebUI + AnythingLLM + Aider) and `bundles/privacy-stack.md` (Pi-hole + Vaultwarden + Headscale OR wg-easy).
 
 ## Is this software in scope?
 
@@ -429,11 +437,14 @@ open-forge/
 ├── README.md                              ← user-facing, lives on GitHub
 ├── LICENSE                                ← MIT
 ├── .claude-plugin/marketplace.json        ← marketplace manifest
+├── ARCHITECTURE.md                        ← system shape (actors, data flow, state stores, quality gates) — complement to this file
 ├── .github/
 │   ├── ISSUE_TEMPLATE/                    ← three issue channels (recipe-feedback, software-nomination, method-proposal)
 │   └── workflows/dist-bundles.yml         ← CI: fail PRs whose dist/ bundles are stale vs canonical sources
-├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / generic)
+├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / OpenClaw / Hermes / generic)
 ├── dist/                                  ← regenerated multi-platform distribution bundles (see scripts/build-dist.sh)
+├── progress/                              ← bot's run log: heartbeat-log.md + selfhst-progress.json + issues-log.json (bot-owned)
+├── assets/                                ← icon.svg + social-preview.svg
 ├── scripts/
 │   └── build-dist.sh                      ← regenerates dist/ from canonical sources; run when CLAUDE.md / SKILL.md / modules change
 └── plugins/open-forge/
@@ -441,14 +452,17 @@ open-forge/
     └── skills/open-forge/
         ├── SKILL.md                       ← end-user-Claude entrypoint
         ├── references/
-        │   ├── projects/<name>.md         ← software layer
+        │   ├── projects/<name>.md         ← software layer (1,100+ Tier 1 verified recipes)
         │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring, credentials, feedback)
+        │   ├── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, credentials, feedback, backups, monitoring)
+        │   └── bundles/<name>.md          ← curated multi-software bundles (recipe-of-recipes; ai-homelab, privacy-stack)
         └── scripts/                       ← deployment-time operational scripts (per-recipe); empty by default
 ```
 
 The skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time) stays empty unless something is reused 3+ times across deployments — inline commands in recipes are clearer for one-off use. Distinct from the top-level `scripts/` (build-time tooling for dist/ bundles).
+
+For the **system architecture** (how the catalog grows, who maintains what, how an issue becomes a recipe edit, where state lives), see [`ARCHITECTURE.md`](ARCHITECTURE.md). This file is *policy*; ARCHITECTURE.md is *system shape*.
 
 ## Versioning + publish flow
 

--- a/dist/generic/open-forge-bundle.md
+++ b/dist/generic/open-forge-bundle.md
@@ -14,6 +14,8 @@ Tool names like AskUserQuestion, WebFetch, mcp__github__* are Claude Code-specif
 Instructions for any AI coding session working *on* the open-forge plugin (not running it). Different audience from `plugins/open-forge/skills/open-forge/SKILL.md`, which is what an end-user's agent reads to *use* the plugin.
 
 > **Also accessible as [`AGENTS.md`](AGENTS.md)** per the [agents.md](https://agents.md) convention. AGENTS.md is a thin landing page that points here; this file is the canonical reference. Tools that look for either filename find their way in.
+>
+> **For *system shape* (actors, data flow, state stores, quality gates, cadence) see [`ARCHITECTURE.md`](ARCHITECTURE.md).** This file is the *policy* (what's in scope, strict-doc rules, sanitization principles, processing workflow); ARCHITECTURE.md is how the policy is operationalized as a maintenance system.
 
 ## What is open-forge
 
@@ -60,6 +62,12 @@ references/
 ```
 
 `localhost.md` is a first-class infra — for many projects (especially OpenClaw), running locally is the default upstream path. Same conversational UX as a cloud deploy; differences are: no SSH (Claude runs commands directly), no provisioning, public reach via tunnel (`references/modules/tunnels.md`).
+
+### A fourth orchestration layer — bundles
+
+Above software / infra / runtime sits an optional **bundle** layer (`references/bundles/`). A bundle is a *recipe-of-recipes* — it pairs commonly-co-deployed software for goal-shaped user requests (*"set up an AI homelab"*) and ships the cross-software wiring (env vars / DNS / ports between constituents). Bundles don't replace single-recipe routing; they're an additional entry point for goal-shaped intents.
+
+Per *Tier 2 → Tier 1 graduation criteria* below, bundles aren't speculative authoring — they orchestrate **existing Tier 1 recipes** only. If a constituent recipe gets demoted, the bundle goes with it. New bundles get added when 3+ users (or one repeat user) ask for the same combination. Current bundles: `bundles/ai-homelab.md` (Ollama + Open WebUI + AnythingLLM + Aider) and `bundles/privacy-stack.md` (Pi-hole + Vaultwarden + Headscale OR wg-easy).
 
 ## Is this software in scope?
 
@@ -424,11 +432,14 @@ open-forge/
 ├── README.md                              ← user-facing, lives on GitHub
 ├── LICENSE                                ← MIT
 ├── .claude-plugin/marketplace.json        ← marketplace manifest
+├── ARCHITECTURE.md                        ← system shape (actors, data flow, state stores, quality gates) — complement to this file
 ├── .github/
 │   ├── ISSUE_TEMPLATE/                    ← three issue channels (recipe-feedback, software-nomination, method-proposal)
 │   └── workflows/dist-bundles.yml         ← CI: fail PRs whose dist/ bundles are stale vs canonical sources
-├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / generic)
+├── docs/platforms/                        ← per-platform usage guides (Codex / Cursor / Aider / Continue / OpenClaw / Hermes / generic)
 ├── dist/                                  ← regenerated multi-platform distribution bundles (see scripts/build-dist.sh)
+├── progress/                              ← bot's run log: heartbeat-log.md + selfhst-progress.json + issues-log.json (bot-owned)
+├── assets/                                ← icon.svg + social-preview.svg
 ├── scripts/
 │   └── build-dist.sh                      ← regenerates dist/ from canonical sources; run when CLAUDE.md / SKILL.md / modules change
 └── plugins/open-forge/
@@ -436,14 +447,17 @@ open-forge/
     └── skills/open-forge/
         ├── SKILL.md                       ← end-user-Claude entrypoint
         ├── references/
-        │   ├── projects/<name>.md         ← software layer
+        │   ├── projects/<name>.md         ← software layer (1,100+ Tier 1 verified recipes)
         │   ├── runtimes/<name>.md         ← runtime layer (docker.md, podman.md, native.md, kubernetes.md)
         │   ├── infra/<name>.md            ← infra layer (aws/, azure/, hetzner/, digitalocean/, gcp/, oracle/, paas/, hostinger.md, raspberry-pi.md, macos-vm.md, byo-vps.md, localhost.md)
-        │   └── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, backups, monitoring, credentials, feedback)
+        │   ├── modules/<name>.md          ← cross-cutting (preflight, dns, tls, smtp providers, inbound forwarders, tunnels, credentials, feedback, backups, monitoring)
+        │   └── bundles/<name>.md          ← curated multi-software bundles (recipe-of-recipes; ai-homelab, privacy-stack)
         └── scripts/                       ← deployment-time operational scripts (per-recipe); empty by default
 ```
 
 The skill-side `plugins/open-forge/skills/open-forge/scripts/` (deployment-time) stays empty unless something is reused 3+ times across deployments — inline commands in recipes are clearer for one-off use. Distinct from the top-level `scripts/` (build-time tooling for dist/ bundles).
+
+For the **system architecture** (how the catalog grows, who maintains what, how an issue becomes a recipe edit, where state lives), see [`ARCHITECTURE.md`](ARCHITECTURE.md). This file is *policy*; ARCHITECTURE.md is *system shape*.
 
 ## Versioning + publish flow
 

--- a/plugins/open-forge/.claude-plugin/plugin.json
+++ b/plugins/open-forge/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-forge",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Self-host open-source apps on your own cloud, your own VPS, your own Kubernetes cluster, a PaaS, or your own laptop. Chat-friendly interface to existing tools (aws, az, hcloud, doctl, gcloud, flyctl, kubectl, helm, podman, docker, lume, tailscale, terraform, cdk, ssh, gh) — Claude runs every command; you only answer what/where/how and provide credentials. Supported software: Ghost, OpenClaw, Hermes-Agent, Ollama, Open WebUI, Stable Diffusion WebUI (Automatic1111), ComfyUI, Dify, LibreChat, AnythingLLM, Aider, vLLM, Langfuse. AI stack focus: Ollama (single-user LLM inference) + vLLM (production-grade LLM inference) + Open WebUI / LibreChat (multi-user chat UIs) + Stable Diffusion WebUI / ComfyUI (image generation) + AnythingLLM (RAG-focused workspace) + Aider (terminal pair-programming CLI) + Langfuse (LLM observability + evals) compose into a complete local-AI stack; OpenClaw + Hermes-Agent are agent projects; Dify is the LLMOps platform layer. Every recipe is verified against upstream's docs index per the strict-doc policy in CLAUDE.md (community-maintained methods are explicitly flagged when upstream ships no first-party version).",
   "author": { "name": "zhangqi444" },
   "repository": "https://github.com/zhangqi444/open-forge",


### PR DESCRIPTION
## Summary

The catalog has grown from ~180 to 1,100+ recipes and accumulated several architectural concepts (multi-platform support, agent platforms, backups module, bundles) without a single doc that shows the maintenance system as a system. CLAUDE.md is *policy*; README is user-facing; SKILL.md is end-user-skill; `docs/platforms/` is per-platform. None of those describe the whole pipeline.

This PR fills that gap (`ARCHITECTURE.md`) and refreshes cross-doc references / counts to match current state. Bumps plugin to **v0.23.1**.

Single commit: `f8cbe68`.

## What changed

### `ARCHITECTURE.md` (new, ~200 lines)

| Section | What |
|---|---|
| System overview diagram | ASCII showing issue → AI session → PR → CI → merge → marketplace, with bot loop + newsletter intake highlighted |
| The four actors | Bot / maintainer / AI sessions / end users — what each does + what files they touch |
| Data flow | 9-step pipeline from issue → triage → strict-doc verification → patch → CI → merge → marketplace publish |
| State stores | Where everything lives: GitHub issues, `progress/`, `references/`, `dist/`, `docs/platforms/`, `.github/`, `~/.open-forge/deployments/` |
| Quality gates | Strict-doc-policy / sanitization / CI / community-flagging / first-run-discipline / versioning rules |
| Cadence | What actually happens in main — bot-batch rhythm, version-bump timeline (0.17.x → 0.23.x) |
| Three layers + bundles | Existing 3-axis model + new bundles orchestration layer |
| Two-tier coverage | Tier 1 vs Tier 2; demand-driven graduation |
| Multi-platform shape | 7+ platforms; how build script + sed post-process keeps bundles in sync |
| Subsystem doc map | Table routing readers to the right doc — no duplication |

### Cross-doc refresh

| File | Change |
|---|---|
| `README.md` | Prose count `950+` → `1,100+`; Coverage bullet adds curated bundles links (ai-homelab + privacy-stack); footer cross-link to ARCHITECTURE.md |
| `AGENTS.md` | Prose count `950+` → `1,100+`; mentions curated bundles; Reference section now points at both CLAUDE.md (policy) and ARCHITECTURE.md (system shape) |
| `CLAUDE.md` | Header callout adds ARCHITECTURE.md pointer ("policy vs system shape"); File layout updated with ARCHITECTURE.md / `progress/` / `assets/` / `bundles/`; new § *A fourth orchestration layer — bundles* under Architecture |
| `plugin.json` | 0.23.0 → 0.23.1 (patch — doc refresh; bump triggers marketplace cache invalidation) |
| `dist/*` | Regenerated; issue #40 fix's post-process step keeps inline refs clean |

## Why a separate file vs adding to CLAUDE.md

CLAUDE.md is already long (~600+ lines after recent additions) and is *policy* — strict-doc rules, sanitization patterns, processing workflow. ARCHITECTURE.md is *system shape* — what the maintenance pipeline looks like as a system. Separating means each file has a clear audience:

- A new contributor reads ARCHITECTURE.md to understand "how does this thing actually work?"
- An AI session processing an issue reads CLAUDE.md to know "what are the rules I must follow?"
- A user reads README.md to know "what does this do, how do I install it?"

## Test plan

- [ ] CI's `dist-bundles-up-to-date` check passes.
- [ ] All four docs render correctly on github.com (ASCII diagram in ARCHITECTURE.md, tables, cross-links resolve).
- [ ] Smoke test: a new visitor lands on README → finds ARCHITECTURE.md link → can answer "how is the catalog maintained" without reading CLAUDE.md.

## Out of scope

- **Per-recipe `## Backup` section sweep** — module exists; recipes can link it on their next first-run-discipline pass.
- **Monitoring module** (mentioned as "TODO" in `references/modules/<name>.md` layout but not yet authored).
- **Issue #42 batch-split** — separate work; per the demand-signal queue conversation.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_