### PR TITLE
Add auto-Release workflow on plugin.json version bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+name: release-on-version-bump
+
+# Auto-create a GitHub Release whenever plugin.json's version bumps on main.
+#
+# Why: the Claude Code marketplace is pull-based — users have to run
+# /plugin marketplace update to pick up changes. A GitHub Release gives them a
+# subscribable atom feed (releases.atom) plus an entry on the Releases page so
+# they know when a meaningful update has shipped.
+#
+# Tag format: v<version> (e.g. v0.24.0)
+# Release notes: pulled from CHANGELOG.md's matching section if present;
+# otherwise generated from commit log since previous tag.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/open-forge/.claude-plugin/plugin.json'
+
+permissions:
+  contents: write   # needed to create tags + releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # need full history for changelog generation
+
+      - name: Read current plugin.json version
+        id: version
+        run: |
+          VERSION=$(jq -r '.version' plugins/open-forge/.claude-plugin/plugin.json)
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: tag_check
+        run: |
+          if git rev-parse "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag ${{ steps.version.outputs.tag }} already exists; skipping release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        if: steps.tag_check.outputs.skip == 'false'
+        id: notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Pull the section between "## [<version>]" and the next "## [" header.
+          NOTES=$(awk -v v="$VERSION" '
+            $0 ~ "^## \\[" v "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [[ -z "$NOTES" || "$NOTES" =~ ^[[:space:]]*$ ]]; then
+            # Fallback: commit log since previous tag.
+            PREV_TAG=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
+            if [[ -n "$PREV_TAG" ]]; then
+              NOTES=$(git log --pretty=format:'- %s' "${PREV_TAG}..HEAD" -- plugins/open-forge/skills/open-forge plugins/open-forge/.claude-plugin SKILL.md CLAUDE.md ARCHITECTURE.md README.md BRD.md AGENTS.md scripts/build-dist.sh)
+            else
+              NOTES="Initial release."
+            fi
+          fi
+
+          {
+            echo "notes<<EOF"
+            echo "$NOTES"
+            echo
+            echo "---"
+            echo
+            echo "Run \`/plugin marketplace update zhangqi444/open-forge\` in Claude Code to pick up this version. Full changelog: [CHANGELOG.md](https://github.com/zhangqi444/open-forge/blob/main/CHANGELOG.md)."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        if: steps.tag_check.outputs.skip == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          body: ${{ steps.notes.outputs.notes }}
+          draft: false
+          prerelease: false

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Or just ask Claude — *"self-host X on Y"* — and it'll match.
 
 An AI agent reads [`CLAUDE.md`](CLAUDE.md) as its runbook, re-verifies every change against upstream docs, and patches the catalog. Why issues, not PRs? Central verification keeps the catalog consistent, and the skill sanitizes drafts before posting so credentials don't leak into commit history.
 
-For how the catalog is maintained as a system (actors, data flow, state stores, quality gates), see [`ARCHITECTURE.md`](ARCHITECTURE.md). For policy details (3-axis model, strict-doc-verification policy, two-tier coverage, sanitization rules), see [`CLAUDE.md`](CLAUDE.md).
+For how the catalog is maintained as a system (actors, data flow, state stores, quality gates), see [`ARCHITECTURE.md`](ARCHITECTURE.md). For policy details (3-axis model, strict-doc-verification policy, two-tier coverage, sanitization rules), see [`CLAUDE.md`](CLAUDE.md). For project intent (why / who / success / non-goals), see [`BRD.md`](BRD.md).
 
 ## License
 


### PR DESCRIPTION
## Summary

Closes the user-update-notification gap. The Claude Code marketplace is **pull-based** — users have to run `/plugin marketplace update` to pick up changes, but they had no signal telling them when to do that.

CHANGELOG.md + README § Updates section already landed on main via #50's earlier partial merge (commit c6f9521 — the PAT lacked `workflow` scope, so release.yml was deferred). This PR is the rebased remainder: adds **only `.github/workflows/release.yml`** plus a one-line BRD.md cross-link in README.md.

## What changed

### `.github/workflows/release.yml` (new, 88 lines)

Triggers on push to main when `plugins/open-forge/.claude-plugin/plugin.json` changes:

1. Reads version from plugin.json
2. Skips if a tag with that name already exists (idempotent)
3. Pulls release notes from `CHANGELOG.md`'s matching `## [<version>]` section (via awk); falls back to commit-log-since-previous-tag if missing
4. Creates a GitHub Release tagged `v<version>` with notes + footer reminding users to run `/plugin marketplace update`

Uses `softprops/action-gh-release@v2`. `permissions: contents: write` to create tags + releases.

### `README.md` (1-line addition)

Adds a `BRD.md` cross-link to § Contributing's doc-routing line so the four-doc set (BRD / CLAUDE / ARCHITECTURE / README) is fully discoverable.

## Test plan

- [ ] CI's `dist-bundles-up-to-date` check passes (no canonical-source files touched).
- [ ] After this lands: next plugin.json bump triggers release.yml; verify the auto-generated GitHub Release at https://github.com/zhangqi444/open-forge/releases.
- [ ] Verify awk-based CHANGELOG-section extraction works on the next bump's release-notes generation.

## Caveats

- **Retroactive tags don't trigger releases** — the workflow only fires on `push` events that change plugin.json. So 0.1.0 through 0.24.0 won't get GitHub Releases automatically; only 0.24.1+ will.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY