### PR TITLE
docs(README): rebrand around Claude Code + fix stale version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">open-forge</h1>
 
 <p align="center">
-  <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/plugin-v0.20.1-F97316?style=flat-square&labelColor=0F172A" alt="Plugin version" /></a>
+  <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fzhangqi444%2Fopen-forge%2Fmain%2Fplugins%2Fopen-forge%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=plugin&style=flat-square&color=F97316&labelColor=0F172A" alt="Plugin version" /></a>
   <a href="https://deepwiki.com/zhangqi444/open-forge"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
   <a href="https://github.com/zhangqi444/open-forge/tree/main/plugins/open-forge/skills/open-forge/references/projects"><img src="https://img.shields.io/github/directory-file-count/zhangqi444/open-forge/plugins/open-forge/skills/open-forge/references/projects?type=file&extension=md&style=flat-square&labelColor=0F172A&color=EA580C&label=verified%20recipes" alt="Verified recipes" /></a>
   <a href="#install"><img src="https://img.shields.io/badge/built%20for-Claude%20Code-D77756?style=flat-square&labelColor=0F172A" alt="Built for Claude Code" /></a>
@@ -19,7 +19,7 @@
 ```
 > "Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired."
 
-  [open-forge] Loading verified recipe openclaw.md (v0.20.1).
+  [open-forge] Loading verified recipe openclaw.md (v0.24.0).
   [open-forge] Combo: AWS Lightsail OpenClaw blueprint (vendor-bundled, Bedrock IAM included).
   [open-forge] I'll need your AWS profile and the domain you want.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 <h1 align="center">open-forge</h1>
 
+<p align="center"><strong>A Claude Code skill that self-deploys 2,200+ open-source apps to your own infrastructure.</strong></p>
+
 <p align="center">
   <a href="https://github.com/zhangqi444/open-forge/releases"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fzhangqi444%2Fopen-forge%2Fmain%2Fplugins%2Fopen-forge%2F.claude-plugin%2Fplugin.json&query=%24.version&prefix=v&label=plugin&style=flat-square&color=F97316&labelColor=0F172A" alt="Plugin version" /></a>
   <a href="https://deepwiki.com/zhangqi444/open-forge"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki" /></a>
@@ -13,31 +15,42 @@
   <a href="https://github.com/zhangqi444/open-forge/stargazers"><img src="https://img.shields.io/github/stars/zhangqi444/open-forge?style=flat-square&labelColor=0F172A&color=FACC15" alt="GitHub stars" /></a>
 </p>
 
-> **Self-host any open-source app on your own infrastructure — guided by Claude Code.**
-> A self-improving recipe catalog that gets better every time anyone deploys.
+> **Tell Claude Code what to self-host. It does the rest** — picks the right install method, provisions the server, configures DNS + TLS, sets up SMTP, hardens it, and brings the app up at your domain.
+>
+> No more reading a 30-step README and copy-pasting bash for hours. You stay in chat; Claude Code drives the CLIs (aws, gcloud, kubectl, docker, ssh, …) and asks you only the things only you can answer (which cloud, which domain, which credential).
+>
+> Backed by a self-improving catalog: every deploy can feed gotchas back so the next user starts further ahead.
 
 ```
 > "Self-host OpenClaw on AWS Lightsail with Bedrock pre-wired."
 
-  [open-forge] Loading verified recipe openclaw.md (v0.24.0).
-  [open-forge] Combo: AWS Lightsail OpenClaw blueprint (vendor-bundled, Bedrock IAM included).
-  [open-forge] I'll need your AWS profile and the domain you want.
+  Claude Code: Loading verified recipe openclaw.md (v0.24.0).
+  Claude Code: Combo: AWS Lightsail OpenClaw blueprint (vendor-bundled, Bedrock IAM included).
+  Claude Code: I'll need your AWS profile and the domain you want.
 
   AWS profile name?
 ```
 
 > *(OpenClaw — the self-hosted personal AI agent at [openclaw.ai](https://openclaw.ai) — is the project's signature use case; works the same way for any of the [2,200+ verified recipes](#coverage).)*
 
-## Install
-
-In **Claude Code**:
+## Install in Claude Code
 
 ```
 /plugin marketplace add zhangqi444/open-forge
 /plugin install open-forge@open-forge
 ```
 
-**Other AI coding tools and agent platforms** — see [`docs/platforms/`](docs/platforms/):
+That's it. From now on, just say what you want self-hosted in any Claude Code session:
+
+> *"Self-host Vaultwarden on my laptop, expose via Cloudflare Tunnel."*
+>
+> *"Run Immich on a Hetzner CX22 with restic backups to Backblaze B2."*
+>
+> *"Deploy Ghost on AWS Lightsail at blog.mydomain.com."*
+
+### Also works on other AI coding tools and agent platforms
+
+Claude Code is the canonical home, but the same recipes ship for other agents — see [`docs/platforms/`](docs/platforms/):
 
 | Platform | How |
 |---|---|
@@ -63,19 +76,9 @@ To know when a new version ships:
 
 To apply an update in Claude Code: `/plugin marketplace update zhangqi444/open-forge`
 
-Then say what you want to deploy:
+## Why use open-forge instead of asking Claude Code directly?
 
-> *"Set up OpenClaw on my Raspberry Pi with the local Ollama provider."*
->
-> *"Run OpenClaw on a Hetzner CX22 + Docker, paired with Open WebUI."*
->
-> *"Self-host Vaultwarden on my laptop, expose via Cloudflare Tunnel."*
->
-> *"Deploy Mastodon on a Hetzner VPS — I'll bring my own SMTP."*
-
-## A self-improving catalog (the key idea)
-
-Raw Claude Code starts from zero every session. `open-forge` *accumulates* — every deploy can feed gotchas back into the catalog so the next user starts further ahead.
+Raw Claude Code can absolutely deploy software for you — but it starts from zero every session. `open-forge` *accumulates* — every deploy can feed gotchas back into the catalog so the next user starts further ahead.
 
 ```
    you deploy ─► skill captures gotchas ─► you review + opt in to share
@@ -94,11 +97,12 @@ Raw Claude Code starts from zero every session. `open-forge` *accumulates* — e
 
 That's why captured tribal knowledge already includes things like *"OpenClaw's three installers (`install.sh`, `install-cli.sh`, `install.ps1`) don't share state — pick one and stick with it"*, *"the Lightsail OpenClaw blueprint runs the gateway as a systemd USER unit with `loginctl enable-linger` so it survives no-login sessions"*, *"on Windows, OpenClaw's `iwr | iex` failures are non-fatal to the shell — silent partial installs are common, always check the explicit success line"*, and *"Bitnami's `bncert-tool` won't accept `--unattended`"* — none of which are in any upstream README.
 
-## Other reasons it's better than raw Claude Code
+**Other reasons it's better than raw Claude Code:**
 
 - **Resumable across sessions** — phased workflow + state file at `~/.open-forge/deployments/<name>.yaml`. If TLS fails at 11pm, resume from the `tls` phase tomorrow.
 - **Consistent across clouds** — "install Docker on Ubuntu" is written once and reused for Hetzner / DO / Lightsail / localhost. Swap clouds without re-deriving.
 - **Source-attributed** — every install method cites the upstream URL it derives from. When upstream drifts, the link is the recovery path.
+- **Safer credential handling** — five patterns ordered by safety (file path → env var → cloud-CLI session → secrets manager → chat paste); chat paste asks you to acknowledge the risk and reminds you to rotate after.
 
 ## Coverage
 
@@ -108,7 +112,7 @@ That's why captured tribal knowledge already includes things like *"OpenClaw's t
 
 📖 **Browse the catalog**: [deepwiki.com/zhangqi444/open-forge](https://deepwiki.com/zhangqi444/open-forge) — auto-generated wiki view of every recipe, infra adapter, and module. Stays current with the repo.
 
-Or just ask Claude — *"self-host X on Y"* — and it'll match.
+Or just tell Claude Code — *"self-host X on Y"* — and it'll match.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Two related README changes (squashed into one PR):

1. **Fix stale plugin version** — the README badge was pinned to `v0.20.1` but `plugin.json` is at `v0.24.0`.
2. **Rebrand around Claude Code as the actor** — per user feedback: *"make it very clearly to let people know what it is — Claude Code to help you self deploy the software."*

## Stale version fixes (commit `a256b4c`)

- Top-of-README plugin badge → dynamic shields.io JSON badge that reads `.version` live from `plugin.json` on `main` (auto-updates on each version bump).
- Demo block (line 22) → `v0.20.1` → `v0.24.0`.

## Rebrand (commit `34f12e3`)

| What | Before | After |
|---|---|---|
| Subtitle under H1 | (none) | "A Claude Code skill that self-deploys 2,200+ open-source apps to your own infrastructure." |
| Hero blockquote | "Self-host any open-source app on your own infrastructure — guided by Claude Code." | "**Tell Claude Code what to self-host. It does the rest** — picks install method, provisions server, configures DNS + TLS, sets up SMTP, hardens it, brings the app up." (+ a paragraph contrasting against the manual workflow) |
| Demo block prefix | `[open-forge]` (3×) | `Claude Code:` (3×) — reads literally as Claude Code talking |
| Install header | `## Install` | `## Install in Claude Code` |
| Deploy-prompt examples | Buried under § Updates | Moved up to § Install in Claude Code (where new users actually look) |
| Other platforms section | Peer header `## Install` table | Demoted to `### Also works on other AI coding tools and agent platforms` — preserves the multi-platform value while keeping Claude Code canonical |
| Self-improving section header | "A self-improving catalog (the key idea)" | "Why use open-forge instead of asking Claude Code directly?" — answers the question every reader will have |
| "Better than raw Claude Code" list | 3 bullets | Added 4th bullet: **safer credential handling** (5-pattern hierarchy from `references/modules/credentials.md`, never advertised before) |
| Bottom CTA | "Or just ask Claude — *self-host X on Y*" | "Or just tell Claude Code — *self-host X on Y*" |

## Diff scope

- 1 file (`README.md`), +29 / −25 lines across both commits.
- Badges preserved (colors, layout, count). Coverage section preserved (2,200+ count). Self-improving loop preserved. Contributing section preserved.

## Not in scope

- `plugin.json`'s `description` field also lists the old narrow Tier 1 set (Ghost, OpenClaw, Hermes, Ollama, …). That's the marketplace card text — separate decision.
- GitHub repo's `description` field (set in repo Settings) — proposed text already shared; needs manual update via UI.

## Test plan

- [x] `grep -n '\[open-forge\]' README.md` — only counts in non-demo prose; the demo block is clean
- [x] `grep -n 'v0\.20\.1' README.md` — zero hits
- [x] Dynamic badge URL renders correctly (test via `curl https://img.shields.io/badge/dynamic/json?…` returns 200 + an SVG)
- [ ] After merge: verify rendered repo page on GitHub

https://claude.ai/code/session_01Vg8ZdNVvgbd6y2VS58shqY