### PR TITLE
Refresh upstream repo URLs: flint + nanoclaw (closes #51)

### DIFF
--- a/plugins/open-forge/skills/open-forge/references/projects/flint.md
+++ b/plugins/open-forge/skills/open-forge/references/projects/flint.md
@@ -1,15 +1,15 @@
 ---
 name: Flint
-description: "Modern KVM management tool. Single Go binary + embedded Next.js web UI + CLI + API. ccheshirecat/flint (volantvm/flint). No XML, no bloat. libvirt-based. Remote KVM via SSH."
+description: "Modern KVM management tool. Single Go binary + embedded Next.js web UI + CLI + API. 0xchasercat/flint (volantvm/flint). No XML, no bloat. libvirt-based. Remote KVM via SSH."
 ---
 
 # Flint
 
 **Modern KVM management, reimagined.** A single <11MB Go binary with an embedded Next.js web UI, CLI, and REST API for managing KVM/libvirt virtual machines. No XML. No Virt-Manager. No bloat. Built for developers, sysadmins, and homelabbers who want zero-friction VM management.
 
-Built + maintained by **volantvm** / ccheshirecat. Built quickly out of frustration with existing tooling.
+Built + maintained by **volantvm** / 0xchasercat. Built quickly out of frustration with existing tooling.
 
-- Upstream repo: <https://github.com/ccheshirecat/flint> (also: <https://github.com/volantvm/flint>)
+- Upstream repo: <https://github.com/0xchasercat/flint> (also: <https://github.com/volantvm/flint>)
 - Releases: <https://github.com/volantvm/flint/releases/latest>
 - Chaser platform: <https://chaser.sh>
 
@@ -185,7 +185,7 @@ Active releases, CI (GitHub Actions), solo-maintained by volantvm/ccheshirecat, 
 
 ## Links
 
-- Repo: <https://github.com/ccheshirecat/flint>
+- Repo: <https://github.com/0xchasercat/flint>
 - Releases: <https://github.com/volantvm/flint/releases>
 - Proxmox (alt): <https://www.proxmox.com>
 - Cockpit (alt): <https://cockpit-project.org>

--- a/plugins/open-forge/skills/open-forge/references/projects/nanoclaw.md
+++ b/plugins/open-forge/skills/open-forge/references/projects/nanoclaw.md
@@ -5,7 +5,7 @@ description: NanoClaw recipe for open-forge. MIT-licensed minimalist AI-assistan
 
 # NanoClaw
 
-MIT-licensed AI-assistant framework. Upstream: <https://github.com/qwibitai/nanoclaw>. Docs: <https://docs.nanoclaw.dev>. Website: <https://nanoclaw.dev>.
+MIT-licensed AI-assistant framework. Upstream: <https://github.com/nanocoai/nanoclaw>. Docs: <https://docs.nanoclaw.dev>. Website: <https://nanoclaw.dev>.
 
 **Positioning:** Built explicitly as a minimalist alternative to [OpenClaw](https://github.com/openclaw/openclaw). From the README:
 
@@ -61,7 +61,7 @@ Key files (from upstream):
 
 | Method | Upstream | First-party? | When to use |
 |---|---|---|---|
-| Bootstrap script (`nanoclaw.sh`) | <https://github.com/qwibitai/nanoclaw> | ✅ Only documented path | The standard install. Works on fresh machine. |
+| Bootstrap script (`nanoclaw.sh`) | <https://github.com/nanocoai/nanoclaw> | ✅ Only documented path | The standard install. Works on fresh machine. |
 | Manual (clone + `pnpm install`) | Implicit — read `nanoclaw.sh` | ⚠️ Advanced | Contributors. Not officially documented. |
 | Windows native | ❌ Not supported | Use WSL2. |
 
@@ -80,7 +80,7 @@ There are no multi-user / K8s / VPS deployment methods (yet) — it's a workstat
 ## Install — Bootstrap script
 
 ```bash
-git clone https://github.com/qwibitai/nanoclaw.git nanoclaw-v2
+git clone https://github.com/nanocoai/nanoclaw.git nanoclaw-v2
 cd nanoclaw-v2
 bash nanoclaw.sh
 ```
@@ -179,7 +179,7 @@ git merge upstream/main                    # or cherry-pick security fixes only
 
 The README explicitly states: **only security fixes, bug fixes, and clear improvements** will be accepted to base configuration. Everything else (new capabilities, OS support, hardware) should be contributed as skills on `channels` / `providers` branches.
 
-Changelog: <https://github.com/qwibitai/nanoclaw/blob/main/CHANGELOG.md>. Full release history: <https://docs.nanoclaw.dev/changelog>.
+Changelog: <https://github.com/nanocoai/nanoclaw/blob/main/CHANGELOG.md>. Full release history: <https://docs.nanoclaw.dev/changelog>.
 
 ## Gotchas
 
@@ -204,14 +204,14 @@ Changelog: <https://github.com/qwibitai/nanoclaw/blob/main/CHANGELOG.md>. Full r
 
 ## Links
 
-- Upstream repo: <https://github.com/qwibitai/nanoclaw>
+- Upstream repo: <https://github.com/nanocoai/nanoclaw>
 - Docs: <https://docs.nanoclaw.dev>
 - Website: <https://nanoclaw.dev>
 - Security model: <https://docs.nanoclaw.dev/concepts/security>
 - Architecture: `docs/architecture.md` in the repo
 - Isolation model: `docs/isolation-model.md`
 - Docker Sandboxes: `docs/docker-sandboxes.md`
-- Changelog: <https://github.com/qwibitai/nanoclaw/blob/main/CHANGELOG.md>
+- Changelog: <https://github.com/nanocoai/nanoclaw/blob/main/CHANGELOG.md>
 - OneCLI (credential vault dependency): <https://github.com/onecli/onecli>
 - Anthropic Claude Agent SDK: <https://docs.anthropic.com>
 - Claude Code (required): <https://claude.ai/download>


### PR DESCRIPTION
## Summary

Closes #51. Two in-catalog recipes had stale upstream-repository URLs flagged in Self-Host Weekly 2026-05-15 → Project Updates section. Refreshing them keeps the `> **Source:**` recovery path intact (CLAUDE.md § Strict-doc-verification policy principle #6).

## What changed

| Recipe | Old | New | Refs touched |
|---|---|---|---|
| `flint.md` | `ccheshirecat/flint` | `0xchasercat/flint` | 3 (frontmatter description, "Upstream repo" line, Links section) |
| `nanoclaw.md` | `qwibitai/nanoclaw` | `nanocoai/nanoclaw` | 6 (intro paragraph, install-method table, git-clone command, changelog link, Links section, bottom link) |

`volantvm/flint` mirror references inside flint.md were left intact — those match the install commands in upstream's own README, so changing them would diverge from upstream rather than track it.

## Verification

Both new canonical URLs WebFetch-confirmed:

- `https://github.com/0xchasercat/flint` — Flint v1.28.0, Apache-2.0, actively maintained, 1.6k stars
- `https://github.com/nanocoai/nanoclaw` — NanoClaw, MIT, install command unchanged (`bash nanoclaw.sh`), docs at `docs.nanoclaw.dev`

Post-fix grep confirms zero stale references:

```bash
grep -rln 'ccheshirecat/flint\|qwibitai/nanoclaw' plugins/open-forge/skills/open-forge/references/projects/
# returns nothing
```

## Test plan

- [x] All `ccheshirecat/flint` references replaced with `0xchasercat/flint`
- [x] All `qwibitai/nanoclaw` references replaced with `nanocoai/nanoclaw`
- [x] `volantvm/flint` mirror references preserved (match upstream README)
- [x] New URLs verified canonical via WebFetch
- [ ] CI `dist-bundles-up-to-date` passes (project recipes aren't bundled into dist/)

## Not in scope

- No version bump — recipe-URL refresh isn't user-visible per CLAUDE.md § Versioning ("Don't bump on … internal cleanups").
- No CHANGELOG entry for the same reason.
- No dist regeneration — project recipes aren't canonical bundle sources (`CLAUDE.md` / `SKILL.md` / `references/modules/*.md` are; `references/projects/*.md` is not).
- 17 in-catalog software-version refreshes (Bichon, FreshRSS, Home Assistant, Matomo, etc.) from the same newsletter are the bot's routine recipe-refresh lane — separate from this URL-rename batch.

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY)_